### PR TITLE
fix #182

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arcapi",
-  "version": "1.0.0+4892f43",
+  "version": "1.0.0+ece863d",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arcapi",
-      "version": "1.0.0+4892f43",
+      "version": "1.0.0+ece863d",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/src/FileSystem/FileSystemTree.fs
+++ b/src/FileSystem/FileSystemTree.fs
@@ -122,7 +122,7 @@ type FileSystemTree =
     static member toFilePaths (?removeRoot: bool) =
         fun (root: FileSystemTree) -> root.ToFilePaths(?removeRoot=removeRoot)
 
-    member this.Filter (predicate: string -> bool) =
+    member this.FilterFiles (predicate: string -> bool) =
         let rec loop (parent: FileSystemTree) =
             match parent with
             | File n -> 
@@ -135,6 +135,25 @@ type FileSystemTree =
                     Folder (n, filteredChildren)
                     |> Some 
         loop this
+
+    static member filterFiles (predicate: string -> bool) =
+        fun (tree: FileSystemTree) -> tree.Filter predicate
+
+    member this.Filter (predicate: string -> bool) = 
+        let rec loop (parent: FileSystemTree) = 
+            match parent with 
+            | File n ->  
+                if predicate n then Some (FileSystemTree.File n) else None 
+            | Folder (n, children) -> 
+                if predicate n then 
+                    let filteredChildren = children |> Array.choose loop 
+                    if Array.isEmpty filteredChildren then  
+                        None
+                    else
+                        Some (FileSystemTree.Folder (n,filteredChildren))
+                else
+                    None
+        loop this 
 
     static member filter (predicate: string -> bool) =
         fun (tree: FileSystemTree) -> tree.Filter predicate

--- a/src/ISA/ISA.Spreadsheet/ARCtrl.ISA.Spreadsheet.fsproj
+++ b/src/ISA/ISA.Spreadsheet/ARCtrl.ISA.Spreadsheet.fsproj
@@ -35,7 +35,6 @@
     <ProjectReference Include="..\ISA\ARCtrl.ISA.fsproj" />
     <ProjectReference Include="..\..\FileSystem\ARCtrl.FileSystem.fsproj" />
   </ItemGroup>
-  <ItemGroup />
   <PropertyGroup>
     <Authors>nfdi4plants, Lukas Weil</Authors>
     <Description>ARC and ISA xlsx compliant parser for experimental metadata toolkit in F#. This project is meant as an easy means to open, manipulate and save ISA (Investigation,Study,Assay) metadata files in isa-xlsx format.</Description>

--- a/tests/FileSystem/FileSystemTree.Tests.fs
+++ b/tests/FileSystem/FileSystemTree.Tests.fs
@@ -114,9 +114,9 @@ let private tests_ToFilePaths =
             Expect.equal actual_sorted expected_sorted "equal"
     ]
 
-let private tests_Filter = 
-    testList "Filter" [
-        testCase "new arc (2023-07-11)" <| fun _ ->
+let private tests_Filter_Files = 
+    testList "FilterFiles" [
+        test "new arc (2023-07-11), keep .xlsx files" {
             let expected = Some(
                 Folder("root",[|
                     File "isa.investigation.xlsx";
@@ -132,8 +132,91 @@ let private tests_Filter =
                 |])
             )
             let filest = FileSystemTree.fromFilePaths newArcRelativePaths
-            let actual = filest.Filter (fun n -> n.EndsWith ".xlsx")
+            let actual = filest.FilterFiles (fun n -> n.EndsWith ".xlsx")
             Expect.equal actual expected ""
+        }
+        test "new arc (2023-07-11), filter startswith '.'" {
+            let expected = Some(
+                Folder("root",[|
+                    File "isa.investigation.xlsx"; 
+                    Folder(".git",[|
+                        File "config"; File "description"; File "HEAD";
+                        Folder("hooks",[|
+                            File "applypatch-msg.sample"; File "commit-msg.sample";
+                            File "fsmonitor-watchman.sample"; File "post-update.sample";
+                            File "pre-applypatch.sample"; File "pre-commit.sample";
+                            File "pre-merge-commit.sample"; File "pre-push.sample";
+                            File "pre-rebase.sample"; File "pre-receive.sample";
+                            File "prepare-commit-msg.sample";
+                            File "push-to-checkout.sample"; File "update.sample"
+                        |]);
+                        Folder ("info", [|File "exclude"|])
+                    |]);
+                    Folder("assays",[|
+                        Folder("est",[|
+                            File "isa.assay.xlsx"; File "README.md";
+                        |]);
+                        Folder
+                            ("TestAssay1",[|
+                            File "isa.assay.xlsx"; File "README.md";
+                        |])
+                    |]);
+                    Folder("studies",[|
+                        Folder("est",[|
+                            File "isa.study.xlsx"; File "README.md";
+                        |]);
+                        Folder("MyStudy",[|
+                            File "isa.study.xlsx"; File "README.md";
+                        |]);
+                        Folder("TestAssay1",[|
+                            File "isa.study.xlsx"; File "README.md";
+                        |])
+                    |]);
+                |])
+            )
+            let filest = FileSystemTree.fromFilePaths newArcRelativePaths
+            let actual = filest.FilterFiles (fun n -> not (n.StartsWith "."))
+            Expect.equal actual expected ""
+        }
+    ]
+
+let private tests_Filter = 
+    testList "Filter" [
+        test "new arc (2023-07-11), filter startswith '.'" {
+            let expected = Some(
+                Folder("root",[|
+                    File "isa.investigation.xlsx"; 
+                    Folder("assays",[|
+                        Folder("est",[|
+                            File "isa.assay.xlsx"; 
+                            File "README.md";
+                        |]);
+                        Folder
+                            ("TestAssay1",[|
+                            File "isa.assay.xlsx"; 
+                            File "README.md";
+                        |])
+                    |]);
+                    Folder("studies",[|
+                        Folder("est",[|
+                            File "isa.study.xlsx"; 
+                            File "README.md";
+                        |]);
+                        Folder("MyStudy",[|
+                            File "isa.study.xlsx"; 
+                            File "README.md";
+                        |]);
+                        Folder("TestAssay1",[|
+                            File "isa.study.xlsx"; 
+                            File "README.md";
+                        |])
+                    |]);
+                |])
+            )
+            let filest = FileSystemTree.fromFilePaths newArcRelativePaths
+            let actual = filest.Filter (fun n -> not (n.StartsWith "."))
+            Expect.equal actual expected ""
+        }
     ]
 
 let private tests_AddFile = 
@@ -309,6 +392,7 @@ let private tests_AddFile =
 let main = testList "FileSystemTree" [
     tests_fromFilePaths
     tests_ToFilePaths
+    tests_Filter_Files
     tests_Filter
     tests_AddFile
 ]


### PR DESCRIPTION
- rename FileSystemTree.filter -> FileSystemTree.filterFiles
- add FileSystemTree.filter that also applies predicate to folder names
- add tests that show difference when filtering for names starting with '.'