### PR TITLE
Registration sensitive arc type getter functions

### DIFF
--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -1198,8 +1198,8 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             this.Assays 
             |> ResizeArray.filter (fun a ->
                 this.RegisteredStudies
-                |> ResizeArray.exists (fun s -> 
-                    ResizeArray.exists (fun i -> i = a.Identifier) s.RegisteredAssayIdentifiers
+                |> Seq.exists (fun s -> 
+                    Seq.exists (fun i -> i = a.Identifier) s.RegisteredAssayIdentifiers
                 )
                 |> not
             )
@@ -1408,7 +1408,7 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             this.Studies 
             |> ResizeArray.filter (fun s -> 
                 this.RegisteredStudyIdentifiers
-                |> ResizeArray.exists ((=) s.Identifier)
+                |> Seq.exists ((=) s.Identifier)
                 |> not
             )
 

--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -612,14 +612,28 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
     static member FileName = ARCtrl.Path.StudyFileName
     //member this.FileName = ArcStudy.FileName
 
-    member this.RegisteredAssayCount 
+    /// Returns the count of registered assay *identifiers*. This is not necessarily the same as the count of registered assays, as not all identifiers correspond to an existing assay.
+    member this.RegisteredAssayIdentifierCount 
         with get() = this.RegisteredAssayIdentifiers.Count
 
+    /// Returns the count of registered assays. This is not necessarily the same as the count of registered assay *identifiers*, as not all identifiers correspond to an existing assay.
+    member this.RegisteredAssayCount 
+        with get() = this.RegisteredAssays.Count
+
+    /// Returns all assays registered in this study, that correspond to an existing assay object in the associated investigation.
     member this.RegisteredAssays
         with get(): ResizeArray<ArcAssay> = 
             let inv = ArcTypesAux.SanityChecks.validateRegisteredInvestigation this.Investigation
             this.RegisteredAssayIdentifiers 
             |> Seq.choose inv.TryGetAssay
+            |> ResizeArray
+
+    /// Returns all registered assay identifiers that do not correspond to an existing assay object in the associated investigation.
+    member this.VacantAssayIdentifiers
+        with get() = 
+            let inv = ArcTypesAux.SanityChecks.validateRegisteredInvestigation this.Investigation
+            this.RegisteredAssayIdentifiers 
+            |> Seq.filter (inv.ContainsAssay >> not)
             |> ResizeArray
 
     // - Assay API - CRUD //
@@ -1179,6 +1193,17 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
     member this.AssayIdentifiers 
         with get(): string [] = this.Assays |> Seq.map (fun (x:ArcAssay) -> x.Identifier) |> Array.ofSeq
 
+    member this.UnregisteredAssays 
+        with get(): ResizeArray<ArcAssay> = 
+            this.Assays 
+            |> ResizeArray.filter (fun a ->
+                this.RegisteredStudies
+                |> ResizeArray.exists (fun s -> 
+                    ResizeArray.exists (fun i -> i = a.Identifier) s.RegisteredAssayIdentifiers
+                )
+                |> not
+            )
+
     // - Assay API - CRUD //
     member this.AddAssay(assay: ArcAssay) =
         ArcTypesAux.SanityChecks.validateUniqueAssayIdentifier assay.Identifier (this.Assays |> Seq.map (fun x -> x.Identifier))
@@ -1344,18 +1369,48 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             let newInvestigation = inv.Copy()
             newInvestigation.TryGetAssay(assayIdentifier)
     
+    member this.ContainsAssay(assayIdentifier: string) =
+        this.Assays
+        |> Seq.exists (fun a -> a.Identifier = assayIdentifier)
 
+    static member containsAssay (assayIdentifier: string) : ArcInvestigation -> bool =
+        fun (inv: ArcInvestigation) ->            
+            inv.ContainsAssay(assayIdentifier)
+
+    /// Returns the count of registered study *identifiers*. This is not necessarily the same as the count of registered studies, as not all identifiers correspond to an existing study object.
+    member this.RegisteredStudyIdentifierCount 
+        with get() = this.RegisteredStudyIdentifiers.Count
+
+    /// Returns all studies registered in this investigation, that correspond to an existing study object investigation.
     member this.RegisteredStudies 
+        with get() : ResizeArray<ArcStudy> = 
+            this.RegisteredStudyIdentifiers 
+            |> ResizeArray.choose (fun identifier -> this.TryGetStudy identifier)
+
+    /// Returns the count of registered studies. This is not necessarily the same as the count of registered study *identifiers*, as not all identifiers correspond to an existing study object.
+    member this.RegisteredStudyCount 
+        with get() = this.RegisteredStudies.Count
+
+    /// Returns all registered study identifiers that do not correspond to an existing study object in the investigation.
+    member this.VacantStudyIdentifiers
         with get() = 
             this.RegisteredStudyIdentifiers 
-            |> Seq.choose (fun identifier -> this.TryGetStudy identifier)
-            |> ResizeArray
+            |> ResizeArray.filter (this.ContainsStudy >> not)
 
     member this.StudyCount 
         with get() = this.Studies.Count
 
     member this.StudyIdentifiers
         with get() = this.Studies |> Seq.map (fun (x:ArcStudy) -> x.Identifier) |> Seq.toArray
+
+    member this.UnregisteredStudies 
+        with get() = 
+            this.Studies 
+            |> ResizeArray.filter (fun s -> 
+                this.RegisteredStudyIdentifiers
+                |> ResizeArray.exists ((=) s.Identifier)
+                |> not
+            )
 
     // - Study API - CRUD //
     member this.AddStudy(study: ArcStudy) =
@@ -1539,6 +1594,13 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             let newInv = inv.Copy()
             newInv.TryGetStudy(studyIdentifier)
 
+    member this.ContainsStudy(studyIdentifier: string) =
+        this.Studies
+        |> Seq.exists (fun s -> s.Identifier = studyIdentifier)
+
+    static member containsStudy (studyIdentifier: string) : ArcInvestigation -> bool =
+        fun (inv: ArcInvestigation) ->            
+            inv.ContainsStudy(studyIdentifier)
 
     // - Study API - CRUD //
     /// <summary>

--- a/src/ISA/ISA/Helper.fs
+++ b/src/ISA/ISA/Helper.fs
@@ -30,13 +30,6 @@ module ResizeArray =
             if f i then b.Add(i)
         b
 
-    let exists f (a : ResizeArray<_>) =
-        let mutable state = false
-        for i in a do
-            if f i then
-                state <- true
-        state
-
     let fold f s (a : ResizeArray<_>) =
         let mutable state = s
         for i in a do

--- a/src/ISA/ISA/Helper.fs
+++ b/src/ISA/ISA/Helper.fs
@@ -30,6 +30,13 @@ module ResizeArray =
             if f i then b.Add(i)
         b
 
+    let exists f (a : ResizeArray<_>) =
+        let mutable state = false
+        for i in a do
+            if f i then
+                state <- true
+        state
+
     let fold f s (a : ResizeArray<_>) =
         let mutable state = s
         for i in a do

--- a/tests/ISA/ISA.Tests/ArcInvestigation.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcInvestigation.Tests.fs
@@ -198,7 +198,7 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
         Expect.equal i.AssayCount 1 "assay count"
         Expect.equal i.StudyCount 1 "study count"
         i.RegisterAssay(s.Identifier, a.Identifier)
-        Expect.equal s.RegisteredAssayCount 1 "registered assay count"
+        Expect.equal s.RegisteredAssayIdentifierCount 1 "registered assay count"
         Expect.equal s.RegisteredAssayIdentifiers.[0] a.Identifier "identifier"
     testCase "Study.RegisterAssay" <| fun _ ->
         let i = ArcInvestigation.init("MyInvestigation")
@@ -207,7 +207,7 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
         Expect.equal i.AssayCount 1 "assay count"
         Expect.equal i.StudyCount 1 "study count"
         s.RegisterAssay(a.Identifier)
-        Expect.equal s.RegisteredAssayCount 1 "registered assay count"
+        Expect.equal s.RegisteredAssayIdentifierCount 1 "registered assay count"
         Expect.equal s.RegisteredAssayIdentifiers.[0] a.Identifier "identifier"
     testCase "Investigation.DeregisterAssay" <| fun _ ->
         let i = ArcInvestigation.init("MyInvestigation")
@@ -216,10 +216,10 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
         Expect.equal i.AssayCount 1 "assay count"
         Expect.equal i.StudyCount 1 "study count"
         i.RegisterAssay(s.Identifier, a.Identifier)
-        Expect.equal s.RegisteredAssayCount 1 "registered assay count"
+        Expect.equal s.RegisteredAssayIdentifierCount 1 "registered assay count"
         Expect.equal s.RegisteredAssayIdentifiers.[0] a.Identifier "identifier"
         i.DeregisterAssay(s.Identifier,a.Identifier)
-        Expect.equal s.RegisteredAssayCount 0 "registered assay count 2"
+        Expect.equal s.RegisteredAssayIdentifierCount 0 "registered assay count 2"
     testCase "Study.DeregisterAssay" <| fun _ ->
         let i = ArcInvestigation.init("MyInvestigation")
         let a = i.InitAssay("MyAssay")
@@ -227,10 +227,10 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
         Expect.equal i.AssayCount 1 "assay count"
         Expect.equal i.StudyCount 1 "study count"
         s.RegisterAssay(a.Identifier)
-        Expect.equal s.RegisteredAssayCount 1 "registered assay count"
+        Expect.equal s.RegisteredAssayIdentifierCount 1 "registered assay count"
         Expect.equal s.RegisteredAssayIdentifiers.[0] a.Identifier "identifier"
         s.DeregisterAssay(a.Identifier)
-        Expect.equal s.RegisteredAssayCount 0 "registered assay count 2"
+        Expect.equal s.RegisteredAssayIdentifierCount 0 "registered assay count 2"
     testCase "Remove registered assay from investigation" <| fun _ ->
         let i = ArcInvestigation.init("MyInvestigation")
         let a = i.InitAssay("MyAssay")
@@ -238,23 +238,23 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
         Expect.equal i.AssayCount 1 "assay count"
         Expect.equal i.StudyCount 1 "study count"
         s.RegisterAssay(a.Identifier)
-        Expect.equal s.RegisteredAssayCount 1 "registered assay count"
+        Expect.equal s.RegisteredAssayIdentifierCount 1 "registered assay count"
         Expect.equal s.RegisteredAssayIdentifiers.[0] a.Identifier "identifier"
         i.RemoveAssayAt 0 
         Expect.equal i.AssayCount 0 "assay count 2"
-        Expect.equal s.RegisteredAssayCount 0 "registered assay count 2"
+        Expect.equal s.RegisteredAssayIdentifierCount 0 "registered assay count 2"
     testCase "Remove registered assay from investigation, without removing other missing assays" <| fun _ ->
         let i = ArcInvestigation.init("MyInvestigation")
         let a = i.InitAssay("MyAssay")
         let s = i.InitStudy("MyStudy")
         s.RegisterAssay(a.Identifier)
-        Expect.equal s.RegisteredAssayCount 1 "registered assay count"
+        Expect.equal s.RegisteredAssayIdentifierCount 1 "registered assay count"
         Expect.equal s.RegisteredAssayIdentifiers.[0] a.Identifier "identifier"
         s.RegisteredAssayIdentifiers.Add("Any Assay That is missing")
-        Expect.equal s.RegisteredAssayCount 2 "registered assay count 2"
+        Expect.equal s.RegisteredAssayIdentifierCount 2 "registered assay count 2"
         i.RemoveAssayAt 0
         Expect.equal i.AssayCount 0 "assay count"
-        Expect.equal s.RegisteredAssayCount 1 "registered assay count 3"
+        Expect.equal s.RegisteredAssayIdentifierCount 1 "registered assay count 3"
     testCase "Investigation.DeregisterMissingAssays" <| fun _ ->
         let i = ArcInvestigation.init("MyInvestigation")
         let a = i.InitAssay("MyAssay")
@@ -266,9 +266,9 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
         Expect.equal s.RegisteredAssayIdentifiers.[0] a.Identifier "identifier"
         i.Assays <- (ResizeArray())
         Expect.equal i.AssayCount 0 "assay count 2"
-        Expect.equal s.RegisteredAssayCount 1 "registered assay count 2"
+        Expect.equal s.RegisteredAssayIdentifierCount 1 "registered assay count 2"
         i.DeregisterMissingAssays()
-        Expect.equal s.RegisteredAssayCount 0 "registered assay count 3"
+        Expect.equal s.RegisteredAssayIdentifierCount 0 "registered assay count 3"
 ]
 
 let tests_RegisteredStudies = testList "RegisteredStudies" [

--- a/tests/ISA/ISA.Tests/ArcStudy.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcStudy.Tests.fs
@@ -170,7 +170,7 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
         testCase "RegisterAssay" <| fun _ ->
             let study = createTestStudy()
             study.RegisterAssay(_assay_identifier)
-            Expect.equal study.RegisteredAssayCount 1 "registered assay count"
+            Expect.equal study.RegisteredAssayIdentifierCount 1 "registered assay count"
         testCase "GetRegisteredAssay" <| fun _ ->
             let study = createTestStudy()
             study.RegisterAssay(_assay_identifier)
@@ -184,9 +184,9 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
         testCase "DeregisterAssay" <| fun _ ->
             let study = createTestStudy()
             study.RegisterAssay(_assay_identifier)
-            Expect.equal study.RegisteredAssayCount 1 "registered assay count"
+            Expect.equal study.RegisteredAssayIdentifierCount 1 "registered assay count"
             study.DeregisterAssay(_assay_identifier)
-            Expect.equal study.RegisteredAssayCount 0 "registered assay count 2"
+            Expect.equal study.RegisteredAssayIdentifierCount 0 "registered assay count 2"
         testCase "InitAssay" <| fun _ ->
             let study = createTestStudy()
             let eval() = study.InitRegisteredAssay(_assay_identifier) |> ignore
@@ -206,7 +206,7 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
             study.RegisterAssay(_assay_identifier)
             Expect.equal i.AssayCount 1 "AssayCount"
             Expect.equal i.StudyCount 1 "StudyCount"
-            Expect.equal study.RegisteredAssayCount 1 "registered assay count"
+            Expect.equal study.RegisteredAssayIdentifierCount 1 "registered assay count"
         testCase "GetRegisteredAssay" <| fun _ ->
             let i = ArcInvestigation.init("MyInvestigation")
             let assay = createTestAssay()
@@ -233,7 +233,7 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
             i.AddAssay(assay)
             study.RegisterAssay(_assay_identifier)
             study.DeregisterAssay(_assay_identifier)
-            Expect.equal study.RegisteredAssayCount 0 "registered assay count 2"
+            Expect.equal study.RegisteredAssayIdentifierCount 0 "registered assay count 2"
             Expect.equal i.AssayCount 1 "AssayCount, only deregister from study, not remove"
             Expect.equal i.StudyCount 1 "StudyCount"
         testCase "InitAssay" <| fun _ ->
@@ -243,7 +243,7 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
             let assay = study.InitRegisteredAssay(_assay_identifier)
             Expect.equal i.AssayCount 1 "AssayCount"
             Expect.equal i.StudyCount 1 "StudyCount"
-            Expect.equal study.RegisteredAssayCount 1 "registered assay count"
+            Expect.equal study.RegisteredAssayIdentifierCount 1 "registered assay count"
             Expect.equal i.Assays.[0] assay "equal"
         testCase "AddAssay" <| fun _ ->
             let i = ArcInvestigation.init("MyInvestigation")
@@ -253,7 +253,7 @@ let tests_RegisteredAssays = testList "RegisteredAssays" [
             study.AddRegisteredAssay(assay)
             Expect.equal i.AssayCount 1 "AssayCount"
             Expect.equal i.StudyCount 1 "StudyCount"
-            Expect.equal study.RegisteredAssayCount 1 "registered assay count"
+            Expect.equal study.RegisteredAssayIdentifierCount 1 "registered assay count"
             Expect.equal i.Assays.[0] assay "equal"
         testCase "Check mutability" <| fun _ ->
             let i = ArcInvestigation.init("MyInvestigation")
@@ -283,7 +283,7 @@ let tests_copy =
             let study = createTestStudy()
             Expect.equal study.Identifier _study_identifier "_study_identifier"
             Expect.equal study.Description _study_description "_study_description"
-            Expect.equal study.RegisteredAssayCount 1 "AssayCount"
+            Expect.equal study.RegisteredAssayIdentifierCount 1 "AssayCount"
             let assayIdentifier = study.RegisteredAssayIdentifiers.[0]
             Expect.equal assayIdentifier _assay_identifier "_assay_identifier"
         testCase "test mutable fields" <| fun _ -> 
@@ -297,14 +297,14 @@ let tests_copy =
                 Expect.equal study.Identifier _study_identifier "_study_identifier"
                 Expect.equal study.Description _study_description "_study_description"
                 Expect.equal study.PublicReleaseDate None "PublicReleaseDate"
-                Expect.equal study.RegisteredAssayCount 1 "AssayCount"
+                Expect.equal study.RegisteredAssayIdentifierCount 1 "AssayCount"
                 let assayIdentifier = study.RegisteredAssayIdentifiers.[0]
                 Expect.equal assayIdentifier _assay_identifier "_assay_identifier"
             let checkCopy =
                 Expect.equal copy.Identifier _study_identifier "copy _study_identifier"
                 Expect.equal copy.Description newDesciption "copy _study_description"
                 Expect.equal copy.PublicReleaseDate newPublicReleaseDate "copy PublicReleaseDate"
-                Expect.equal copy.RegisteredAssayCount 1 "copy AssayCount"
+                Expect.equal copy.RegisteredAssayIdentifierCount 1 "copy AssayCount"
                 let assayIdentifier = study.RegisteredAssayIdentifiers.[0]
                 Expect.equal assayIdentifier _assay_identifier "copy _assay_identifier"
             ()

--- a/tests/ISA/ISA.Tests/DataModel.Tests.fs
+++ b/tests/ISA/ISA.Tests/DataModel.Tests.fs
@@ -2,7 +2,73 @@
 
 open TestingUtils
 open ARCtrl.ISA
+open ARCtrl.ISA.Aux
 
+/// Tests to test whether the accessors, that handel different cases of registration work properly
+let registrationAccessTests = 
+    testList "RegistrationAccessTests" [
+        let studyOnlyRegistered = "StudyOnlyRegistered"
+        let studyOnlyExisting = "StudyOnlyExisting"
+        let studyRegisteredAndExisting = "StudyRegisteredAndExisting"
+
+        let assayOnlyRegistered = "AssayOnlyRegistered"
+        let assayOnlyExisting = "AssayOnlyExisting"
+        let assayRegisteredAndExisting = "AssayRegisteredAndExisting"
+
+        
+        let i = ArcInvestigation("MyInvestigation", registeredStudyIdentifiers = ResizeArray [studyOnlyRegistered])
+
+        let s = ArcStudy(studyRegisteredAndExisting, registeredAssayIdentifiers = ResizeArray [assayOnlyRegistered])
+
+        i.AddRegisteredStudy(s)
+        i.AddStudy(ArcStudy(studyOnlyExisting))
+
+        s.AddRegisteredAssay(ArcAssay(assayRegisteredAndExisting))
+        i.AddAssay(ArcAssay(assayOnlyExisting))
+
+        testCase "RegisteredStudyIdentifiers" (fun () ->
+            let actual = i.RegisteredStudyIdentifiers
+            let expected = ResizeArray [studyOnlyRegistered; studyRegisteredAndExisting]
+            Expect.sequenceEqual actual expected "Study identifiers were not correctly retrieved"
+        )
+        testCase "RegisteredStudies" (fun () -> 
+            let actual = i.RegisteredStudies |> ResizeArray.map (fun s -> s.Identifier)
+            let expected = ResizeArray [studyRegisteredAndExisting]
+            Expect.sequenceEqual actual expected "Registered studies were not correctly retrieved"
+        )
+        testCase "VacantStudyIdentifers" (fun () -> 
+            let actual = i.VacantStudyIdentifiers
+            let expected = ResizeArray [studyOnlyRegistered]
+            Expect.sequenceEqual actual expected "Vacant study identifiers were not correctly retrieved"
+        )
+        testCase "UnregisteredStudies" (fun () -> 
+            let actual = i.UnregisteredStudies |> ResizeArray.map (fun s -> s.Identifier)
+            let expected = ResizeArray [studyOnlyExisting]
+            Expect.sequenceEqual actual expected "Unregistered studies were not correctly retrieved"
+        )
+        testCase "RegisteredAssayIdentifiers" (fun  () ->
+            let actual = s.RegisteredAssayIdentifiers
+            let expected = ResizeArray [assayOnlyRegistered; assayRegisteredAndExisting]
+            Expect.sequenceEqual actual expected "Assay identifiers were not correctly retrieved"
+        )   
+        testCase "RegisteredAssays" (fun () -> 
+            let actual = s.RegisteredAssays |> ResizeArray.map (fun s -> s.Identifier)
+            let expected = ResizeArray [assayRegisteredAndExisting]
+            Expect.sequenceEqual actual expected "Registered assays were not correctly retrieved"
+        )
+        testCase "VacantAssayIdentifers" (fun () -> 
+            let actual = s.VacantAssayIdentifiers
+            let expected = ResizeArray [assayOnlyRegistered]
+            Expect.sequenceEqual actual expected "Vacant assay identifiers were not correctly retrieved"
+        )
+        testCase "UnregisteredAssays" (fun () -> 
+            let actual = i.UnregisteredAssays |> ResizeArray.map (fun s -> s.Identifier)
+            let expected = ResizeArray [assayOnlyExisting]
+            Expect.sequenceEqual actual expected "Unregistered assays were not correctly retrieved"
+        )
+
+
+    ]
 
 let componentCastingTests =
 


### PR DESCRIPTION
New Keywords: 
 - `Vacant` = RegisteredButNotExisting
 - `Unregistered` = ExistingButNotRegistered

Changes:
- `RegisteredXCount` now only returns the count of those `X` that are registered AND existing, like `RegisteredXs`. 
- `RegisteredXIdentifierCount` returns that what `RegisteredXCount` used to return

Tests