### PR TITLE
Developer swatelogic

### DIFF
--- a/build/GenerateIndexJs.fs
+++ b/build/GenerateIndexJs.fs
@@ -92,6 +92,7 @@ let ARCtrl_generate(rootPath: string) =
         "ArcStudy"; 
         "ArcInvestigation"; 
         "Template"
+        "Templates"
         "Organisation"
         "JsWeb"
         "ARC"

--- a/src/ARCtrl/ARCtrl.fsproj
+++ b/src/ARCtrl/ARCtrl.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="Contracts\Contracts.Git.fs" />
     <Compile Include="Contracts\Contracts.ARCtrl.fs" />
     <Compile Include="Templates\Template.fs" />
+    <Compile Include="Templates\Templates.fs" />
     <Compile Include="Templates\Template.Json.fs" />
     <Compile Include="Templates\Template.Spreadsheet.fs" />
     <Compile Include="Templates\Template.Web.fs" />
@@ -49,7 +50,5 @@
 		    <NpmPackage Name="isomorphic-fetch" Version="gt 3.0.0 lt 3.0.0" ResolutionStrategy="Max" />
 	    </NpmDependencies>
     </PropertyGroup>
-    <ItemGroup>
-	    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
-    </ItemGroup>
+    <ItemGroup />
 </Project>

--- a/src/ARCtrl/ARCtrl.fsproj
+++ b/src/ARCtrl/ARCtrl.fsproj
@@ -34,7 +34,6 @@
     <Compile Include="Templates\Template.Spreadsheet.fs" />
     <Compile Include="Templates\Template.Web.fs" />
     <None Include="README.md" />
-    <Compile Include="ARC.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Contract\ARCtrl.Contract.fsproj" />

--- a/src/ARCtrl/ARCtrl.fsproj
+++ b/src/ARCtrl/ARCtrl.fsproj
@@ -33,6 +33,7 @@
     <Compile Include="Templates\Template.Json.fs" />
     <Compile Include="Templates\Template.Spreadsheet.fs" />
     <Compile Include="Templates\Template.Web.fs" />
+	<Compile Include="ARC.fs" />
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ARCtrl/Templates/Template.Json.fs
+++ b/src/ARCtrl/Templates/Template.Json.fs
@@ -127,7 +127,7 @@ module Templates =
 
     let fromJsonString (jsonString: string) =
         match decode jsonString with
-        | Ok templateMap    -> templateMap
+        | Ok templateMap    -> templateMap.Values |> Array.ofSeq
         | Error exn         -> failwithf "Error. Given json string cannot be parsed to Templates map: %A" exn
 
     let toJsonString (spaces: int) (templateList: (string*Template) []) =

--- a/src/ARCtrl/Templates/Template.Web.fs
+++ b/src/ARCtrl/Templates/Template.Web.fs
@@ -21,7 +21,7 @@ let getTemplates(url: string option) =
 type JsWeb =
     static member getTemplates(url: string option) =
         async {
-            let! map = getTemplates(url)
-            return System.Collections.Generic.Dictionary(map)
+            let! templates = getTemplates(url)
+            return templates
         }
         |> Async.StartAsPromise

--- a/src/ARCtrl/Templates/Templates.fs
+++ b/src/ARCtrl/Templates/Templates.fs
@@ -7,7 +7,7 @@ open Fable.Core
 [<RequireQualifiedAccess>]
 module TemplatesAux =
 
-    let getDefault_comparer (isAnd: bool option) =
+    let getComparer (isAnd: bool option) =
         let isAnd = defaultArg isAnd false
         let comparer = if isAnd then (&&) else (||)
         comparer
