### PR TITLE
Fixes

### DIFF
--- a/src/ISA/ISA.Spreadsheet/Metadata/SparseTable.fs
+++ b/src/ISA/ISA.Spreadsheet/Metadata/SparseTable.fs
@@ -26,7 +26,10 @@ module SparseRow =
 
     let fromFsRow (r : FsRow) = 
         r.Cells
-        |> Seq.map (fun c -> c.ColumnNumber - 1, c.Value)
+        |> Seq.choose (fun c -> 
+            if c.Value = "" then Option.None 
+            else Option.Some (c.ColumnNumber - 1, c.Value)          
+        )
 
     let tryGetValueAt i (vs : SparseRow) =
         vs 

--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -267,6 +267,15 @@ type ArcTable =
         fun (table:ArcTable) ->
             table.GetColumnByHeader(header)
 
+    member this.TryGetColumnByHeader (header:CompositeHeader) =
+        let index = this.Headers |> Seq.tryFindIndex (fun x -> x = header)
+        index
+        |> Option.map (fun i -> this.GetColumn(i))
+
+    static member tryGetColumnByHeader (header:CompositeHeader) =
+        fun (table:ArcTable) ->
+            table.TryGetColumnByHeader(header)
+
     // - Row API - //
     member this.AddRow (?cells: CompositeCell [], ?index: int) : unit = 
         let index = defaultArg index this.RowCount
@@ -467,6 +476,9 @@ type ArcTable =
 
     member this.GetProtocolNameColumn() =
         this.GetColumnByHeader(CompositeHeader.ProtocolREF)
+
+    member this.TryGetProtocolNameColumn() =
+        this.TryGetColumnByHeader(CompositeHeader.ProtocolREF)
 
     member this.GetComponentColumns() =
         this.Headers

--- a/src/ISA/ISA/ArcTypes/ArcTables.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTables.fs
@@ -314,7 +314,12 @@ type ArcTables(thisTables:ResizeArray<ArcTable>) =
         let keepUnusedRefTables = Option.defaultValue false keepUnusedRefTables
         let usedTables = HashSet<string>()
         let referenceTableMap = 
-            referenceTables.Tables |> Seq.map (fun t -> t.GetProtocolNameColumn().Cells.[0].AsFreeText, t) |> Map.ofSeq
+            referenceTables.Tables 
+            |> Seq.choose (fun t -> 
+                t.TryGetProtocolNameColumn()
+                |> Option.map (fun c -> c.Cells.[0].AsFreeText, t)
+            ) 
+            |> Map.ofSeq
         sheetTables.Tables
         |> Seq.toArray
         |> Array.collect ArcTable.SplitByProtocolREF

--- a/tests/ISA/ISA.Spreadsheet.Tests/AssayFileTests.fs
+++ b/tests/ISA/ISA.Spreadsheet.Tests/AssayFileTests.fs
@@ -132,6 +132,15 @@ let testMetaDataFunctions =
             Expect.isNone assay.TechnologyType "TechnologyType should not be set"
         )
 
