### PR TITLE
Rework ontologyannotation localID field

### DIFF
--- a/src/ISA/ISA.Json/Ontology.fs
+++ b/src/ISA/ISA.Json/Ontology.fs
@@ -109,27 +109,16 @@ module OntologyAnnotation =
         |> GEncode.choose
         |> Encode.object
 
-    let localIDDecoder : Decoder<string> =
-        fun s json ->
-            match Decode.string s json with
-            | Ok (Regex.ActivePatterns.TermAnnotation tan) -> 
-                Ok (tan.TermSourceREF)
-            | _ -> Ok ""
-            //| Ok s -> Error (DecoderError(s,ErrorReason.FailMessage "Could not parse local ID from string"))
-            //| Error e -> Error e
-
 
     let decoder (options : ConverterOptions) : Decoder<OntologyAnnotation> =
         Decode.object (fun get ->
-            {
-                ID = get.Optional.Field "@id" GDecode.uri
-                Name = get.Optional.Field "annotationValue" (AnnotationValue.decoder options)
-                TermSourceREF = get.Optional.Field "termSource" Decode.string
-                //LocalID = try get.Optional.Field "termAccession" localIDDecoder with | _ -> None
-                LocalID = get.Optional.Field "termAccession" localIDDecoder |> Option.bind (fun s -> if s = "" then None else Some s)
-                TermAccessionNumber = get.Optional.Field "termAccession" Decode.string
-                Comments = get.Optional.Field "comments" (Decode.array (Comment.decoder options))               
-            }
+            OntologyAnnotation.create(
+                ?Id = get.Optional.Field "@id" GDecode.uri,
+                ?Name = get.Optional.Field "annotationValue" (AnnotationValue.decoder options),
+                ?TermSourceREF = get.Optional.Field "termSource" Decode.string,
+                ?TermAccessionNumber = get.Optional.Field "termAccession" Decode.string,
+                ?Comments = get.Optional.Field "comments" (Decode.array (Comment.decoder options))               
+            )
         )
 
     let fromString (s:string) = 

--- a/src/ISA/ISA.Spreadsheet/CompositeHeader.fs
+++ b/src/ISA/ISA.Spreadsheet/CompositeHeader.fs
@@ -7,10 +7,10 @@ module ActivePattern =
 
     open ARCtrl.ISA.Regex.ActivePatterns
 
-    let mergeTerms tsr1 tan1 tsr2 tan2 =
-        if tsr1 <> tsr2 then failwithf "TermSourceRef %s and %s do not match" tsr1 tsr2
-        if tan1 <> tan2 then failwithf "TermAccessionNumber %s and %s do not match" tan1 tan2
-        {|TermSourceRef = tsr1; TermAccessionNumber = tan1|}
+    let mergeIDInfo idSpace1 localID1 idSpace2 localID2 =
+        if idSpace1 <> idSpace2 then failwithf "TermSourceRef %s and %s do not match" idSpace1 idSpace2
+        if localID1 <> localID2 then failwithf "LocalID %s and %s do not match" localID1 localID2
+        {|TermSourceRef = idSpace1; TermAccessionNumber = $"{idSpace1}:{localID1}"|}
 
     let (|Term|_|) (categoryParser : string -> string option) (f : OntologyAnnotation -> CompositeHeader) (cells : FsCell list) =
         let (|AC|_|) s =
@@ -25,7 +25,7 @@ module ActivePattern =
         //| [AC name; TermAccessionNumber term1; TermSourceREF term2] 
         //| [AC name; Unit; TermAccessionNumber term1; TermSourceREF term2] 
         | [AC name; UnitColumnHeader; TSRColumnHeader term1; TANColumnHeader term2] ->
-            let term = mergeTerms term1.TermSourceREF term1.TermAccessionNumber term2.TermSourceREF term2.TermAccessionNumber
+            let term = mergeIDInfo term1.IDSpace term1.LocalID term2.IDSpace term2.LocalID
             let ont = OntologyAnnotation.fromString(name, term.TermSourceRef, term.TermAccessionNumber)
             f ont
             |> Some

