### PR TITLE
Hotfix UpdateFileSystem

### DIFF
--- a/src/FileSystem/FileSystem.fs
+++ b/src/FileSystem/FileSystem.fs
@@ -34,3 +34,8 @@ type FileSystem =
         let tree = this.Tree.Union(other.Tree)
         let history = Array.append this.History other.History
         FileSystem.create(tree, history)
+
+    member this.Copy() =
+        let fstCopy = this.Tree.Copy()
+        let historyCopy = this.History |> Array.map id
+        FileSystem.create(fstCopy,historyCopy)

--- a/src/FileSystem/FileSystemTree.fs
+++ b/src/FileSystem/FileSystemTree.fs
@@ -25,6 +25,28 @@ type FileSystemTree =
 
     static member createRootFolder(children:FileSystemTree array) = 
         Folder(FileSystemTree.ROOT_NAME,children)
+        
+    /// Non-recursive lookup of child with the given name
+    member this.TryGetChildByName(name : string) = 
+        match this with
+        | Folder (_,children) ->
+            children
+            |> Array.tryFind (fun c -> c.Name = name)
+        | File _ -> None
+
+    static member tryGetChildByName (name : string) =
+        fun (fst : FileSystemTree) -> fst.TryGetChildByName name
+
+    /// Non-recursive lookup of child with the given name
+    member this.ContainsChildWithName(name : string) =
+        match this with
+        | Folder (_,children) ->
+            children
+            |> Array.exists (fun c -> c.Name = name)
+        | File _ -> false
+
+    static member containsChildWithName (name : string) =
+        fun (fst : FileSystemTree) -> fst.ContainsChildWithName name
 
     member this.AddFile (path: string) : FileSystemTree =
         let existingPaths = this.ToFilePaths()
@@ -122,3 +144,10 @@ type FileSystemTree =
         |> Array.append (otherFST.ToFilePaths())
         |> Array.distinct
         |> FileSystemTree.fromFilePaths
+
+    member this.Copy() =
+        match this with
+        | Folder(name,children) -> 
+            Folder (name, children |> Array.map (fun c -> c.Copy()))
+        | File(name) -> 
+            File name

--- a/tests/ARCtrl/ARCtrl.Tests.fs
+++ b/tests/ARCtrl/ARCtrl.Tests.fs
@@ -56,7 +56,7 @@ let private test_isaFromContracts = testList "read_contracts" [
         let aContract = TestObjects.ISAContracts.SimpleISA.assayReadContract
         let arc = ARC()
         arc.SetISAFromContracts([|iContract; sContract; aContract|])
-        Expect.isSome arc.ISA "isa should be fille out"
+        Expect.isSome arc.ISA "isa should be filled out"
         let inv = arc.ISA.Value
         Expect.equal inv.Identifier TestObjects.Investigation.investigationIdentifier "investigation identifier should have been read from investigation contract"
 
@@ -128,8 +128,52 @@ let private test_writeContracts = testList "write_contracts" [
     )
 ]
 
+let private test_updateFileSystem = testList "update_Filesystem" [
+    testCase "empty noChanges" (fun () ->
+        let arc = ARC()
+        let oldFS = arc.FileSystem.Copy()
+        arc.UpdateFileSystem()
+        let newFS = arc.FileSystem
+        Expect.equal oldFS.Tree newFS.Tree "Tree should be equal"
+    )
+    testCase "empty addInvestigationWithStudy" (fun () ->
+        let arc = ARC()
+        let oldFS = arc.FileSystem.Copy()
+        let study = ArcStudy("MyStudy")
+        let inv = ArcInvestigation("MyInvestigation")
+        inv.AddStudy(study)
+        arc.ISA <- Some (inv)
+        arc.UpdateFileSystem()
+        let newFS = arc.FileSystem
+        Expect.notEqual oldFS.Tree newFS.Tree "Tree should be unequal"
+    )
+    testCase "simple noChanges" (fun () ->
+        let study = ArcStudy("MyStudy")
+        let inv = ArcInvestigation("MyInvestigation")
+        inv.AddStudy(study)
+        let arc = ARC(isa = inv)
+        let oldFS = arc.FileSystem.Copy()   
+        arc.UpdateFileSystem()
+        let newFS = arc.FileSystem
+        Expect.equal oldFS.Tree newFS.Tree "Tree should be equal"
+    )
+    testCase "simple addAssayToStudy" (fun () ->
+        let study = ArcStudy("MyStudy")
+        let inv = ArcInvestigation("MyInvestigation")
+        inv.AddStudy(study)
+        let arc = ARC(isa = inv)
+        let oldFS = arc.FileSystem.Copy()   
+        let assay = ArcAssay("MyAssay")
+        study.AddAssay(assay)
+        arc.UpdateFileSystem()
+        let newFS = arc.FileSystem
+        Expect.notEqual oldFS.Tree newFS.Tree "Tree should be unequal"
+    )
+]
+
 let main = testList "main" [
     test_model
+    test_updateFileSystem
     test_isaFromContracts
     test_writeContracts
 ]


### PR DESCRIPTION
`Arc.UpdateFileSystem()` did not correctly update the filesystem part of the arc according to its ISA part. This was because some erroneous handling of mutable values.
This PR hotfixes this behaviour and adds some basic tests.