@@ -58,7 +58,7 @@ type Templates =
     /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
     static member filterByTags(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
         fun (templates: Template []) ->
-            let comparer = TemplatesAux.getDefault_comparer isAnd
+            let comparer = TemplatesAux.getComparer isAnd
             TemplatesAux.filterOnTags (fun t -> t.Tags) queryTags comparer templates
 
     /// <summary>
@@ -68,7 +68,7 @@ type Templates =
     /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
     static member filterByEndpointRepositories(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
         fun (templates: Template []) ->
-            let comparer = TemplatesAux.getDefault_comparer isAnd
+            let comparer = TemplatesAux.getComparer isAnd
             TemplatesAux.filterOnTags (fun t -> t.EndpointRepositories) queryTags comparer templates
 
     /// <summary>
@@ -78,7 +78,7 @@ type Templates =
     /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
     static member filterByOntologyAnnotation(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
         fun (templates: Template []) ->
-            let comparer = TemplatesAux.getDefault_comparer isAnd
+            let comparer = TemplatesAux.getComparer isAnd
             TemplatesAux.filterOnTags (fun t -> Array.append t.Tags t.EndpointRepositories) queryTags comparer templates
 
     /// <summary>

--- a/src/ARCtrl/Templates/Templates.fs
+++ b/src/ARCtrl/Templates/Templates.fs
@@ -28,6 +28,29 @@ module TemplatesAux =
 [<AttachMembers>]
 type Templates =
 
+    static member getDistinctTags (templates: Template []) =
+        templates |> Array.collect (fun t -> t.Tags)
+
+    /// <summary>
+    /// Returns all **distinct** `template.Tags` and `template.EndpointRepositories`
+    /// </summary>
+    /// <param name="templates"></param>
+    static member getDistinctEndpointRepositories (templates: Template []) =
+        templates |> Array.collect (fun t -> t.EndpointRepositories)
+
+    /// <summary>
+    /// Returns all **distinct** `template.Tags` and `template.EndpointRepositories`
+    /// </summary>
+    /// <param name="templates"></param>
+    static member getDistinctOntologyAnnotations (templates: Template []) =
+        let oas = ResizeArray()
+        for t in templates do
+            oas.AddRange(t.Tags)
+            oas.AddRange(t.EndpointRepositories)
+        oas
+        |> Array.ofSeq
+        |> Array.distinct
+
     /// <summary>
     /// Filter templates by `template.Tags`.
     /// </summary>
@@ -62,7 +85,7 @@ type Templates =
     /// Filters templates by template.Organisation = `Organisation.DataPLANT`/`"DataPLANT"`.
     /// </summary>
     /// <param name="templates"></param>
-    static member filterByDataPLANT (templates: Template [])=
+    static member filterByDataPLANT (templates: Template []) =
         templates
         |> Array.filter (fun t -> t.Organisation.IsOfficial())
         

--- a/src/ARCtrl/Templates/Templates.fs
+++ b/src/ARCtrl/Templates/Templates.fs
@@ -7,9 +7,9 @@ open Fable.Core
 [<RequireQualifiedAccess>]
 module TemplatesAux =
 
-    let getComparer (isAnd: bool option) =
-        let isAnd = defaultArg isAnd false
-        let comparer = if isAnd then (&&) else (||)
+    let getComparer (matchAll: bool option) =
+        let matchAll = defaultArg matchAll false
+        let comparer = if matchAll then (&&) else (||)
         comparer
 
     let filterOnTags (tagGetter: Template -> OntologyAnnotation []) (queryTags: OntologyAnnotation []) (comparer: bool -> bool -> bool) (templates: Template []) =
@@ -55,30 +55,30 @@ type Templates =
     /// Filter templates by `template.Tags`.
     /// </summary>
     /// <param name="queryTags">The ontology annotation to filter by.</param>
-    /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
-    static member filterByTags(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
+    /// <param name="matchAll">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
+    static member filterByTags(queryTags: OntologyAnnotation [], ?matchAll: bool) = 
         fun (templates: Template []) ->
-            let comparer = TemplatesAux.getComparer isAnd
+            let comparer = TemplatesAux.getComparer matchAll
             TemplatesAux.filterOnTags (fun t -> t.Tags) queryTags comparer templates
 
     /// <summary>
     /// Filter templates by `template.EndpointRepositories`.
     /// </summary>
     /// <param name="queryTags">The ontology annotation to filter by.</param>
-    /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
-    static member filterByEndpointRepositories(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
+    /// <param name="matchAll">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
+    static member filterByEndpointRepositories(queryTags: OntologyAnnotation [], ?matchAll: bool) = 
         fun (templates: Template []) ->
-            let comparer = TemplatesAux.getComparer isAnd
+            let comparer = TemplatesAux.getComparer matchAll
             TemplatesAux.filterOnTags (fun t -> t.EndpointRepositories) queryTags comparer templates
 
     /// <summary>
     /// Filters templates by template.Tags and template.EndpointRepositories
     /// </summary>
     /// <param name="queryTags">The ontology annotation to filter by.</param>
-    /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
-    static member filterByOntologyAnnotation(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
+    /// <param name="matchAll">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
+    static member filterByOntologyAnnotation(queryTags: OntologyAnnotation [], ?matchAll: bool) = 
         fun (templates: Template []) ->
-            let comparer = TemplatesAux.getComparer isAnd
+            let comparer = TemplatesAux.getComparer matchAll
             TemplatesAux.filterOnTags (fun t -> Array.append t.Tags t.EndpointRepositories) queryTags comparer templates
 
     /// <summary>

--- a/src/ARCtrl/Templates/Templates.fs
+++ b/src/ARCtrl/Templates/Templates.fs
@@ -1,0 +1,68 @@
+﻿namespace ARCtrl.Template
+
+open ARCtrl.ISA
+open Fable.Core
+
+/// This module contains unchecked helper functions for templates
+[<RequireQualifiedAccess>]
+module TemplatesAux =
+
+    let getDefault_comparer (isAnd: bool option) =
+        let isAnd = defaultArg isAnd false
+        let comparer = if isAnd then (&&) else (||)
+        comparer
+
+    let filterOnTags (tagGetter: Template -> OntologyAnnotation []) (queryTags: OntologyAnnotation []) (comparer: bool -> bool -> bool) (templates: Template []) =
+        templates 
+        |> Array.filter(fun t ->
+            let templateTags = tagGetter t
+            let mutable isValid = None
+            for qt in queryTags do
+                let contains = templateTags |> Array.contains qt
+                match isValid, contains with
+                | None, any -> isValid <- Some any
+                | Some maybe, any -> isValid <- Some (comparer maybe any)
+            Option.defaultValue false isValid
+        )
+
+[<AttachMembers>]
+type Templates =
+
+    /// <summary>
+    /// Filter templates by `template.Tags`.
+    /// </summary>
+    /// <param name="queryTags">The ontology annotation to filter by.</param>
+    /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
+    static member filterByTags(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
+        fun (templates: Template []) ->
+            let comparer = TemplatesAux.getDefault_comparer isAnd
+            TemplatesAux.filterOnTags (fun t -> t.Tags) queryTags comparer templates
+
+    /// <summary>
+    /// Filter templates by `template.EndpointRepositories`.
+    /// </summary>
+    /// <param name="queryTags">The ontology annotation to filter by.</param>
+    /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
+    static member filterByEndpointRepositories(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
+        fun (templates: Template []) ->
+            let comparer = TemplatesAux.getDefault_comparer isAnd
+            TemplatesAux.filterOnTags (fun t -> t.EndpointRepositories) queryTags comparer templates
+
+    /// <summary>
+    /// Filters templates by template.Tags and template.EndpointRepositories
+    /// </summary>
+    /// <param name="queryTags">The ontology annotation to filter by.</param>
+    /// <param name="isAnd">Default: false. If true all `queryTags` must be contained in template, if false only 1 tags must be contained in template.</param>
+    static member filterByOntologyAnnotation(queryTags: OntologyAnnotation [], ?isAnd: bool) = 
+        fun (templates: Template []) ->
+            let comparer = TemplatesAux.getDefault_comparer isAnd
+            TemplatesAux.filterOnTags (fun t -> Array.append t.Tags t.EndpointRepositories) queryTags comparer templates
+
+    /// <summary>
+    /// Filters templates by template.Organisation = `Organisation.DataPLANT`/`"DataPLANT"`.
+    /// </summary>
+    /// <param name="templates"></param>
+    static member filterByDataPLANT (templates: Template [])=
+        templates
+        |> Array.filter (fun t -> t.Organisation.IsOfficial())
+        

--- a/src/ARCtrl/Templates/Templates.fs
+++ b/src/ARCtrl/Templates/Templates.fs
@@ -29,14 +29,14 @@ module TemplatesAux =
 type Templates =
 
     static member getDistinctTags (templates: Template []) =
-        templates |> Array.collect (fun t -> t.Tags)
+        templates |> Array.collect (fun t -> t.Tags) |> Array.distinct
 
     /// <summary>
     /// Returns all **distinct** `template.Tags` and `template.EndpointRepositories`
     /// </summary>
     /// <param name="templates"></param>
     static member getDistinctEndpointRepositories (templates: Template []) =
-        templates |> Array.collect (fun t -> t.EndpointRepositories)
+        templates |> Array.collect (fun t -> t.EndpointRepositories) |> Array.distinct
 
     /// <summary>
     /// Returns all **distinct** `template.Tags` and `template.EndpointRepositories`

--- a/src/ISA/ISA.Spreadsheet/AnnotationTable/ArcTable.fs
+++ b/src/ISA/ISA.Spreadsheet/AnnotationTable/ArcTable.fs
@@ -102,6 +102,7 @@ let toFsWorksheet (table : ArcTable) =
     let ws = FsWorksheet(table.Name)
     let columns = 
         table.Columns
+        |> List.ofArray
         |> List.sortBy classifyColumnOrder
         |> List.collect CompositeColumn.toFsColumns
     let maxRow = columns.Head.Length

--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -5,8 +5,6 @@ open System.Collections.Generic
 open ArcTableAux
 open ColumnIndex
 
-open Fable.Core.JsInterop
-
 [<StringEnum>]
 type TableJoinOptions =
 /// Add only headers, no values
@@ -260,7 +258,9 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
         let h = this.Headers.[columnIndex]
         let cells = [|
             for i = 0 to this.RowCount - 1 do 
-                this.TryGetCellAt(columnIndex, i).Value
+                match this.TryGetCellAt(columnIndex, i) with
+                | None -> failwithf "Unable to find cell for index: (%i, %i)" columnIndex i
+                | Some c -> c
         |]
         CompositeColumn.create(h, cells)
 

--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -452,7 +452,7 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
             // this is the most problematic case. How do we decide which unit we want to propagate? All?
             | WithUnit -> 
                 pre |> Array.map (fun c -> 
-                    let unitsOpt = c.GetColumnUnits()
+                    let unitsOpt = c.TryGetColumnUnits()
                     match unitsOpt with
                     | Some units ->
                         let toCompositeCell = fun unitOA -> CompositeCell.createUnitized ("", unitOA)

--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -713,10 +713,19 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
 
     // it's good practice to ensure that this behaves using the same fields as Equals does:
     override this.GetHashCode() = 
+        //let v1,v2 = 
+        let v =
+            [|
+                for KeyValue(k,v) in this.Values do
+                    yield k, v
+            |] 
+            |> Array.sortBy fst
+            // must remove tuples. Tuples handle unpredictable for GetHashCode in javascript.
+            |> Array.map (fun ((k1,k2),v) -> [|box k1; box k2; box v|] |> Aux.HashCodes.boxHashArray) 
         [|
             box this.Name
             Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Headers
-            this.Values |> Array.ofSeq |> Array.sortBy (function | KeyValue (key,_) -> key) |> Aux.HashCodes.boxHashArray
+            Array.ofSeq >> Aux.HashCodes.boxHashArray <| v
         |]
         |> Aux.HashCodes.boxHashArray 
         |> fun x -> x :?> int

--- a/src/ISA/ISA/ArcTypes/ArcTableAux.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTableAux.fs
@@ -127,7 +127,6 @@ module Unchecked =
     let moveCellTo (fromCol:int,fromRow:int,toCol:int,toRow:int) (cells:Dictionary<int*int,CompositeCell>) =
         match Dictionary.tryFind (fromCol, fromRow) cells with
         | Some c ->
-            // Dictionary.addOrUpdateInPlace (column+amount,row) c this.Values |> ignore // This is the same as `SetCellAt`
             // Remove value. This is necessary in the following scenario:
             //
             // "AddColumn.Existing Table.add less rows, insert at".

--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -49,6 +49,10 @@ module ArcTypesAux =
             | None ->
                 ()
 
+    let boxHashOption (a: 'a option) : obj =
+        if a.IsSome then a.Value.GetHashCode() else (0).GetHashCode()
+        |> box
+
     /// <summary>
     /// Some functions can change ArcInvestigation.Assays elements. After these functions we must remove all registered assays which might have gone lost.
     /// </summary>
@@ -449,15 +453,14 @@ type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?techno
             nextTables.Add(copy)
         let nextComments = this.Comments |> Array.map (fun c -> c.Copy())
         let nextPerformers = this.Performers |> Array.map (fun c -> c.Copy())
-        ArcAssay(
-            this.Identifier,
-            ?measurementType = this.MeasurementType,
-            ?technologyType = this.TechnologyType, 
-            ?technologyPlatform = this.TechnologyPlatform, 
-            tables=nextTables, 
-            performers=nextPerformers, 
-            comments=nextComments
-        )
+        ArcAssay.make
+            this.Identifier
+            this.MeasurementType
+            this.TechnologyType
+            this.TechnologyPlatform
+            nextTables
+            nextPerformers
+            nextComments
 
     /// <summary>
     /// Updates given assay with another assay, Identifier will never be updated. By default update is full replace. Optional Parameters can be used to specify update logic.
@@ -628,18 +631,18 @@ type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?techno
             this.StructurallyEquals(assay)
         | _ -> false
 
-    override this.GetHashCode() =
-        [|
-            box this.Identifier
-            this.MeasurementType
-            this.TechnologyType
-            this.TechnologyPlatform
-            this.Tables
-            this.Performers
-            this.Comments
-        |]
-        |> Array.map (fun o -> o.GetHashCode())
-        |> Array.sum
+    override this.GetHashCode() = failwith "Still need to implement correct GetHashCode function for ArcAssay type."
+        //[|
+        //    box this.Identifier
+        //    ArcTypesAux.boxHashOption this.MeasurementType
+        //    ArcTypesAux.boxHashOption this.TechnologyType
+        //    ArcTypesAux.boxHashOption this.TechnologyPlatform
+        //    box <| Array.ofSeq this.Tables
+        //    box this.Performers
+        //    box this.Comments
+        //|]
+        //|> Array.map (fun o -> o.GetHashCode())
+        //|> Array.sum
 
 [<AttachMembers>]
 type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publicReleaseDate, ?publications, ?contacts, ?studyDesignDescriptors, ?tables, ?registeredAssayIdentifiers: ResizeArray<string>, ?factors, ?comments) = 
@@ -1137,20 +1140,19 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
         let nextContacts = this.Contacts |> Array.map (fun c -> c.Copy())
         let nextPublications = this.Publications |> Array.map (fun c -> c.Copy())
         let nextStudyDesignDescriptors = this.StudyDesignDescriptors |> Array.map (fun c -> c.Copy())
-        ArcStudy(
-            this.Identifier, 
-            ?title = this.Title, 
-            ?description = this.Description, 
-            ?submissionDate = this.SubmissionDate, 
-            ?publicReleaseDate = this.PublicReleaseDate, 
-            publications = nextPublications, 
-            contacts = nextContacts,
-            studyDesignDescriptors = nextStudyDesignDescriptors,
-            tables = nextTables,
-            registeredAssayIdentifiers = nextAssayIdentifiers,
-            factors = nextFactors,
-            comments = nextComments
-        )
+        ArcStudy.make
+            this.Identifier
+            this.Title
+            this.Description
+            this.SubmissionDate
+            this.PublicReleaseDate
+            nextPublications
+            nextContacts
+            nextStudyDesignDescriptors
+            nextTables
+            nextAssayIdentifiers
+            nextFactors
+            nextComments
 
     /// <summary>
     /// Updates given study from an investigation file against a study from a study file. Identifier will never be updated. 
@@ -1282,23 +1284,23 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
             this.StructurallyEquals(s)
         | _ -> false
 
-    override this.GetHashCode() =
-        [|
-            box this.Identifier
-            this.Title
-            this.Description
-            this.SubmissionDate
-            this.PublicReleaseDate
-            this.Publications
-            this.Contacts
-            this.StudyDesignDescriptors
-            this.Tables
-            this.RegisteredAssayIdentifiers
-            this.Factors
-            this.Comments
-        |]
-        |> Array.map (fun o -> o.GetHashCode())
-        |> Array.sum
+    override this.GetHashCode() = failwith "Still need to implement correct GetHashCode function for ArcStudy type."
+        //[|
+        //    box this.Identifier
+        //    ArcTypesAux.boxHashOption this.Title
+        //    ArcTypesAux.boxHashOption this.Description
+        //    ArcTypesAux.boxHashOption this.SubmissionDate
+        //    ArcTypesAux.boxHashOption this.PublicReleaseDate
+        //    this.Publications
+        //    this.Contacts
+        //    this.StudyDesignDescriptors
+        //    this.Tables
+        //    this.RegisteredAssayIdentifiers
+        //    this.Factors
+        //    this.Comments
+        //|]
+        //|> Array.map (fun o -> o.GetHashCode())
+        //|> Array.sum
 
 [<AttachMembers>]
 type ArcInvestigation(identifier : string, ?title : string, ?description : string, ?submissionDate : string, ?publicReleaseDate : string, ?ontologySourceReferences : OntologySourceReference [], ?publications : Publication [], ?contacts : Person [], ?assays : ResizeArray<ArcAssay>, ?studies : ResizeArray<ArcStudy>, ?registeredStudyIdentifiers : ResizeArray<string>, ?comments : Comment [], ?remarks : Remark []) as this = 
@@ -1815,21 +1817,21 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             this.StructurallyEquals(i)
         | _ -> false
 
-    override this.GetHashCode() =
-        [|
-            box this.Identifier
-            this.Title
-            this.Description
-            this.SubmissionDate
-            this.PublicReleaseDate
-            this.Publications
-            this.Contacts
-            this.OntologySourceReferences
-            this.Assays
-            this.Studies
-            this.RegisteredStudyIdentifiers
-            this.Comments
-            this.Remarks
-        |]
-        |> Array.map (fun o -> o.GetHashCode())
-        |> Array.sum
+    override this.GetHashCode() = failwith "Still need to implement correct GetHashCode function for ArcInvestigation type."
+        //[|
+        //    box this.Identifier
+        //    ArcTypesAux.boxHashOption this.Title
+        //    ArcTypesAux.boxHashOption this.Description
+        //    ArcTypesAux.boxHashOption this.SubmissionDate
+        //    ArcTypesAux.boxHashOption this.PublicReleaseDate
+        //    this.Publications
+        //    this.Contacts
+        //    this.OntologySourceReferences
+        //    this.Assays
+        //    this.Studies
+        //    this.RegisteredStudyIdentifiers
+        //    this.Comments
+        //    this.Remarks
+        //|]
+        //|> Array.map (fun o -> o.GetHashCode())
+        //|> Array.sum

--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -49,10 +49,6 @@ module ArcTypesAux =
             | None ->
                 ()
 
-    let boxHashOption (a: 'a option) : obj =
-        if a.IsSome then a.Value.GetHashCode() else (0).GetHashCode()
-        |> box
-
     /// <summary>
     /// Some functions can change ArcInvestigation.Assays elements. After these functions we must remove all registered assays which might have gone lost.
     /// </summary>
@@ -631,18 +627,18 @@ type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?techno
             this.StructurallyEquals(assay)
         | _ -> false
 
-    override this.GetHashCode() = failwith "Still need to implement correct GetHashCode function for ArcAssay type."
-        //[|
-        //    box this.Identifier
-        //    ArcTypesAux.boxHashOption this.MeasurementType
-        //    ArcTypesAux.boxHashOption this.TechnologyType
-        //    ArcTypesAux.boxHashOption this.TechnologyPlatform
-        //    box <| Array.ofSeq this.Tables
-        //    box this.Performers
-        //    box this.Comments
-        //|]
-        //|> Array.map (fun o -> o.GetHashCode())
-        //|> Array.sum
+    override this.GetHashCode() = 
+        [|
+            box this.Identifier
+            Aux.HashCodes.boxHashOption this.MeasurementType
+            Aux.HashCodes.boxHashOption this.TechnologyType
+            Aux.HashCodes.boxHashOption this.TechnologyPlatform
+            Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Tables
+            Aux.HashCodes.boxHashArray this.Performers
+            Aux.HashCodes.boxHashArray this.Comments
+        |]
+        |> Aux.HashCodes.boxHashArray 
+        |> fun x -> x :?> int
 
 [<AttachMembers>]
 type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publicReleaseDate, ?publications, ?contacts, ?studyDesignDescriptors, ?tables, ?registeredAssayIdentifiers: ResizeArray<string>, ?factors, ?comments) = 
@@ -1284,23 +1280,23 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
             this.StructurallyEquals(s)
         | _ -> false
 
-    override this.GetHashCode() = failwith "Still need to implement correct GetHashCode function for ArcStudy type."
-        //[|
-        //    box this.Identifier
-        //    ArcTypesAux.boxHashOption this.Title
-        //    ArcTypesAux.boxHashOption this.Description
-        //    ArcTypesAux.boxHashOption this.SubmissionDate
-        //    ArcTypesAux.boxHashOption this.PublicReleaseDate
-        //    this.Publications
-        //    this.Contacts
-        //    this.StudyDesignDescriptors
-        //    this.Tables
-        //    this.RegisteredAssayIdentifiers
-        //    this.Factors
-        //    this.Comments
-        //|]
-        //|> Array.map (fun o -> o.GetHashCode())
-        //|> Array.sum
+    override this.GetHashCode() = 
+        [|
+            box this.Identifier
+            Aux.HashCodes.boxHashOption this.Title
+            Aux.HashCodes.boxHashOption this.Description
+            Aux.HashCodes.boxHashOption this.SubmissionDate
+            Aux.HashCodes.boxHashOption this.PublicReleaseDate
+            Aux.HashCodes.boxHashArray this.Publications
+            Aux.HashCodes.boxHashArray this.Contacts
+            Aux.HashCodes.boxHashArray this.StudyDesignDescriptors
+            Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Tables
+            Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.RegisteredAssayIdentifiers
+            Aux.HashCodes.boxHashArray this.Factors
+            Aux.HashCodes.boxHashArray this.Comments
+        |]
+        |> Aux.HashCodes.boxHashArray 
+        |> fun x -> x :?> int
 
 [<AttachMembers>]
 type ArcInvestigation(identifier : string, ?title : string, ?description : string, ?submissionDate : string, ?publicReleaseDate : string, ?ontologySourceReferences : OntologySourceReference [], ?publications : Publication [], ?contacts : Person [], ?assays : ResizeArray<ArcAssay>, ?studies : ResizeArray<ArcStudy>, ?registeredStudyIdentifiers : ResizeArray<string>, ?comments : Comment [], ?remarks : Remark []) as this = 
@@ -1829,21 +1825,21 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             this.StructurallyEquals(i)
         | _ -> false
 
-    override this.GetHashCode() = failwith "Still need to implement correct GetHashCode function for ArcInvestigation type."
-        //[|
-        //    box this.Identifier
-        //    ArcTypesAux.boxHashOption this.Title
-        //    ArcTypesAux.boxHashOption this.Description
-        //    ArcTypesAux.boxHashOption this.SubmissionDate
-        //    ArcTypesAux.boxHashOption this.PublicReleaseDate
-        //    this.Publications
-        //    this.Contacts
-        //    this.OntologySourceReferences
-        //    this.Assays
-        //    this.Studies
-        //    this.RegisteredStudyIdentifiers
-        //    this.Comments
-        //    this.Remarks
-        //|]
-        //|> Array.map (fun o -> o.GetHashCode())
-        //|> Array.sum
+    override this.GetHashCode() = 
+        [|
+            box this.Identifier
+            Aux.HashCodes.boxHashOption this.Title
+            Aux.HashCodes.boxHashOption this.Description
+            Aux.HashCodes.boxHashOption this.SubmissionDate
+            Aux.HashCodes.boxHashOption this.PublicReleaseDate
+            Aux.HashCodes.boxHashArray this.Publications
+            Aux.HashCodes.boxHashArray this.Contacts
+            Aux.HashCodes.boxHashArray this.OntologySourceReferences
+            Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Assays
+            Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Studies
+            Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.RegisteredStudyIdentifiers
+            Aux.HashCodes.boxHashArray this.Comments
+            Aux.HashCodes.boxHashArray this.Remarks
+        |]
+        |> Aux.HashCodes.boxHashArray 
+        |> fun x -> x :?> int

--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -628,6 +628,19 @@ type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?techno
             this.StructurallyEquals(assay)
         | _ -> false
 
+    override this.GetHashCode() =
+        [|
+            box this.Identifier
+            this.MeasurementType
+            this.TechnologyType
+            this.TechnologyPlatform
+            this.Tables
+            this.Performers
+            this.Comments
+        |]
+        |> Array.map (fun o -> o.GetHashCode())
+        |> Array.sum
+
 [<AttachMembers>]
 type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publicReleaseDate, ?publications, ?contacts, ?studyDesignDescriptors, ?tables, ?registeredAssayIdentifiers: ResizeArray<string>, ?factors, ?comments) = 
     let publications = defaultArg publications [||]
@@ -1269,6 +1282,24 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
             this.StructurallyEquals(s)
         | _ -> false
 
+    override this.GetHashCode() =
+        [|
+            box this.Identifier
+            this.Title
+            this.Description
+            this.SubmissionDate
+            this.PublicReleaseDate
+            this.Publications
+            this.Contacts
+            this.StudyDesignDescriptors
+            this.Tables
+            this.RegisteredAssayIdentifiers
+            this.Factors
+            this.Comments
+        |]
+        |> Array.map (fun o -> o.GetHashCode())
+        |> Array.sum
+
 [<AttachMembers>]
 type ArcInvestigation(identifier : string, ?title : string, ?description : string, ?submissionDate : string, ?publicReleaseDate : string, ?ontologySourceReferences : OntologySourceReference [], ?publications : Publication [], ?contacts : Person [], ?assays : ResizeArray<ArcAssay>, ?studies : ResizeArray<ArcStudy>, ?registeredStudyIdentifiers : ResizeArray<string>, ?comments : Comment [], ?remarks : Remark []) as this = 
 
@@ -1783,3 +1814,22 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
         | :? ArcInvestigation as i -> 
             this.StructurallyEquals(i)
         | _ -> false
+
+    override this.GetHashCode() =
+        [|
+            box this.Identifier
+            this.Title
+            this.Description
+            this.SubmissionDate
+            this.PublicReleaseDate
+            this.Publications
+            this.Contacts
+            this.OntologySourceReferences
+            this.Assays
+            this.Studies
+            this.RegisteredStudyIdentifiers
+            this.Comments
+            this.Remarks
+        |]
+        |> Array.map (fun o -> o.GetHashCode())
+        |> Array.sum

--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -1646,9 +1646,9 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             copy
 
     /// <summary>
-    /// Returns all Contacts/Performers from assays/studies/investigation unfiltered. 
+    /// Returns all fully distinct Contacts/Performers from assays/studies/investigation. 
     /// </summary>
-    member this.GetAllPersons() =
+    member this.GetAllPersons() : Person [] =
         let persons = ResizeArray()
         for a in this.Assays do
             persons.AddRange(a.Performers)
@@ -1656,6 +1656,20 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             persons.AddRange(s.Contacts)
         persons.AddRange(this.Contacts)
         persons
+        |> Array.ofSeq
+        |> Array.distinct
+
+    /// <summary>
+    /// Returns all fully distinct Contacts/Performers from assays/studies/investigation unfiltered. 
+    /// </summary>
+    member this.GetAllPublications() : Publication [] =
+        let pubs = ResizeArray()
+        for s in this.Studies do
+            pubs.AddRange(s.Publications)
+        pubs.AddRange(this.Publications)
+        pubs
+        |> Array.ofSeq
+        |> Array.distinct
 
     // - Study API - CRUD //
     /// <summary>

--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -1649,6 +1649,18 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             copy.DeregisterAssay(studyIdentifier, assayIdentifier)
             copy
 
+    /// <summary>
+    /// Returns all Contacts/Performers from assays/studies/investigation unfiltered. 
+    /// </summary>
+    member this.GetAllPersons() =
+        let persons = ResizeArray()
+        for a in this.Assays do
+            persons.AddRange(a.Performers)
+        for s in this.Studies do
+            persons.AddRange(s.Contacts)
+        persons.AddRange(this.Contacts)
+        persons
+
     // - Study API - CRUD //
     /// <summary>
     /// Deregisters assays not found in ArcInvestigation.Assays from all studies.

--- a/src/ISA/ISA/ArcTypes/CompositeColumn.fs
+++ b/src/ISA/ISA/ArcTypes/CompositeColumn.fs
@@ -18,7 +18,7 @@ type CompositeColumn = {
     ///
     /// ?raiseExeption: Default false. Set true if this function should raise an exception instead of return false.
     // TODO! Do not only check cells.Head
-    member this.validate(?raiseException: bool) =
+    member this.Validate(?raiseException: bool) =
         let raiseExeption = Option.defaultValue false raiseException
         let header = this.Header
         let cells = this.Cells
@@ -38,3 +38,14 @@ type CompositeColumn = {
             // Maybe still return `msg` somehow if `raiseExeption` is false?
             false
 
+    /// <summary>
+    /// Returns an array of all units found in the cells of this column. Returns None if no units are found.
+    /// </summary>
+    member this.GetColumnUnits() =
+        let arr = [|
+            for cell in this.Cells do
+                if cell.isUnitized then
+                    let _, unit = cell.AsUnitized
+                    unit
+        |]
+        if Array.isEmpty arr then None else Some arr

--- a/src/ISA/ISA/ArcTypes/CompositeColumn.fs
+++ b/src/ISA/ISA/ArcTypes/CompositeColumn.fs
@@ -41,7 +41,7 @@ type CompositeColumn = {
     /// <summary>
     /// Returns an array of all units found in the cells of this column. Returns None if no units are found.
     /// </summary>
-    member this.GetColumnUnits() =
+    member this.TryGetColumnUnits() =
         let arr = [|
             for cell in this.Cells do
                 if cell.isUnitized then

--- a/src/ISA/ISA/ArcTypes/CompositeHeader.fs
+++ b/src/ISA/ISA/ArcTypes/CompositeHeader.fs
@@ -74,9 +74,9 @@ type IOType =
         | Some s -> IOType.ofString s |> Some
         | None -> None
 
-    member this.GetExplanation() = IOType.getExplanation(!^this)
+    member this.GetUITooltip() = IOType.getUITooltip(!^this)
 
-    static member getExplanation(iotype: U2<IOType,string>) =
+    static member getUITooltip(iotype: U2<IOType,string>) =
         match iotype with
         | U2.Case1 Source | U2.Case2 "Source" -> 
             "The source value must be a unique identifier for an organism or a sample." 
@@ -402,9 +402,9 @@ type CompositeHeader =
         | Component oa -> Some (Component.create(ComponentType = oa))
         | _ -> None
 
-    member this.GetExplanation() =
+    member this.GetUITooltip() =
         // https://fable.io/docs/javascript/features.html#u2-u3--u9
-        CompositeHeader.getExplanation (!^this)
+        CompositeHeader.getUITooltip (!^this)
 
     // https://fable.io/docs/javascript/features.html#u2-u3--u9
     // U2 is an erased union type, allowing seemless integration into js syntax
@@ -412,7 +412,7 @@ type CompositeHeader =
     /// Can pass header as `U2.Case1 compositeHeader` or `U2.Case2 string` or (requires `open Fable.Core.JsInterop`) `!^compositeHeader` or `!^string`
     /// </summary>
     /// <param name="header"></param>
-    static member getExplanation(header:U2<CompositeHeader,string>) =
+    static member getUITooltip(header:U2<CompositeHeader,string>) =
         match header with
         | U2.Case1 (Component _) | U2.Case2 "Component" -> 
             "Component columns are used to describe physical components of a experiment, e.g. instrument names, software names, and reagents names."

--- a/src/ISA/ISA/ArcTypes/CompositeHeader.fs
+++ b/src/ISA/ISA/ArcTypes/CompositeHeader.fs
@@ -73,6 +73,17 @@ type IOType =
         | Some s -> IOType.ofString s |> Some
         | None -> None
 
+    member this.GetExplanation() =
+        match this with
+        | Source            -> "The source value must be a unique identifier for an organism or a sample." 
+        | Sample            -> "The Sample Name column describes specifc laboratory samples with a unique identifier." 
+        | RawDataFile       -> "The Raw Data File column defines untransformed and unprocessed data files."
+        | DerivedDataFile   -> "The Derived Data File column defines transformed and/or processed data files."
+        | ImageFile         -> "Placeholder"
+        | Material          -> "Placeholder" 
+        | FreeText s        -> "Placeholder"
+
+
 /// <summary>
 /// Model of the different types of Building Blocks in an ARC Annotation Table.
 /// </summary>
@@ -380,3 +391,19 @@ type CompositeHeader =
         | Component oa -> Some (Component.create(ComponentType = oa))
         | _ -> None
 
+    member this.GetExplanation() =
+        match this with
+        | Parameter oa          -> "Parameter columns describe steps in your experimental workflow, e.g. the centrifugation time or the temperature used for your assay."
+        | Factor oa             -> "Use Factor columns to describe independent variables that result in a specific output of your experiment, e.g. the light intensity under which an organism was grown."
+        | Characteristic oa     -> "Characteristic columns are used for study descriptions and describe inherent properties of the source material, e.g. a certain strain or organism part."
+        | Component oa          -> "Component columns are used to describe physical components of a experiment, e.g. instrument names, software names, and reagents names."
+        | ProtocolType          -> "Defines the protocol type according to your preferred endpoint repository." 
+        | ProtocolREF           -> "Defines the protocol name."
+        | ProtocolDescription   -> "Describe the protocol in free text."
+        | ProtocolUri           -> "Web or local address where the in-depth protocol is stored."
+        | ProtocolVersion       -> "Defines the protocol version."
+        | Performer             -> "Defines the protocol performer."
+        | Date                  -> "Defines the date the protocol was performed."
+        | Input io              -> sprintf "Only one input column per table. E.g. experimental samples or files. %s" <| io.GetExplanation()
+        | Output io             -> sprintf "Only one output column per table. E.g. experimental samples or files. %s" <| io.GetExplanation()
+        | FreeText str          -> "Placeholder"

--- a/src/ISA/ISA/Helper.fs
+++ b/src/ISA/ISA/Helper.fs
@@ -7,6 +7,19 @@ let inline compareSeq (a: seq<'a>) (b: seq<'a>) =
     else 
         false
 
+
+module HashCodes =
+
+    let boxHashOption (a: 'a option) : obj =
+        if a.IsSome then a.Value.GetHashCode() else (0).GetHashCode()
+        |> box
+
+    let boxHashArray (a: 'a []) : obj =
+        a 
+        // from https://stackoverflow.com/a/53507559
+        |> Array.fold (fun acc o -> 0x9e3779b9 + o.GetHashCode() + (acc <<< 6) + (acc >>> 2) ) 0
+        |> box
+
 [<RequireQualifiedAccess>]
 module Option =
  

--- a/tests/ARCtrl/Template.Tests.fs
+++ b/tests/ARCtrl/Template.Tests.fs
@@ -326,7 +326,7 @@ let private tests_equality = testList "equality" [
 let private tests_Web = testList "Web" [
     testCaseAsync "getTemplates" <| async {
         let! templatesMap = ARCtrl.Template.Web.getTemplates(None)
-        Expect.isTrue (templatesMap.Count > 0) "Count > 0"
+        Expect.isTrue (templatesMap.Length > 0) "Count > 0"
     }
 ]
 

--- a/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
@@ -601,27 +601,32 @@ let private tests_UpdateBy = testList "UpdateBy" [
 
 let private tests_GetHashCode = testList "GetHashCode" [
     testCase "passing" <| fun _ ->
-        let assay = ArcAssay.create("MyAssay", tables= ResizeArray([ArcTable.init("My Table")]))
-        Expect.isSome (assay.GetHashCode() |> Some) ""
+        let actual = ArcAssay.create("MyAssay", tables= ResizeArray([ArcTable.init("My Table")]))
+        Expect.isSome (actual.GetHashCode() |> Some) ""
     testCase "equal minimal" <| fun _ -> 
-        let assay = ArcAssay.init("MyAssay")
-        let copy = assay.Copy()
-        let assay2 = ArcAssay.init("MyAssay")
-        Expect.equal assay copy "equal"
-        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
-        Expect.equal (assay.GetHashCode()) (assay2.GetHashCode()) "assay2 hash equal"
+        let actual = ArcAssay.init("MyAssay")
+        let copy = actual.Copy()
+        let actual2 = ArcAssay.init("MyAssay")
+        Expect.equal actual copy "equal"
+        Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
+        Expect.equal (actual.GetHashCode()) (actual2.GetHashCode()) "assay2 hash equal"
     testCase "equal" <| fun _ ->
-        let assay = 
-            ArcAssay.make 
-                "MyAssay"
-                (OntologyAnnotation.fromString "mt" |> Some)
-                (OntologyAnnotation.fromString "tt" |> Some)
-                (OntologyAnnotation.fromString "tp" |> Some)
-                (ResizeArray([ArcTable.init("My Table"); ArcTable.Tests.create_testTable()]))
+        let actual = 
+            ArcStudy.make 
+                "MyStudy"
+                (Some "My Study Title")
+                (Some "My Study Description")
+                (Some "My Study SubmissionDate")
+                (Some "My Study PRD")
+                [|Publication.empty; Publication.create(Title="Some nice title")|]
                 ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
+                [|OntologyAnnotation.empty; OntologyAnnotation.empty; OntologyAnnotation.fromString("Name", "tsr", "Tan")|]
+                (ResizeArray([ArcTable.init("My Table"); ArcTable.Tests.create_testTable()]))
+                (ResizeArray(["Registered Assay1"; "Registered Assay2"]))
+                [|Factor.empty; Factor.create(Name="Factorios")|]
                 ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
-        let copy = assay.Copy()
-        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) ""
+        let copy = actual.Copy()
+        Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) ""
 ]
 
 let main = 

--- a/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
@@ -604,19 +604,20 @@ let private tests_GetHashCode = testList "GetHashCode" [
         let assay = ArcAssay.create("MyAssay", tables= ResizeArray([ArcTable.init("My Table")]))
         Expect.isSome (assay.GetHashCode() |> Some) ""
     testCase "equal minimal" <| fun _ -> 
-        let assay = ArcAssay.create("MyAssay")
+        let assay = ArcAssay.init("MyAssay")
         let copy = assay.Copy()
+        let assay2 = ArcAssay.init("MyAssay")
         Expect.equal assay copy "equal"
-        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) "hash equal"
-    testCase "equal" <| fun _ -> // This test does not run successfully
-        // Arithmetic operation resulted in an overflow
+        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
+        Expect.equal (assay.GetHashCode()) (assay2.GetHashCode()) "assay2 hash equal"
+    testCase "equal" <| fun _ ->
         let assay = 
             ArcAssay.make 
                 "MyAssay"
                 (OntologyAnnotation.fromString "mt" |> Some)
                 (OntologyAnnotation.fromString "tt" |> Some)
                 (OntologyAnnotation.fromString "tp" |> Some)
-                (ResizeArray([ArcTable.init("My Table")]))
+                (ResizeArray([ArcTable.init("My Table"); ArcTable.Tests.create_testTable()]))
                 ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
                 ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
         let copy = assay.Copy()

--- a/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
@@ -600,33 +600,34 @@ let private tests_UpdateBy = testList "UpdateBy" [
 ]
 
 let private tests_GetHashCode = testList "GetHashCode" [
+    let createFullAssay(name) =
+        ArcAssay.make 
+            name
+            (OntologyAnnotation.fromString "mt" |> Some)
+            (OntologyAnnotation.fromString "tt" |> Some)
+            (OntologyAnnotation.fromString "tp" |> Some)
+            (ResizeArray([ArcTable.init("My Table"); ArcTable.Tests.create_testTable()]))
+            ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
+            ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
     testCase "passing" <| fun _ ->
-        let actual = ArcAssay.create("MyAssay", tables= ResizeArray([ArcTable.init("My Table")]))
+        let actual = ArcStudy.init("MyStudy")
         Expect.isSome (actual.GetHashCode() |> Some) ""
     testCase "equal minimal" <| fun _ -> 
-        let actual = ArcAssay.init("MyAssay")
-        let copy = actual.Copy()
-        let actual2 = ArcAssay.init("MyAssay")
-        Expect.equal actual copy "equal"
-        Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
-        Expect.equal (actual.GetHashCode()) (actual2.GetHashCode()) "assay2 hash equal"
-    testCase "equal" <| fun _ ->
-        let actual = 
-            ArcStudy.make 
-                "MyStudy"
-                (Some "My Study Title")
-                (Some "My Study Description")
-                (Some "My Study SubmissionDate")
-                (Some "My Study PRD")
-                [|Publication.empty; Publication.create(Title="Some nice title")|]
-                ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
-                [|OntologyAnnotation.empty; OntologyAnnotation.empty; OntologyAnnotation.fromString("Name", "tsr", "Tan")|]
-                (ResizeArray([ArcTable.init("My Table"); ArcTable.Tests.create_testTable()]))
-                (ResizeArray(["Registered Assay1"; "Registered Assay2"]))
-                [|Factor.empty; Factor.create(Name="Factorios")|]
-                ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
-        let copy = actual.Copy()
-        Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) ""
+        let assay = ArcStudy.init("MyStudy")
+        let copy = assay.Copy()
+        let assay2 = ArcStudy.init("MyStudy")
+        Expect.equal assay copy "equal"
+        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
+        Expect.equal (assay.GetHashCode()) (assay2.GetHashCode()) "assay2 hash equal"
+    testCase "equal" <| fun _ -> 
+        let assay = createFullAssay "MyAssay"
+        let copy = assay.Copy()
+        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) ""
+    testCase "notEqual" <| fun _ ->
+        let x1 = ArcAssay.init("My assay")
+        let x2 = ArcAssay.init("My other assay")
+        Expect.notEqual x1 x2 "not equal"
+        Expect.notEqual (x1.GetHashCode()) (x2.GetHashCode()) "not equal hash"
 ]
 
 let main = 

--- a/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
@@ -499,7 +499,7 @@ let private tests_technologyPlatform =
         )
     ]
 
-let private test_UpdateBy = testList "UpdateBy" [
+let private tests_UpdateBy = testList "UpdateBy" [
     let create_testAssay() = 
         ArcAssay.create(
             "MyAssay", 
@@ -598,6 +598,31 @@ let private test_UpdateBy = testList "UpdateBy" [
         Expect.equal actual.Performers [|yield! expected.Performers; yield! next.Performers|] "Performers"
         Expect.equal actual.Comments [|yield! expected.Comments; yield! next.Comments|] "Comments"
 ]
+
+let private tests_GetHashCode = testList "GetHashCode" [
+    testCase "passing" <| fun _ ->
+        let assay = ArcAssay.create("MyAssay", tables= ResizeArray([ArcTable.init("My Table")]))
+        Expect.isSome (assay.GetHashCode() |> Some) ""
+    testCase "equal minimal" <| fun _ -> 
+        let assay = ArcAssay.create("MyAssay")
+        let copy = assay.Copy()
+        Expect.equal assay copy "equal"
+        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) "hash equal"
+    testCase "equal" <| fun _ -> // This test does not run successfully
+        // Arithmetic operation resulted in an overflow
+        let assay = 
+            ArcAssay.make 
+                "MyAssay"
+                (OntologyAnnotation.fromString "mt" |> Some)
+                (OntologyAnnotation.fromString "tt" |> Some)
+                (OntologyAnnotation.fromString "tp" |> Some)
+                (ResizeArray([ArcTable.init("My Table")]))
+                ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
+                ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
+        let copy = assay.Copy()
+        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) ""
+]
+
 let main = 
     testList "ArcAssay" [
         test_create
@@ -609,5 +634,5 @@ let main =
         tests_UpdateTable
         tests_updateTable
         tests_technologyPlatform
-        test_UpdateBy
+        tests_UpdateBy
     ]

--- a/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcAssay.Tests.fs
@@ -635,4 +635,5 @@ let main =
         tests_updateTable
         tests_technologyPlatform
         tests_UpdateBy
+        tests_GetHashCode
     ]

--- a/tests/ISA/ISA.Tests/ArcInvestigation.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcInvestigation.Tests.fs
@@ -570,6 +570,11 @@ let private tests_GetHashCode = testList "GetHashCode" [
                 [|Remark.create(12,"Test"); Remark.create(42, "The answer")|]
         let copy = actual.Copy()
         Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) ""
+    testCase "not equal" <| fun _ ->
+        let x1 = ArcInvestigation.init "Test"
+        let x2 = ArcInvestigation.init "Other Test"
+        Expect.notEqual x1 x2 "not equal"
+        Expect.notEqual (x1.GetHashCode()) (x2.GetHashCode()) "not equal hash"
 ]
 
 //let tests_UpdateBy = testList "UpdateBy" [

--- a/tests/ISA/ISA.Tests/ArcInvestigation.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcInvestigation.Tests.fs
@@ -541,6 +541,37 @@ let tests_Assay = testList "CRUD Assay" [
     ]
 ]
 
+let private tests_GetHashCode = testList "GetHashCode" [
+    testCase "passing" <| fun _ ->
+        let actual = ArcInvestigation.init("Test")
+        Expect.isSome (actual.GetHashCode() |> Some) ""
+    testCase "equal minimal" <| fun _ -> 
+        let actual = ArcInvestigation.init("Test")
+        let copy = actual.Copy()
+        let actual2 = ArcInvestigation.init("Test")
+        Expect.equal actual copy "equal"
+        Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
+        Expect.equal (actual.GetHashCode()) (actual2.GetHashCode()) "assay2 hash equal"
+    testCase "equal" <| fun _ ->
+        let actual = 
+            ArcInvestigation.make 
+                "Inv"
+                (Some "My Inv Title")
+                (Some "My Inv Description")
+                (Some "My Inv SubmissionDate")
+                (Some "My Inv PRD")
+                [|OntologySourceReference.create("Some Lorem ipsum description", Name="Descriptore"); OntologySourceReference.empty|]
+                [|Publication.empty; Publication.create(Title="Some nice title")|]
+                ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
+                (ResizeArray([ArcAssay.init("Registered Assay1"); ArcAssay.init("Registered Assay2")]))
+                (ResizeArray([ArcStudy.init("Registered Study1"); ArcStudy.init("Registered Study2")]))
+                (ResizeArray(["Registered Study1"; "Registered Study2"]))
+                ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
+                [|Remark.create(12,"Test"); Remark.create(42, "The answer")|]
+        let copy = actual.Copy()
+        Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) ""
+]
+
 //let tests_UpdateBy = testList "UpdateBy" [
 //    let create_testInvestigation(assay) =
 //        ArcInvestigation.create(
@@ -663,5 +694,6 @@ let main =
         tests_Copy
         tests_Study
         tests_Assay
+        tests_GetHashCode
         // tests_UpdateBy
     ]

--- a/tests/ISA/ISA.Tests/ArcStudy.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcStudy.Tests.fs
@@ -456,12 +456,38 @@ let tests_UpdateBy = testList "UpdateReferenceByStudyFile" [
         Expect.isEmpty actual.Comments "Comments"
 ]
 
+let private tests_GetHashCode = testList "GetHashCode" [
+    testCase "passing" <| fun _ ->
+        let actual = ArcStudy.init("MyStudy")
+        Expect.isSome (actual.GetHashCode() |> Some) ""
+    testCase "equal minimal" <| fun _ -> 
+        let assay = ArcStudy.init("MyStudy")
+        let copy = assay.Copy()
+        let assay2 = ArcStudy.init("MyStudy")
+        Expect.equal assay copy "equal"
+        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
+        Expect.equal (assay.GetHashCode()) (assay2.GetHashCode()) "assay2 hash equal"
+    testCase "equal" <| fun _ -> 
+        let assay = 
+            ArcAssay.make 
+                "MyAssay"
+                (OntologyAnnotation.fromString "mt" |> Some)
+                (OntologyAnnotation.fromString "tt" |> Some)
+                (OntologyAnnotation.fromString "tp" |> Some)
+                (ResizeArray([ArcTable.init("My Table"); ArcTable.Tests.create_testTable()]))
+                ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
+                ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
+        let copy = assay.Copy()
+        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) ""
+]
+
 let main = 
     testList "ArcStudy" [
         tests_copy
         tests_RegisteredAssays
         test_create
         tests_UpdateBy
+        tests_GetHashCode
     ]
 
 

--- a/tests/ISA/ISA.Tests/ArcStudy.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcStudy.Tests.fs
@@ -457,28 +457,39 @@ let tests_UpdateBy = testList "UpdateReferenceByStudyFile" [
 ]
 
 let private tests_GetHashCode = testList "GetHashCode" [
+    let createFullStudy(name) =
+        ArcStudy.make 
+            name
+            (Some "My Study Title")
+            (Some "My Study Description")
+            (Some "My Study SubmissionDate")
+            (Some "My Study PRD")
+            [|Publication.empty; Publication.create(Title="Some nice title")|]
+            ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
+            [|OntologyAnnotation.empty; OntologyAnnotation.empty; OntologyAnnotation.fromString("Name", "tsr", "Tan")|]
+            (ResizeArray([ArcTable.init("My Table"); ArcTable.Tests.create_testTable()]))
+            (ResizeArray(["Registered Assay1"; "Registered Assay2"]))
+            [|Factor.empty; Factor.create(Name="Factorios")|]
+            ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
     testCase "passing" <| fun _ ->
-        let actual = ArcStudy.init("MyStudy")
+        let actual = ArcAssay.create("MyAssay", tables= ResizeArray([ArcTable.init("My Table")]))
         Expect.isSome (actual.GetHashCode() |> Some) ""
     testCase "equal minimal" <| fun _ -> 
-        let assay = ArcStudy.init("MyStudy")
-        let copy = assay.Copy()
-        let assay2 = ArcStudy.init("MyStudy")
-        Expect.equal assay copy "equal"
-        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
-        Expect.equal (assay.GetHashCode()) (assay2.GetHashCode()) "assay2 hash equal"
-    testCase "equal" <| fun _ -> 
-        let assay = 
-            ArcAssay.make 
-                "MyAssay"
-                (OntologyAnnotation.fromString "mt" |> Some)
-                (OntologyAnnotation.fromString "tt" |> Some)
-                (OntologyAnnotation.fromString "tp" |> Some)
-                (ResizeArray([ArcTable.init("My Table"); ArcTable.Tests.create_testTable()]))
-                ([|Person.create(FirstName="John",LastName="Doe"); Person.create(FirstName="Jane",LastName="Doe")|])
-                ([|Comment.create("Hello", "World"); Comment.create("ByeBye", "World") |])
-        let copy = assay.Copy()
-        Expect.equal (assay.GetHashCode()) (copy.GetHashCode()) ""
+        let actual = ArcAssay.init("MyAssay")
+        let copy = actual.Copy()
+        let actual2 = ArcAssay.init("MyAssay")
+        Expect.equal actual copy "equal"
+        Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) "copy hash equal"
+        Expect.equal (actual.GetHashCode()) (actual2.GetHashCode()) "assay2 hash equal"
+    testCase "equal" <| fun _ ->
+        let actual = createFullStudy "MyStudy"
+        let copy = actual.Copy()
+        Expect.equal (actual.GetHashCode()) (copy.GetHashCode()) ""
+    testCase "not equal" <| fun _ ->
+        let x1 = ArcStudy.init "Test"
+        let x2 = ArcStudy.init "Other Test"
+        Expect.notEqual x1 x2 "not equal"
+        Expect.notEqual (x1.GetHashCode()) (x2.GetHashCode()) "not equal hash"
 ]
 
 let main = 

--- a/tests/ISA/ISA.Tests/ArcTable.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcTable.Tests.fs
@@ -75,16 +75,15 @@ let private tests_member =
             let table2 = create_testTable()
             Expect.equal table1 table2 "equal"
         )
-        #if !FABLE_COMPILER
         // i have no idea why this does not work
         testCase "GetHashCode" (fun () ->
             let table1 = create_testTable()
             let table2 = create_testTable()
             let hash1 = table1.GetHashCode()
             let hash2 = table2.GetHashCode()
+            Expect.equal table1 table2 "Table"
             Expect.equal hash1 hash2 "HashCode"
         )
-        #endif
     ]
 
 let private tests_validate = 

--- a/tests/ISA/ISA.Tests/CompositeColumn.Tests.fs
+++ b/tests/ISA/ISA.Tests/CompositeColumn.Tests.fs
@@ -4,16 +4,16 @@ open ARCtrl.ISA
 
 open TestingUtils
 
-let private tests_validate = 
-    testList "validate" [
+let private tests_Validate = 
+    testList "Validate" [
         testCase "Valid header with empty cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.Characteristic (OntologyAnnotation.empty)
             let header1 : CompositeHeader = CompositeHeader.Input IOType.Source
             let header2 : CompositeHeader = CompositeHeader.ProtocolType
             let cells : CompositeCell [] = [||]
-            let c1 = CompositeColumn.create(header, cells).validate()
-            let c2 = CompositeColumn.create(header1, cells).validate()
-            let c3 = CompositeColumn.create(header2, cells).validate()
+            let c1 = CompositeColumn.create(header, cells).Validate()
+            let c2 = CompositeColumn.create(header1, cells).Validate()
+            let c3 = CompositeColumn.create(header2, cells).Validate()
             Expect.isTrue c1 "header"
             Expect.isTrue c2 "header1"
             Expect.isTrue c3 "header2"
@@ -21,8 +21,8 @@ let private tests_validate =
         testCase "Valid term with term cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.Characteristic (OntologyAnnotation.empty)
             let cells : CompositeCell [] = Array.init 2 (fun _ -> CompositeCell.emptyTerm)
-            let column = CompositeColumn.create(header, cells).validate()
-            let eval() = CompositeColumn.create(header, cells).validate(true)
+            let column = CompositeColumn.create(header, cells).Validate()
+            let eval() = CompositeColumn.create(header, cells).Validate(true)
             // Still shows bool as output but could raise an exception.
             eval() |> ignore
             Expect.isTrue column ""
@@ -30,8 +30,8 @@ let private tests_validate =
         testCase "Valid term with unit cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.Characteristic (OntologyAnnotation.empty)
             let cells : CompositeCell [] = Array.init 2 (fun _ -> CompositeCell.emptyUnitized)
-            let column = CompositeColumn.create(header, cells).validate()
-            let eval() = CompositeColumn.create(header, cells).validate(true)
+            let column = CompositeColumn.create(header, cells).Validate()
+            let eval() = CompositeColumn.create(header, cells).Validate(true)
             // Still shows bool as output but could raise an exception.
             eval() |> ignore
             Expect.isTrue column ""
@@ -39,48 +39,48 @@ let private tests_validate =
         testCase "Invalid term with freetext cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.Characteristic (OntologyAnnotation.empty)
             let cells : CompositeCell [] = Array.init 2 (fun _ -> CompositeCell.emptyFreeText)
-            let column = CompositeColumn.create(header, cells).validate()
-            let eval() = CompositeColumn.create(header, cells).validate(true) |> ignore
+            let column = CompositeColumn.create(header, cells).Validate()
+            let eval() = CompositeColumn.create(header, cells).Validate(true) |> ignore
             Expect.isFalse column ""
             Expect.throws eval ""
         )
         testCase "Invalid featured with freetext cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.ProtocolType
             let cells : CompositeCell [] = Array.init 2 (fun _ -> CompositeCell.emptyFreeText)
-            let column = CompositeColumn.create(header, cells).validate()
-            let eval() = CompositeColumn.create(header, cells).validate(true) |> ignore
+            let column = CompositeColumn.create(header, cells).Validate()
+            let eval() = CompositeColumn.create(header, cells).Validate(true) |> ignore
             Expect.isFalse column ""
             Expect.throws eval ""
         )
         testCase "Invalid io column with term cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.Input IOType.ImageFile
             let cells : CompositeCell [] = Array.init 2 (fun _ -> CompositeCell.emptyTerm)
-            let column = CompositeColumn.create(header, cells).validate()
-            let eval() = CompositeColumn.create(header, cells).validate(true) |> ignore
+            let column = CompositeColumn.create(header, cells).Validate()
+            let eval() = CompositeColumn.create(header, cells).Validate(true) |> ignore
             Expect.isFalse column ""
             Expect.throws eval ""
         )
         testCase "Invalid io column with unit cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.Input IOType.ImageFile
             let cells : CompositeCell [] = Array.init 2 (fun _ -> CompositeCell.emptyUnitized)
-            let column = CompositeColumn.create(header, cells).validate()
-            let eval() = CompositeColumn.create(header, cells).validate(true) |> ignore
+            let column = CompositeColumn.create(header, cells).Validate()
+            let eval() = CompositeColumn.create(header, cells).Validate(true) |> ignore
             Expect.isFalse column ""
             Expect.throws eval ""
         )
         testCase "Invalid single column with term cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.ProtocolREF
             let cells : CompositeCell [] = Array.init 2 (fun _ -> CompositeCell.emptyTerm)