--- a/src/ISA/ISA/ArcTypes/CompositeCell.fs
+++ b/src/ISA/ISA/ArcTypes/CompositeCell.fs
@@ -75,10 +75,10 @@ type CompositeCell =
     // TODO: i would really love to have an overload here accepting string input
     static member createTerm (oa:OntologyAnnotation) = Term oa
     static member createTermFromString (?name: string, ?tsr: string, ?tan: string) =
-        Term <| OntologyAnnotation.fromString(?term = name, ?tsr = tsr, ?tan = tan)
+        Term <| OntologyAnnotation.fromString(?termName = name, ?tsr = tsr, ?tan = tan)
     static member createUnitized (value: string, ?oa:OntologyAnnotation) = Unitized (value, Option.defaultValue (OntologyAnnotation.empty) oa)
     static member createUnitizedFromString (value: string, ?name: string, ?tsr: string, ?tan: string) = 
-        Unitized <| (value, OntologyAnnotation.fromString(?term = name, ?tsr = tsr, ?tan = tan))
+        Unitized <| (value, OntologyAnnotation.fromString(?termName = name, ?tsr = tsr, ?tan = tan))
     static member createFreeText (value: string) = FreeText value
     
     static member emptyTerm = Term OntologyAnnotation.empty

--- a/src/ISA/ISA/ArcTypes/CompositeHeader.fs
+++ b/src/ISA/ISA/ArcTypes/CompositeHeader.fs
@@ -140,10 +140,10 @@ type CompositeHeader =
         // Input/Output have similiar naming as Term, but are more specific. 
         // So they have to be called first.
         | Regex.ActivePatterns.Regex Regex.Pattern.InputPattern r ->
-            let iotype = r.Groups.["iotype"].Value
+            let iotype = r.Groups.[Regex.Pattern.MatchGroups.iotype].Value
             Input <| IOType.ofString (iotype)
         | Regex.ActivePatterns.Regex Regex.Pattern.OutputPattern r ->
-            let iotype = r.Groups.["iotype"].Value
+            let iotype = r.Groups.[Regex.Pattern.MatchGroups.iotype].Value
             Output <| IOType.ofString (iotype)
         // Is term column
         | Regex.ActivePatterns.TermColumn r ->

--- a/src/ISA/ISA/JsonTypes/Component.fs
+++ b/src/ISA/ISA/JsonTypes/Component.fs
@@ -69,7 +69,7 @@ type Component =
 
     /// Create a ISAJson Component from ISATab string entries
     static member fromString (?name: string, ?term:string, ?source:string, ?accession:string, ?comments : Comment []) = 
-        let cType = OntologyAnnotation.fromString (?term = term, ?tsr=source, ?tan=accession, ?comments = comments) |> Option.fromValueWithDefault OntologyAnnotation.empty
+        let cType = OntologyAnnotation.fromString (?termName = term, ?tsr=source, ?tan=accession, ?comments = comments) |> Option.fromValueWithDefault OntologyAnnotation.empty
         match name with
         | Some n -> 
             let v,u = Component.decomposeName n

--- a/src/ISA/ISA/JsonTypes/OntologyAnnotation.fs
+++ b/src/ISA/ISA/JsonTypes/OntologyAnnotation.fs
@@ -32,7 +32,7 @@ type OntologyAnnotation =
         OntologyAnnotation.create()
 
 
-    member this.IDInfo = 
+    member this.TANInfo = 
         this.TermAccessionNumber
         |> Option.bind Regex.tryParseTermAnnotation 
 
@@ -101,12 +101,12 @@ type OntologyAnnotation =
     ///
     /// If `TermAccessionString` cannot be parsed to this format, returns empty string!
     member this.TermAccessionShort = 
-        match this.IDInfo with
+        match this.TANInfo with
         | Some id -> $"{id.IDSpace}:{id.LocalID}"
         | _ -> ""
 
     member this.TermAccessionOntobeeUrl = 
-        match this.IDInfo with
+        match this.TANInfo with
         | Some id -> OntologyAnnotation.createUriAnnotation id.IDSpace id.LocalID
         | _ -> ""
 

