### PR TITLE
ArcInvestigation writer fix

### DIFF
--- a/src/ISA/ISA.Spreadsheet/ArcInvestigation.fs
+++ b/src/ISA/ISA.Spreadsheet/ArcInvestigation.fs
@@ -194,7 +194,7 @@ module ArcInvestigation =
             yield  SparseRow.fromValues [contactsLabel]
             yield! Contacts.toRows (Some contactsLabelPrefix) (List.ofArray investigation.Contacts)
 
-            for study in (List.ofSeq investigation.Studies) do
+            for study in investigation.RegisteredStudies do
                 yield  SparseRow.fromValues [studyLabel]
                 yield! Studies.toRows study None
         }

--- a/tests/ISA/ISA.Json.Tests/Json.Tests.fs
+++ b/tests/ISA/ISA.Json.Tests/Json.Tests.fs
@@ -1266,6 +1266,20 @@ let testInvestigationFile =
 
             Expect.equal i.Remarks List.empty "Remark list should be an empty list."
         )
+        testCase "OnlyConsiderRegisteredStudies" (fun () ->
+            let isa = ArcInvestigation("MyInvestigation")
+            let registeredStudyIdentifier = "RegisteredStudy"
+            let registeredStudy = ArcStudy(registeredStudyIdentifier)
+            let unregisteredStudyIdentifier = "UnregisteredStudy"
+            let unregisteredStudy = ArcStudy(unregisteredStudyIdentifier)
+
+            isa.AddStudy(unregisteredStudy)
+            isa.AddRegisteredStudy(registeredStudy)
+
+            let result = ArcInvestigation.toJsonString isa |> ArcInvestigation.fromJsonString
+
+            Expect.sequenceEqual result.RegisteredStudyIdentifiers [registeredStudyIdentifier] "Only the registered study should be written and read"
+        )
         testCase "FullInvestigation" (fun () ->
                   
             let comment = 

--- a/tests/ISA/ISA.Spreadsheet.Tests/InvestigationFileTests.fs
+++ b/tests/ISA/ISA.Spreadsheet.Tests/InvestigationFileTests.fs
@@ -47,6 +47,20 @@ let private testInvestigationWriterComponents =
             wb.AddWorksheet(sheet)
             Expect.isSome (wb.TryGetWorksheetByName "Investigation") "Worksheet should be added to workbook"
         )
+        testCase "OnlyConsiderRegisteredStudies" (fun () ->
+            let isa = ArcInvestigation("MyInvestigation")
+            let registeredStudyIdentifier = "RegisteredStudy"
+            let registeredStudy = ArcStudy(registeredStudyIdentifier)
+            let unregisteredStudyIdentifier = "UnregisteredStudy"
+            let unregisteredStudy = ArcStudy(unregisteredStudyIdentifier)
+
+            isa.AddStudy(unregisteredStudy)
+            isa.AddRegisteredStudy(registeredStudy)
+
+            let result = ArcInvestigation.toFsWorkbook isa |> ArcInvestigation.fromFsWorkbook
+
+            Expect.sequenceEqual result.RegisteredStudyIdentifiers [registeredStudyIdentifier] "Only the registered study should be written and read"
+        )
 
                     
                    


### PR DESCRIPTION
`ArcInvestigation.toFsWorkbook` now only writes registered studies to investigation file.
closes #229 