-            let column = CompositeColumn.create(header, cells).validate()
-            let eval() = CompositeColumn.create(header, cells).validate(true) |> ignore
+            let column = CompositeColumn.create(header, cells).Validate()
+            let eval() = CompositeColumn.create(header, cells).Validate(true) |> ignore
             Expect.isFalse column ""
             Expect.throws eval ""
         )
         testCase "Invalid single column with unit cells" (fun () ->
             let header : CompositeHeader = CompositeHeader.ProtocolREF
             let cells : CompositeCell [] = Array.init 2 (fun _ -> CompositeCell.emptyUnitized)
-            let column = CompositeColumn.create(header, cells).validate()
-            let eval() = CompositeColumn.create(header, cells).validate(true) |> ignore
+            let column = CompositeColumn.create(header, cells).Validate()
+            let eval() = CompositeColumn.create(header, cells).Validate(true) |> ignore
             Expect.isFalse column ""
             Expect.throws eval ""
         )
@@ -88,5 +88,5 @@ let private tests_validate =
 
 let main = 
     testList "CompositeColumn" [
-        tests_validate
+        tests_Validate
     ]

--- a/tests/ISA/ISA.Tests/CompositeHeader.Tests.fs
+++ b/tests/ISA/ISA.Tests/CompositeHeader.Tests.fs
@@ -30,14 +30,14 @@ let private tests_iotype =
             let caseInfos = IOType.Cases
             Expect.hasLength IOType.All (caseInfos.Length-1) "Expect one less than all because we do not want to track `FreeText` case."
         )