--- a/tests/ISA/ISA.Json.Tests/Json.Tests.fs
+++ b/tests/ISA/ISA.Json.Tests/Json.Tests.fs
@@ -160,7 +160,7 @@ let testOntoloyAnnotation =
                     o_out
                     |> Utils.wordFrequency
 
-                Expect.equal actual expected "Written processInput does not match read process input"
+                mySequenceEqual actual expected "Written processInput does not match read process input"
             )
     ]
 
@@ -191,7 +191,7 @@ let testOntoloyAnnotationLD =
                     o_out
                     |> Utils.wordFrequency
 
-                Expect.equal actual expected "Written processInput does not match read process input"
+                mySequenceEqual actual expected "Written processInput does not match read process input"
             )
             testCase "WriterOutputMatchesInputDefaultIDs" (fun () -> 
             
@@ -206,7 +206,7 @@ let testOntoloyAnnotationLD =
                     o_out
                     |> Utils.wordFrequency
 
-                Expect.equal actual expected "Written processInput does not match read process input"
+                mySequenceEqual actual expected "Written processInput does not match read process input"
             )
     ]
 
@@ -239,7 +239,7 @@ let testProcessInput =
                     o_out
                     |> Utils.wordFrequency
 
-                Expect.equal actual expected "Written processInput does not match read process input"
+                mySequenceEqual actual expected "Written processInput does not match read process input"
             )
         ]
         testList "Material" [
@@ -1242,7 +1242,6 @@ let testInvestigationFile =
                     (Some "OntologyTerm/Published")
                     (Some (AnnotationValue.Text "published"))
                     (Some "pso")
-                    (Some "published")
                     (Some "http://purl.org/spar/pso/published")
                     (Some [|comment|])
 
@@ -1260,7 +1259,6 @@ let testInvestigationFile =
                     (Some "OntologyTerm/SoftwareDeveloperRole")
                     (Some (AnnotationValue.Text "software developer role"))
                     (Some "swo")
-                    (Some "0000392")
                     (Some "http://www.ebi.ac.uk/swo/SWO_0000392")
                     (Some [|comment|])
 
@@ -1286,7 +1284,6 @@ let testInvestigationFile =
                             (Some "OntologyTerm/Organism")
                             (Some (AnnotationValue.Text "organism"))
                             (Some "obi")
-                            (Some "0100026")
                             (Some "http://purl.obolibrary.org/obo/OBI_0100026")
                             (Some [|comment|])
                     ))
@@ -1300,7 +1297,6 @@ let testInvestigationFile =
                             (Some "OntologyTerm/Organism")
                             (Some (AnnotationValue.Text "Arabidopsis thaliana"))
                             (Some "obi")
-                            (Some "0100026")
                             (Some "http://purl.obolibrary.org/obo/OBI_0100026")
                             (Some [|comment|])
                         |> Value.Ontology
@@ -1312,7 +1308,6 @@ let testInvestigationFile =
                     (Some "OntologyTerm/TimeSeries")
                     (Some (AnnotationValue.Text "Time Series Analysis"))
                     (Some "ncit")
-                    (Some "C18235")
                     (Some "http://purl.obolibrary.org/obo/NCIT_C18235")               
                     (Some [|comment|])
 
@@ -1321,7 +1316,6 @@ let testInvestigationFile =
                     (Some "OntologyTerm/GrowthProtocol")
                     (Some (AnnotationValue.Text "growth protocol"))
                     (Some "dfbo")
-                    (Some "DFBA_0000001")
                     (Some "http://purl.obolibrary.org/obo/DFBO_1000162")
                     (Some [|comment|])
 
@@ -1333,7 +1327,6 @@ let testInvestigationFile =
                             (Some "OntologyTerm/Temperature")
                             (Some (AnnotationValue.Text "temperature unit"))
                             (Some "uo")
-                            (Some "UO_0000005")
                             (Some "http://purl.obolibrary.org/obo/UO_0000005")
                             (Some [|comment|])
                     ))
@@ -1343,7 +1336,6 @@ let testInvestigationFile =
                     (Some "OntologyTerm/DegreeCelsius")
                     (Some (AnnotationValue.Text "degree celsius"))
                     (Some "uo")
-                    (Some "UO_0000027")
                     (Some "http://purl.obolibrary.org/obo/UO_0000027")
                     (Some [|comment|])
 
