### PR TITLE
Add Npm release as build target

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-### 1.0.0+70f288b (Released 2023-9-20)
+### 1.0.0+7905959 (Released 2023-9-22)
 * Additions:
     * Complete overhaul of the API.
     * Shifted focus from only ISA to include full ARC.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-### 1.0.0+7905959 (Released 2023-9-22)
+### 1.0.0+1c6c4fa (Released 2023-9-22)
 * Additions:
     * Complete overhaul of the API.
     * Shifted focus from only ISA to include full ARC.

--- a/build/BasicTasks.fs
+++ b/build/BasicTasks.fs
@@ -20,6 +20,7 @@ let clean = BuildTask.create "Clean" [] {
     ++ "src/**/obj"
     ++ "tests/**/bin"
     ++ "tests/**/obj"
+    ++ "dist"
     ++ ProjectInfo.pkgDir
     |> Shell.cleanDirs 
 }

--- a/build/Build.fs
+++ b/build/Build.fs
@@ -21,13 +21,13 @@ open ReleaseTasks
 let _release = 
     BuildTask.createEmpty 
         "Release" 
-        [clean; build; runTests; pack; createTag; publishNuget;]
+        [clean; build; runTests; pack; createTag; publishNuget; publishNPM]
 
 /// Full release of nuget package for the prerelease version.
 let _preRelease = 
     BuildTask.createEmpty 
         "PreRelease" 
-        [setPrereleaseTag; clean; build; runTests; packPrerelease; createPrereleaseTag; publishNugetPrerelease]
+        [setPrereleaseTag; clean; build; runTests; packPrerelease; createPrereleaseTag; publishNugetPrerelease; publishNPMPrerelease]
 
 ReleaseNotesTasks.updateReleaseNotes |> ignore
 

--- a/build/Build.fsproj
+++ b/build/Build.fsproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="release_package.json" />
     <None Include="paket.references" />
     <Compile Include="Helpers.fs" />
     <Compile Include="MessagePrompts.fs" />
@@ -25,6 +26,7 @@
     <PackageReference Include="Fake.DotNet.Cli" Version="5.23.0-alpha002" />
     <PackageReference Include="Fake.DotNet.MSBuild" Version="5.23.0-alpha002" />
     <PackageReference Include="Fake.IO.FileSystem" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.JavaScript.Npm" Version="5.23.0-alpha002" />
     <PackageReference Include="Fake.Tools.Git" Version="5.23.0-alpha002" />
     <PackageReference Include="Fake.Extensions.Release" Version="0.3.0" />
   </ItemGroup>

--- a/build/ProjectInfo.fs
+++ b/build/ProjectInfo.fs
@@ -31,6 +31,7 @@ let gitHome = $"https://github.com/{gitOwner}"
 let projectRepo = $"https://github.com/{gitOwner}/{project}"
 
 let pkgDir = "dist/pkg"
+let npmPkgDir = "dist/js"
 
 // Create RELEASE_NOTES.md if not existing. Or "release" would throw an error.
 Fake.Extensions.Release.ReleaseNotes.ensure()