-        testCase "getExplanation" <| fun _ ->
+        testCase "getUIToolTip" <| fun _ ->
             let cases = IOType.Cases |> Array.map snd
             for case in cases do
-                let actual = IOType.getExplanation(U2.Case2 case)
+                let actual = IOType.getUITooltip(U2.Case2 case)
                 Expect.isTrue (actual.Length > 0) $"{case}"
-        testCase "GetExplanation" <| fun _ ->
+        testCase "GetUIToolTip" <| fun _ ->
             let iotype = IOType.Material
-            let actual = iotype.GetExplanation()
+            let actual = iotype.GetUITooltip()
             Expect.isTrue (actual.Length > 0) ""
     ]
 
@@ -59,11 +59,11 @@ let private tests_compositeHeader =
         testCase "getExplanation" <| fun _ ->
             let cases = CompositeHeader.Cases |> Array.map snd
             for case in cases do
-                let actual = CompositeHeader.getExplanation(U2.Case2 case)
+                let actual = CompositeHeader.getUITooltip(U2.Case2 case)
                 Expect.isTrue (actual.Length > 0) $"{case}"
         testCase "GetExplanation" <| fun _ ->
             let header = CompositeHeader.Component OntologyAnnotation.empty
-            let actual = header.GetExplanation()
+            let actual = header.GetUITooltip()
             Expect.isTrue (actual.Length > 0) ""
         testList "ToString()" [
             testCase "Characteristic" (fun () -> 

--- a/tests/ISA/ISA.Tests/CompositeHeader.Tests.fs
+++ b/tests/ISA/ISA.Tests/CompositeHeader.Tests.fs
@@ -3,7 +3,7 @@
 open ARCtrl.ISA
 
 open TestingUtils
-
+open Fable.Core
 
 let private tests_iotype = 
     testList "IOType" [
@@ -26,11 +26,19 @@ let private tests_iotype =
             Expect.equal (IOType.FreeText "Test").asOutput "Output [Test]" "FreeText Test"
         )
         // This test ensures that new IOTypes are also added to `All` static member.
-        testCase "All" (fun () -> 
-            let caseInfos = Microsoft.FSharp.Reflection.FSharpType.GetUnionCases(typeof<IOType>) 
-            let count = caseInfos |> Array.length
-            Expect.hasLength IOType.All (count-1) "Expect one less than all because we do not want to track `FreeText` case."
+        testCase "Cases" (fun () -> 
+            let caseInfos = IOType.Cases
+            Expect.hasLength IOType.All (caseInfos.Length-1) "Expect one less than all because we do not want to track `FreeText` case."
         )
+        testCase "getExplanation" <| fun _ ->
+            let cases = IOType.Cases |> Array.map snd
+            for case in cases do
+                let actual = IOType.getExplanation(U2.Case2 case)
+                Expect.isTrue (actual.Length > 0) $"{case}"
+        testCase "GetExplanation" <| fun _ ->
+            let iotype = IOType.Material
+            let actual = iotype.GetExplanation()
+            Expect.isTrue (actual.Length > 0) ""
     ]
 
 let private tests_jsHelper = testList "jsHelper" [
@@ -48,6 +56,15 @@ let private tests_compositeHeader =
         testCase "Cases" <| fun _ ->
             let count = CompositeHeader.Cases.Length
             Expect.equal count 14 "count"
+        testCase "getExplanation" <| fun _ ->
+            let cases = CompositeHeader.Cases |> Array.map snd
+            for case in cases do
+                let actual = CompositeHeader.getExplanation(U2.Case2 case)
+                Expect.isTrue (actual.Length > 0) $"{case}"
+        testCase "GetExplanation" <| fun _ ->
+            let header = CompositeHeader.Component OntologyAnnotation.empty
+            let actual = header.GetExplanation()
+            Expect.isTrue (actual.Length > 0) ""
         testList "ToString()" [
             testCase "Characteristic" (fun () -> 
                 let header = CompositeHeader.Characteristic <| OntologyAnnotation.fromString("species", "MS", "MS:0000042")

--- a/tests/JavaScript/Template.Web.js
+++ b/tests/JavaScript/Template.Web.js
@@ -4,7 +4,7 @@ import { JsWeb } from "./ARCtrl/Templates/Template.Web.js";
 describe('Template.Web', function () {
     it('getTemplates', async () => {
         let templates = await JsWeb.getTemplates()
-        let exists = templates.size >= 0
+        let exists = templates.length >= 0
         deepEqual(exists, true, "If true templates were found and downloaded")
     })
 });


### PR DESCRIPTION
Will come with some utility functions:

- `import { Templates } from 'arctrl'` (please verify import from index.js works correctly), has functions to filter arrays of templates.
  - `Templates.getDistinctTags()`, `Templates.getDistinctEndpointRepositories()`, `getDistinctOntologyAnnotations()`
  - `Templates.filterByTags(tagArray)`, also exists for EndpointRepositories and OntologyAnnotations. Can be used with optional boolean input to toggle between OR and AND search. Default is false, is OR.

```js
const templates = [create_TestTemplate()];
const queryTags = [OntologyAnnotation.fromString("DNA"), OntologyAnnotation.fromString("RNA")];
Templates.filterByOntologyAnnotation(queryTags, true)(templates); //example for AND search
```

- `CompositeHeader` and `IOType` both have `getUITooltip(caseName)`, which will return a string with a description. `caseName` can be used from `CompositeHeader.Cases`/`IOType.Cases`
- `Templates_fromJsonString ` will now return an array.
- `ArcTable.Join`, can be used to append one ArcTable to another. See source code comment. ⚠️for js `TableJoinOptions` can be any of "Headers" (Add only headers, no values), "WithUnit" (Add headers and unit information without main value), "WithValues" (Add full columns).

```fsharp
/// <summary>
/// This function can be used to join two arc tables.
/// </summary>
/// <param name="table">The table to join to this table.</param>
/// <param name="joinOptions">Can add only headers, header with unitized cell information, headers with values.</param>
/// <param name="forceReplace">if set to true will replace unique columns.</param>
member this.Join(table:ArcTable, ?joinOptions: TableJoinOptions, ?forceReplace: bool) : unit =
```