+        testCase "ReaderCorrectnessEmptyStrings" (fun () -> 
+            
+            let assay = ArcAssay.fromMetadataSheet TestObjects.Assay.assayMetadataEmptyStrings
+            Expect.isNone assay.MeasurementType "MeasurementType should not be set"
+            Expect.isNone assay.TechnologyPlatform "TechnologyPlatform should not be set"
+            Expect.isNone assay.TechnologyType "TechnologyType should not be set"
+            Expect.isEmpty assay.Performers "Performers should be empty"
+        )
+
         testCase "ReaderSuccessEmptyObsoleteSheetName" (fun () -> 
             
             let readingSuccess = 

--- a/tests/ISA/ISA.Spreadsheet.Tests/TestObjects/Assay.fs
+++ b/tests/ISA/ISA.Spreadsheet.Tests/TestObjects/Assay.fs
@@ -225,6 +225,93 @@ let assayMetadataEmptyObsoleteSheetName =
     cp.Name <- "Assay"
     cp
 
+let assayMetadataEmptyStrings = 
+    let ws = FsWorksheet("isa_assay")
+    let row1 = ws.Row(1)
+    row1.[1].Value <- "ASSAY"
+    let row2 = ws.Row(2)
+    row2.[1].Value <- "Assay Measurement Type"
+    row2.[2].Value <- ""
+    let row3 = ws.Row(3)
+    row3.[1].Value <- "Assay Measurement Type Term Accession Number"
+    row3.[2].Value <- ""
+    let row4 = ws.Row(4)
+    row4.[1].Value <- "Assay Measurement Type Term Source REF"
+    row4.[2].Value <- ""
+    let row5 = ws.Row(5)
+    row5.[1].Value <- "Assay Technology Type"
+    row5.[2].Value <- ""
+    let row6 = ws.Row(6)
+    row6.[1].Value <- "Assay Technology Type Term Accession Number"
+    row6.[2].Value <- ""
+    let row7 = ws.Row(7)
+    row7.[1].Value <- "Assay Technology Type Term Source REF"
+    row7.[2].Value <- ""
+    let row8 = ws.Row(8)
+    row8.[1].Value <- "Assay Technology Platform"
+    row8.[2].Value <- ""
+    let row9 = ws.Row(9)
+    row9.[1].Value <- "Assay File Name"
+    row9.[2].Value <- $"assays/{assayIdentifier}/isa.assay.xlsx"
+    let row10 = ws.Row(10)
+    row10.[1].Value <- "ASSAY PERFORMERS"    
+    let row11 = ws.Row(11)
+    row11.[1].Value <- "Assay Person Last Name"
+    row11.[2].Value <- ""
+    row11.[3].Value <- ""
+    row11.[4].Value <- ""
+    let row12 = ws.Row(12)
+    row12.[1].Value <- "Assay Person First Name"
+    row12.[2].Value <- ""
+    row12.[3].Value <- ""
+    row12.[4].Value <- ""
+    let row13 = ws.Row(13)
+    row13.[1].Value <- "Assay Person Mid Initials"
+    row13.[2].Value <- ""
+    row13.[3].Value <- ""
+    row13.[4].Value <- ""
+    let row14 = ws.Row(14)
+    row14.[1].Value <- "Assay Person Email"
+    row14.[2].Value <- ""
+    row14.[3].Value <- ""
+    row14.[4].Value <- ""
+    let row15 = ws.Row(15)
+    row15.[1].Value <- "Assay Person Phone"
+    row15.[2].Value <- ""
+    row15.[3].Value <- ""
+    row15.[4].Value <- ""
+    let row16 = ws.Row(16)
+    row16.[1].Value <- "Assay Person Fax"
+    row16.[2].Value <- ""
+    row16.[3].Value <- ""
+    row16.[4].Value <- ""
+    let row17 = ws.Row(17)
+    row17.[1].Value <- "Assay Person Address"
+    row17.[2].Value <- ""
+    row17.[3].Value <- ""
+    row17.[4].Value <- ""
+    let row18 = ws.Row(18)
+    row18.[1].Value <- "Assay Person Affiliation"
+    row18.[2].Value <- ""
+    row18.[3].Value <- ""
+    row18.[4].Value <- ""
+    let row19 = ws.Row(19)
+    row19.[1].Value <- "Assay Person Roles"
+    row19.[2].Value <- ""
+    row19.[3].Value <- ""
+    row19.[4].Value <- ""
+    let row20 = ws.Row(20)
+    row20.[1].Value <- "Assay Person Roles Term Accession Number"
+    row20.[2].Value <- ""
+    row20.[3].Value <- ""
+    row20.[4].Value <- ""
+    let row21 = ws.Row(21)
+    row21.[1].Value <- "Assay Person Roles Term Source REF"
+    row21.[2].Value <- ""
+    row21.[3].Value <- ""
+    row21.[4].Value <- ""
+    ws
+
 let assayMetadataWorkbook = 
     let wb = new FsWorkbook()
     wb.AddWorksheet(assayMetadata)

--- a/tests/ISA/ISA.Tests/ArcTables.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcTables.Tests.fs
@@ -203,6 +203,19 @@ let updateReferenceWithSheet =
                 (Array.create 2 (CompositeCell.createFreeText descriptionValue1))
                 "Description value was not taken correctly"
         )
+        testCase "RefTableHasNoProtocolREF" (fun () ->
+            let tableOfInterest = sheetWithREF()
+            let tables = ArcTables.ofSeq [tableOfInterest]
+            let refTables = ArcTables.ofSeq [sheetWithNoREF()]
+            let result = ArcTables.updateReferenceTablesBySheets(refTables,tables)
+            
+            Expect.equal result.Count tables.Count "Should be same number of tables"
+            let resultTable = result.[0]
+            Expect.equal resultTable.Name tableOfInterest.Name "Should be same table name"
+            Expect.equal resultTable.ColumnCount (tableOfInterest.ColumnCount) "Should have same number of columns as before"
+            Expect.equal resultTable.RowCount tableOfInterest.RowCount "Should be same number of columns as before"
+            
+        )
         testCase "TwoTablesWithSameProtocol" (fun () ->
             let tableOfInterest1 = sheetWithREF()
             let tableOfInterest2 = sheetWithREFAndFactor()


### PR DESCRIPTION
Added two tests with fixes:
- metadatasheet parsers now again ignore cells with empty string. This was broken since one #184 
- reference table update functionality failed for tables with no Protocol REF column