@@ -1361,7 +1353,6 @@ let testInvestigationFile =
                             (Some "OntologyTerm/RTPCR")
                             (Some (AnnotationValue.Text "real-time PCR machine"))
                             (Some "obi")
-                            (Some "0001110")
                             (Some "http://purl.obolibrary.org/obo/OBI_0001110")
                             (Some [|comment|])
                         |> Value.Ontology
@@ -1372,7 +1363,6 @@ let testInvestigationFile =
                             (Some "OntologyTerm/PCR")
                             (Some (AnnotationValue.Text "PCR instrument"))
                             (Some "obi")
-                            (Some "0000989")
                             (Some "http://purl.obolibrary.org/obo/OBI_0000989")
                             (Some [|comment|])
                     ))
@@ -1398,7 +1388,6 @@ let testInvestigationFile =
                                 (Some "OntologyTerm/Time")
                                 (Some (AnnotationValue.Text "time"))
                                 (Some "pato")
-                                (Some "0000165")
                                 (Some "http://purl.obolibrary.org/obo/PATO_0000165")
                                 (Some [|comment|])
                         ))
@@ -1409,7 +1398,6 @@ let testInvestigationFile =
                     (Some "OntologyTerm/Hour")
                     (Some (AnnotationValue.Text "hour"))
                     (Some "uo")
-                    (Some "0000032")
                     (Some "http://purl.obolibrary.org/obo/UO_0000032")
                     (Some [|comment|])
                     
@@ -1498,7 +1486,6 @@ let testInvestigationFile =
                     (Some "OntologyTerm/LFQuantification")
                     (Some (AnnotationValue.Text "LC/MS Label-Free Quantification"))
                     (Some "ncit")
-                    (Some "C161813")
                     (Some "http://purl.obolibrary.org/obo/NCIT_C161813")
                     (Some [|comment|])
 
@@ -1507,7 +1494,6 @@ let testInvestigationFile =
                     (Some "OntologyTerm/TOF")
                     (Some (AnnotationValue.Text "Time-of-Flight"))
                     (Some "ncit")
-                    (Some "C70698")
                     (Some "http://purl.obolibrary.org/obo/NCIT_C70698")
                     (Some [|comment|])
 
@@ -1678,7 +1664,6 @@ let testInvestigationFileLD =
                     (Some "OntologyTerm/Published")
                     (Some (AnnotationValue.Text "published"))
                     (Some "pso")
-                    (Some "published")
                     (Some "http://purl.org/spar/pso/published")
                     (Some [|comment|])
 
@@ -1696,7 +1681,6 @@ let testInvestigationFileLD =
                     (Some "OntologyTerm/SoftwareDeveloperRole")
                     (Some (AnnotationValue.Text "software developer role"))
                     (Some "swo")
-                    (Some "0000392")
                     (Some "http://www.ebi.ac.uk/swo/SWO_0000392")
                     (Some [|comment|])
 
@@ -1722,7 +1706,6 @@ let testInvestigationFileLD =
                             (Some "OntologyTerm/Organism")
                             (Some (AnnotationValue.Text "organism"))
                             (Some "obi")
-                            (Some "0100026")
                             (Some "http://purl.obolibrary.org/obo/OBI_0100026")
                             (Some [|comment|])
                     ))
@@ -1736,7 +1719,6 @@ let testInvestigationFileLD =
                             (Some "OntologyTerm/Organism")
                             (Some (AnnotationValue.Text "Arabidopsis thaliana"))
                             (Some "obi")
-                            (Some "0100026")
                             (Some "http://purl.obolibrary.org/obo/OBI_0100026")
                             (Some [|comment|])
                         |> Value.Ontology
@@ -1748,7 +1730,6 @@ let testInvestigationFileLD =
                     (Some "OntologyTerm/TimeSeries")
                     (Some (AnnotationValue.Text "Time Series Analysis"))
                     (Some "ncit")
-                    (Some "C18235")
                     (Some "http://purl.obolibrary.org/obo/NCIT_C18235")               
                     (Some [|comment|])
 
