### PR TITLE
Hotfix protocol handling

### DIFF
--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -465,7 +465,7 @@ type ArcTable =
     /// The table will have at most one row, with the protocol information and the component values
     static member fromProtocol (p : Protocol) : ArcTable = 
         
-        let t = ArcTable.init (p.Name |> Option.defaultValue "")
+        let t = ArcTable.init (p.Name |> Option.defaultValue (Identifier.createMissingIdentifier()))
 
         for pp in p.Parameters |> Option.defaultValue [] do
 
@@ -506,13 +506,13 @@ type ArcTable =
                     let c = Component.create(ComponentType = oa)
                     Protocol.addComponent c p
                 | _ -> p
-            ) Protocol.empty
+            ) (Protocol.create(Name = this.Name))
             |> List.singleton
         else
             List.init this.RowCount (fun i ->
                 this.GetRow(i) 
                 |> Seq.zip this.Headers
-                |> CompositeRow.toProtocol                    
+                |> CompositeRow.toProtocol this.Name                   
             )
             |> List.distinct
 

--- a/src/ISA/ISA/ArcTypes/CompositeRow.fs
+++ b/src/ISA/ISA/ArcTypes/CompositeRow.fs
@@ -1,6 +1,6 @@
 ﻿module ARCtrl.ISA.CompositeRow
 
-let toProtocol (row : (CompositeHeader*CompositeCell) seq) =
+let toProtocol (tableName : string) (row : (CompositeHeader*CompositeCell) seq) =
     row
     |> Seq.fold (fun p hc ->
         match hc with
@@ -20,4 +20,4 @@ let toProtocol (row : (CompositeHeader*CompositeCell) seq) =
             let c = Component.create(ComponentType = oa, Value = Value.Ontology t)
             Protocol.addComponent c p     
         | _ -> p
-    ) Protocol.empty
+    ) (Protocol.create(Name = tableName))

--- a/tests/ISA/ISA.Tests/ArcJsonConversionTests.fs
+++ b/tests/ISA/ISA.Tests/ArcJsonConversionTests.fs
@@ -523,6 +523,7 @@ let private tests_protocolTransformation =
             let t = p |> ArcTable.fromProtocol
 
             Expect.equal t.ColumnCount 0 "ColumnCount should be 0"
+            Expect.isTrue (Identifier.isMissingIdentifier t.Name) $"Name should be missing identifier, not \"{t.Name}\""
         )
         testCase "FromProtocol SingleParameter" (fun () ->
             let p = Protocol.create(Parameters = [pParam1])
@@ -576,7 +577,12 @@ let private tests_protocolTransformation =
             let c = c.Value
             Expect.equal c expected "Cell value does not match"
         )
+        testCase "GetProtocols NoName" (fun () ->           
+            let t = ArcTable.init "TestTable"
+            let expected = [Protocol.create(Name = "TestTable")]
 
+            TestingUtils.mySequenceEqual (t.GetProtocols()) expected "Protocol Name should be ArcTable name."
+        )
         testCase "GetProtocols SingleName" (fun () ->           
             let t = ArcTable.init "TestTable"
             let name = "Name"


### PR DESCRIPTION
Parsing between ArcTables and Protocols lead to breaking changes when writing and reading an ARC. 

This is because the name of the ArcTables was not included into the protocol, leading to empty protocols in the study section of the investigation file when writing. These would then be read to nameless ArcTables, leasing to breaks. 

- Fixed this broken behaviour 
- added another safetynet, namely using `Missing identifiers` when reading nameless protocols
- added tests