--- a/build/ReleaseNotesTasks.fs
+++ b/build/ReleaseNotesTasks.fs
@@ -18,7 +18,7 @@ let updateReleaseNotes = BuildTask.createFn "ReleaseNotes" [] (fun config ->
         |> fun x -> x.SemVer.AsString
     Trace.trace "Start updating package.json version"
     // Update Version in src/Nfdi4Plants.Fornax.Template/package.json
-    let p = "package.json"
+    let p = "build/release_package.json"
     let t = System.IO.File.ReadAllText p
     let tNew = System.Text.RegularExpressions.Regex.Replace(t, """\"version\": \".*\",""", sprintf "\"version\": \"%s\"," semVer )
     System.IO.File.WriteAllText(p, tNew)

--- a/build/ReleaseTasks.fs
+++ b/build/ReleaseTasks.fs
@@ -14,7 +14,7 @@ open Fake.Tools
 open Fake.IO
 open Fake.IO.Globbing.Operators
 
-let createTag = BuildTask.create "CreateTag" [clean; build; runTests; pack] {
+let createTag = BuildTask.create "CreateTag" [clean; build; runTests; packDotNet] {
     if promptYesNo (sprintf "tagging branch with %s OK?" stableVersionTag ) then
         Git.Branches.tag "" stableVersionTag
         Git.Branches.pushTag "" projectRepo stableVersionTag
@@ -22,7 +22,7 @@ let createTag = BuildTask.create "CreateTag" [clean; build; runTests; pack] {
         failwith "aborted"
 }
 
-let createPrereleaseTag = BuildTask.create "CreatePrereleaseTag" [setPrereleaseTag; clean; build; runTests; packPrerelease] {
+let createPrereleaseTag = BuildTask.create "CreatePrereleaseTag" [setPrereleaseTag; clean; build; runTests; packDotNetPrerelease] {
     if promptYesNo (sprintf "tagging branch with %s OK?" prereleaseTag ) then 
         Git.Branches.tag "" prereleaseTag
         Git.Branches.pushTag "" projectRepo prereleaseTag
@@ -31,7 +31,7 @@ let createPrereleaseTag = BuildTask.create "CreatePrereleaseTag" [setPrereleaseT
 }
 
 
-let publishNuget = BuildTask.create "PublishNuget" [clean; build; runTests; pack] {
+let publishNuget = BuildTask.create "PublishNuget" [clean; build; runTests; packDotNet] {
     let targets = (!! (sprintf "%s/*.*pkg" pkgDir ))
     for target in targets do printfn "%A" target
     let msg = sprintf "release package with version %s?" stableVersionTag
@@ -44,7 +44,7 @@ let publishNuget = BuildTask.create "PublishNuget" [clean; build; runTests; pack
     else failwith "aborted"
 }
 
-let publishNugetPrerelease = BuildTask.create "PublishNugetPrerelease" [clean; build; runTests; packPrerelease] {
+let publishNugetPrerelease = BuildTask.create "PublishNugetPrerelease" [clean; build; runTests; packDotNetPrerelease] {
     let targets = (!! (sprintf "%s/*.*pkg" pkgDir ))
     for target in targets do printfn "%A" target
     let msg = sprintf "release package with version %s?" prereleaseTag 
@@ -73,7 +73,7 @@ let publishNPM = BuildTask.create "PublishNPM" [clean; build; runTests; packJS] 
     else failwith "aborted"
 }
 
-let publishNPMPrerelease = BuildTask.create "PublishNPMPrerelease" [clean; build; (*runTests*) packJSPrerelease] {
+let publishNPMPrerelease = BuildTask.create "PublishNPMPrerelease" [clean; build; runTests; packJSPrerelease] {
     let target = 
         (!! (sprintf "%s/*.tgz" npmPkgDir ))
         |> Seq.head

--- a/build/ReleaseTasks.fs
+++ b/build/ReleaseTasks.fs
@@ -73,7 +73,7 @@ let publishNPM = BuildTask.create "PublishNPM" [clean; build; runTests; packJS] 
     else failwith "aborted"
 }
 
-let publishNPMPrerelease = BuildTask.create "PublishNPMPrerelease" [clean; build; runTests; packJSPrerelease] {
+let publishNPMPrerelease = BuildTask.create "PublishNPMPrerelease" [clean; build; (*runTests*) packJSPrerelease] {
     let target = 
         (!! (sprintf "%s/*.tgz" npmPkgDir ))
         |> Seq.head
@@ -81,7 +81,7 @@ let publishNPMPrerelease = BuildTask.create "PublishNPMPrerelease" [clean; build
     let msg = sprintf "release package with version %s?" prereleaseTag 
     if promptYesNo msg then
         let apikey =  Environment.environVarOrNone "NPM_KEY"    
-        let otp = if apikey.IsSome then $" --otp + {apikey.Value}" else ""
+        let otp = if apikey.IsSome then $" --otp {apikey.Value}" else ""
         Fake.JavaScript.Npm.exec $"publish {target} --access public --tag next{otp}" (fun o ->
             { o with
                 WorkingDirectory = "./dist/js/"

--- a/build/release_package.json
+++ b/build/release_package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nfdi4plants/arctrl",
-  "version": "1.0.0+7905959",
+  "version": "1.0.0+1c6c4fa",
   "description": "Top level ARC DataModel and API function descriptions.",
   "type": "module",
   "repository": {

--- a/build/release_package.json
+++ b/build/release_package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@nfdi4plants/arctrl",
+  "version": "1.0.0+7905959",
+  "description": "Top level ARC DataModel and API function descriptions.",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nfdi4plants/arcAPI.git"
+  },
+  "author": "Heinrich Lukas Weil <weil@rptu.de> (https://github.com/HLWeil)",
+  "contributors": [
+    "Kevin Frey <Freymaurer@gmx.de> (https://github.com/Freymaurer)"
+  ],
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/nfdi4plants/arcAPI/issues"
+  },
+  "homepage": "https://github.com/nfdi4plants/arcAPI#readme",
+  "dependencies": {
+    "fable-library": "^1.1.1"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
-  "name": "arcapi",
+  "name": "@nfdi4plants/arctrl",
   "version": "1.0.0+ece863d",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "arcapi",
-      "version": "1.0.0+ece863d",
+      "name": "@nfdi4plants/arctrl",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "arcapi",
-  "version": "1.0.0+ece863d",
+  "name": "@nfdi4plants/arctrl",
   "description": "Top level ARC DataModel and API function descriptions.",
   "type": "module",
   "scripts": {
@@ -29,7 +28,10 @@
     "type": "git",
     "url": "git+https://github.com/nfdi4plants/arcAPI.git"
   },
-  "author": "",
+  "author": "Heinrich Lukas Weil <weil@rptu.de> (https://github.com/HLWeil)",
+  "contributors": [
+    "Kevin Frey <Freymaurer@gmx.de> (https://github.com/Freymaurer)"
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/nfdi4plants/arcAPI/issues"
@@ -40,7 +42,11 @@
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {
-    "mkdirp": "3.0.1",
-    "mocha": "^10.2.0"
-  }
+    "mocha": "^10.2.0",
+    "mkdirp": "3.0.1"
+  },
+  "files": [
+    "dist/js/**",
+    "dist/js/fable-modules**"
+  ]
 }

--- a/tests/ARCtrl/WebRequest.Tests.fs
+++ b/tests/ARCtrl/WebRequest.Tests.fs
@@ -5,7 +5,7 @@ open ARCtrl.WebRequest
 
 let tests_download = testList "Download" [
     testCaseAsync "simple json" <| async {
-        let url = @"https://raw.githubusercontent.com/nfdi4plants/ARCtrl/developer_TemplateRequest/tests/TestingUtils/TestObjects.Json/MinimalJson.json"
+        let url = @"https://raw.githubusercontent.com/nfdi4plants/ARCtrl/developer/tests/TestingUtils/TestObjects.Json/MinimalJson.json"
         let expected = """{"TestKey": "TestValue"}"""
         let! jsonString = downloadFile url 
         Expect.equal jsonString expected "equal"


### PR DESCRIPTION
Add build targets for automatic packing and publishing of npm package:
New package: https://www.npmjs.com/package/@nfdi4plants/arctrl/v/1.0.0-alpha7?activeTab=readme

Newly added:
```cli
.\build.cmd packJS
.\build.cmd packJSPrerelease

.\build.cmd publishNPM
.\build.cmd publishNPMPrerelease
```
-------
```cli
.\build.cmd release
.\build.cmd prerelease
```
now do nuget, npm and github release