@@ -1757,7 +1738,6 @@ let testInvestigationFileLD =
                     (Some "OntologyTerm/GrowthProtocol")
                     (Some (AnnotationValue.Text "growth protocol"))
                     (Some "dfbo")
-                    (Some "0000001")
                     (Some "http://purl.obolibrary.org/obo/DFBO_1000162")
                     (Some [|comment|])
 
@@ -1769,7 +1749,6 @@ let testInvestigationFileLD =
                             (Some "OntologyTerm/Temperature")
                             (Some (AnnotationValue.Text "temperature unit"))
                             (Some "uo")
-                            (Some "UO_0000005")
                             (Some "http://purl.obolibrary.org/obo/UO_0000005")
                             (Some [|comment|])
                     ))
@@ -1779,7 +1758,6 @@ let testInvestigationFileLD =
                     (Some "OntologyTerm/DegreeCelsius")
                     (Some (AnnotationValue.Text "degree celsius"))
                     (Some "uo")
-                    (Some "0000027")
                     (Some "http://purl.obolibrary.org/obo/UO_0000027")
                     (Some [|comment|])
 
@@ -1797,7 +1775,6 @@ let testInvestigationFileLD =
                             (Some "OntologyTerm/RTPCR")
                             (Some (AnnotationValue.Text "real-time PCR machine"))
                             (Some "obi")
-                            (Some "0001110")
                             (Some "http://purl.obolibrary.org/obo/OBI_0001110")
                             (Some [|comment|])
                         |> Value.Ontology
@@ -1808,7 +1785,6 @@ let testInvestigationFileLD =
                             (Some "OntologyTerm/PCR")
                             (Some (AnnotationValue.Text "PCR instrument"))
                             (Some "obi")
-                            (Some "0000989")
                             (Some "http://purl.obolibrary.org/obo/OBI_0000989")
                             (Some [|comment|])
                     ))
@@ -1834,7 +1810,6 @@ let testInvestigationFileLD =
                                 (Some "OntologyTerm/Time")
                                 (Some (AnnotationValue.Text "time"))
                                 (Some "pato")
-                                (Some "0000165")
                                 (Some "http://purl.obolibrary.org/obo/PATO_0000165")
                                 (Some [|comment|])
                         ))
@@ -1845,7 +1820,6 @@ let testInvestigationFileLD =
                     (Some "OntologyTerm/Hour")
                     (Some (AnnotationValue.Text "hour"))
                     (Some "uo")
-                    (Some "0000032")
                     (Some "http://purl.obolibrary.org/obo/UO_0000032")
                     (Some [|comment|])
                     
@@ -1934,7 +1908,6 @@ let testInvestigationFileLD =
                     (Some "OntologyTerm/LFQuantification")
                     (Some (AnnotationValue.Text "LC/MS Label-Free Quantification"))
                     (Some "ncit")
-                    (Some "C161813")
                     (Some "http://purl.obolibrary.org/obo/NCIT_C161813")
                     (Some [|comment|])
 
@@ -1943,7 +1916,6 @@ let testInvestigationFileLD =
                     (Some "OntologyTerm/TOF")
                     (Some (AnnotationValue.Text "Time-of-Flight"))
                     (Some "ncit")
-                    (Some "C70698")
                     (Some "http://purl.obolibrary.org/obo/NCIT_C70698")
                     (Some [|comment|])
 

--- a/tests/ISA/ISA.Tests/ArcTable.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcTable.Tests.fs
@@ -446,21 +446,21 @@ let private tests_UpdateColumn =
         )
         testCase "set valid, at invalid index = columnCount" (fun () ->
             let table = create_testTable()
-            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(term="TestTerm")
+            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(termName="TestTerm")
             let cells = createCells_Term 5
             let eval() = table.UpdateColumn(table.ColumnCount, h, cells)
             Expect.throws eval ""
         )
         testCase "set valid, at invalid negative index" (fun () ->
             let table = create_testTable()
-            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(term="TestTerm")
+            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(termName="TestTerm")
             let cells = createCells_Term 5
             let eval() = table.UpdateColumn(-1, h, cells)
             Expect.throws eval ""
         )
         testCase "set valid" (fun () ->
             let table = create_testTable()
-            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(term="TestTerm")
+            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(termName="TestTerm")
             let cells = createCells_Term 5
             table.UpdateColumn(0, h, cells)
             Expect.equal table.RowCount 5 "RowCount"
@@ -498,7 +498,7 @@ let private tests_UpdateColumn =
         )
         testCase "set valid, less rows" (fun () ->
             let table = create_testTable()
-            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(term="TestTerm")
+            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(termName="TestTerm")
             let cells = createCells_Term 2
             table.UpdateColumn(0, h, cells)
             Expect.equal table.RowCount 5 "RowCount"
@@ -514,7 +514,7 @@ let private tests_UpdateColumn =
         )
         testCase "set valid, more rows" (fun () ->
             let table = create_testTable()
-            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(term="TestTerm")
+            let h = CompositeHeader.Component <| OntologyAnnotation.fromString(termName="TestTerm")
             let cells = createCells_Term 7
             table.UpdateColumn(0, h, cells)
             Expect.equal table.RowCount 7 "RowCount"

--- a/tests/ISA/ISA.Tests/Regex.Tests.fs
+++ b/tests/ISA/ISA.Tests/Regex.Tests.fs
@@ -65,9 +65,8 @@ let private tests_AnnotationTableColums =
                 | _ -> None
             Expect.isSome r "Could not match TSRColumnHeader"
             let rv = r.Value
-            Expect.equal rv.LocalTAN localID "LocalId did not match"
-            Expect.equal rv.TermSourceREF space "TermSourceREF did not match"
-            Expect.equal rv.TermAccessionNumber $"{space}:{localID}" "TermAccessionNumber did not match"
+            Expect.equal rv.LocalID localID "LocalId did not match"
+            Expect.equal rv.IDSpace space "TermSourceREF did not match"
         )
         testCase "Term Source REF Empty" (fun () ->
             let testString = $"Term Source REF ()"
@@ -77,9 +76,8 @@ let private tests_AnnotationTableColums =
                 | _ -> None
             Expect.isSome r "Could not match TSRColumnHeader"
             let rv = r.Value
-            Expect.equal rv.LocalTAN "" "LocalID should be empty"
-            Expect.equal rv.TermSourceREF "" "TermSourceREF should be empty"
-            Expect.equal rv.TermAccessionNumber "" "TermAccessionNumber should be empty"
+            Expect.equal rv.LocalID "" "LocalID should be empty"
+            Expect.equal rv.IDSpace "" "TermSourceREF should be empty"
         )
         testCase "Term Accession Number" (fun () ->
             let localID = "12345"
@@ -91,9 +89,8 @@ let private tests_AnnotationTableColums =
                 | _ -> None
             Expect.isSome r "Could not match TANColumnHeader"
             let rv = r.Value
-            Expect.equal rv.LocalTAN localID "LocalId did not match"
-            Expect.equal rv.TermSourceREF space "TermSourceREF did not match"
-            Expect.equal rv.TermAccessionNumber $"{space}:{localID}" "TermAccessionNumber did not match"      
+            Expect.equal rv.LocalID localID "LocalId did not match"
+            Expect.equal rv.IDSpace space "TermSourceREF did not match"
         )
         testCase "Term Accession Number Empty" (fun () ->
             let testString = $"Term Accession Number ()"
@@ -103,9 +100,8 @@ let private tests_AnnotationTableColums =
                 | _ -> None
             Expect.isSome r "Could not match TANColumnHeader"
             let rv = r.Value
-            Expect.equal rv.LocalTAN "" "LocalID should be empty"
-            Expect.equal rv.TermSourceREF "" "TermSourceREF should be empty"
-            Expect.equal rv.TermAccessionNumber "" "TermAccessionNumber should be empty"
+            Expect.equal rv.LocalID "" "LocalID should be empty"
+            Expect.equal rv.IDSpace "" "TermSourceREF should be empty"
         )
         testCase "Reference Column Header Empty" (fun () ->
 


### PR DESCRIPTION
#161 
- `LocalID` field removed
- Instead there is an `IDInfo` member with both the `IDSpace` and the `LocalID`

Maybe rename to `TANInfo`? @Freymaurer 