### PR TITLE
Several performance increases

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+### 1.0.6+c6d86b1 (Released 2024-1-26)
+* Additions:
+    * [[#c6d86b1](https://github.com/nfdi4plants/ARCtrl/commit/c6d86b104392447cc980bf3e16fa64bfb27ca5c6)] small performance improvement for reading ARCs
+    * [[#3f8c788](https://github.com/nfdi4plants/ARCtrl/commit/3f8c7883f6fc40f1be910afe20b19f0b3d0fad1d)] add case for speedtest project
+    * [[#a90a1f1](https://github.com/nfdi4plants/ARCtrl/commit/a90a1f1e135497e7613975c84ae1271849a6944f)] improve and test speed of investigation file writer
+    * [[#123f209](https://github.com/nfdi4plants/ARCtrl/commit/123f209fda76be179fd18cb96eab5871e764f38a)] Merge pull request #299 from nfdi4plants/small_cleanup
+    * [[#70d3c85](https://github.com/nfdi4plants/ARCtrl/commit/70d3c856c3aa45135b0ef1463f399437fefb8a4c)] Merge pull request #297 from nfdi4plants/table_join_296
+    * [[#13428ca](https://github.com/nfdi4plants/ARCtrl/commit/13428ca85f366eb13ba02b8557bec52bc643bab8)] Revert unintended change in default!
+    * [[#66b15f6](https://github.com/nfdi4plants/ARCtrl/commit/66b15f67214f10ee3cfbb97cca0ccf738c8ffb6c)] Update to v1.0.5
+* Deletions:
+    * [[#d121e5c](https://github.com/nfdi4plants/ARCtrl/commit/d121e5ccddf2715958069283e272369fc731b6a2)] remove playground and move speedtest folders
+
 ### 1.0.5+b21e3bc (Released 2024-1-17)
 * Additions:
     * [[#b21e3bc](https://github.com/nfdi4plants/ARCtrl/commit/b21e3bcb0a5679b5ec5494555d9e9d23822bdc9a)] Extend ArcTable.Join :sparkles::white_check_mark:

--- a/build/release_package.json
+++ b/build/release_package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nfdi4plants/arctrl",
-  "version": "1.0.5+b21e3bc",
+  "version": "1.0.6+c6d86b1",
   "description": "Top level ARC DataModel and API function descriptions.",
   "type": "module",
   "main": "index.js",

--- a/src/ISA/ISA.Spreadsheet/ARCtrl.ISA.Spreadsheet.fsproj
+++ b/src/ISA/ISA.Spreadsheet/ARCtrl.ISA.Spreadsheet.fsproj
@@ -29,7 +29,7 @@
     <None Include="../../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FsSpreadsheet" Version="5.0.1" />
+    <PackageReference Include="FsSpreadsheet" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ISA\ARCtrl.ISA.fsproj" />

--- a/src/ISA/ISA.Spreadsheet/ARCtrl.ISA.Spreadsheet.fsproj
+++ b/src/ISA/ISA.Spreadsheet/ARCtrl.ISA.Spreadsheet.fsproj
@@ -29,7 +29,7 @@
     <None Include="../../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FsSpreadsheet" Version="5.1.0" />
+    <PackageReference Include="FsSpreadsheet" Version="5.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ISA\ARCtrl.ISA.fsproj" />

--- a/src/ISA/ISA.Spreadsheet/Metadata/SparseTable.fs
+++ b/src/ISA/ISA.Spreadsheet/Metadata/SparseTable.fs
@@ -48,8 +48,8 @@ module SparseRow =
         let rows = sheet.Rows |> Seq.map fromFsRow
         rows
 
-    let writeToSheet (rowI : int) (row : SparseRow) (sheet : FsWorksheet) =
-        let fsRow = sheet.Row(rowI)
+    let writeToSheet (rowI : int) (row : SparseRow) (sheet : FsWorksheet) =   
+        let fsRow = sheet.RowWithRange(FsRangeAddress(FsAddress(rowI,1),FsAddress(rowI,1)),true)
         row
         |> Seq.iter (fun (colI,v) -> 
             if v.Trim() <> "" then fsRow.[colI + 1].SetValueAs v)

--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -696,7 +696,8 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
                 let headers  = table.Headers |> ResizeArray
                 let rows = 
                     indexGroup
-                    |> Array.map (fun i -> table.GetRow(i))
+                    // Max row index is the last row index of the table, so no validation needed
+                    |> Array.map (fun i -> table.GetRow(i,SkipValidation = true))
                 ArcTable.createFromRows(table.Name,headers,rows)
             )
             

--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -433,11 +433,7 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
                 let column = CompositeColumn.create(h,[|row.[columnIndex]|])
                 SanityChecks.validateColumn column
         // Sanity checks - end
-        rows
-        |> Array.iter (fun row ->
-            Unchecked.addRow index row this.Headers this.Values
-            index <- index + 1
-        )
+        Unchecked.addRows index rows this.Headers this.Values
 
     static member addRows (rows: CompositeCell [] [], ?index: int) =
         fun (table:ArcTable) ->

--- a/src/ISA/ISA/ArcTypes/ArcTableAux.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTableAux.fs
@@ -115,8 +115,13 @@ module Unchecked =
     let tryGetCellAt (column: int,row: int) (cells:System.Collections.Generic.Dictionary<int*int,CompositeCell>) = 
         Dictionary.tryFind (column, row) cells
 
+    /// Add or update a cell in the dictionary.
     let setCellAt(columnIndex, rowIndex,c : CompositeCell) (cells:Dictionary<int*int,CompositeCell>) = 
         cells.[(columnIndex,rowIndex)] <- c
+
+    /// Add a cell to the dictionary. If a cell already exists at the given position, it fails.
+    let addCellAt(columnIndex, rowIndex,c : CompositeCell) (cells:Dictionary<int*int,CompositeCell>) = 
+        cells.Add((columnIndex,rowIndex),c)
 
     let moveCellTo (fromCol:int,fromRow:int,toCol:int,toRow:int) (cells:Dictionary<int*int,CompositeCell>) =
         match Dictionary.tryFind (fromCol, fromRow) cells with
@@ -285,12 +290,12 @@ module Unchecked =
                 let rowKeys = Array.map snd col |> Set.ofArray
                 for rowIndex = 0 to rowCount - 1 do
                     if not <| rowKeys.Contains rowIndex then
-                        setCellAt (columnIndex,rowIndex,defaultCell) values
+                        addCellAt (columnIndex,rowIndex,defaultCell) values
             // No values existed in this column. Fill with default cells
             | None ->
                 let defaultCell = getEmptyCellForHeader header None
                 for rowIndex = 0 to rowCount - 1 do
-                    setCellAt (columnIndex,rowIndex,defaultCell) values
+                    addCellAt (columnIndex,rowIndex,defaultCell) values
 
 
     /// Increases the table size to the given new row count and fills the new rows with the last value of the column

--- a/src/ISA/ISA/ArcTypes/ArcTableAux.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTableAux.fs
@@ -6,17 +6,7 @@ open Fable.Core
 
 // Taken from FSharpAux.Core
 /// .Net Dictionary
-module Dictionary = 
-    
-    /// <summary>Returns the dictionary with the binding added to the given dictionary.
-    /// If a binding with the given key already exists in the input dictionary, the existing binding is replaced by the new binding in the result dictionary.</summary>
-    /// <param name="key">The input key.</param>
-    /// <returns>The dictionary with change in place.</returns>
-    let addOrUpdateInPlace key value (table:IDictionary<_,_>) =
-        match table.ContainsKey(key) with
-        | true  -> table.[key] <- value
-        | false -> table.Add(key,value)
-        table
+module Dictionary =    
 
     /// <summary>Lookup an element in the dictionary, returning a <c>Some</c> value if the element is in the domain 
     /// of the dictionary and <c>None</c> if not.</summary>
@@ -122,8 +112,12 @@ module SanityChecks =
 
 module Unchecked =
         
-    let tryGetCellAt (column: int,row: int) (cells:System.Collections.Generic.Dictionary<int*int,CompositeCell>) = Dictionary.tryFind (column, row) cells
-    let setCellAt(columnIndex, rowIndex,c : CompositeCell) (cells:Dictionary<int*int,CompositeCell>) = Dictionary.addOrUpdateInPlace (columnIndex,rowIndex) c cells |> ignore
+    let tryGetCellAt (column: int,row: int) (cells:System.Collections.Generic.Dictionary<int*int,CompositeCell>) = 
+        Dictionary.tryFind (column, row) cells
+
+    let setCellAt(columnIndex, rowIndex,c : CompositeCell) (cells:Dictionary<int*int,CompositeCell>) = 
+        cells.[(columnIndex,rowIndex)] <- c
+
     let moveCellTo (fromCol:int,fromRow:int,toCol:int,toRow:int) (cells:Dictionary<int*int,CompositeCell>) =
         match Dictionary.tryFind (fromCol, fromRow) cells with
         | Some c ->

--- a/src/ISA/ISA/ArcTypes/ArcTableAux.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTableAux.fs
@@ -328,6 +328,28 @@ module Unchecked =
             )
         ()
 
+    let addRows (index:int) (newRows:CompositeCell [][]) (headers: ResizeArray<CompositeHeader>) (values:Dictionary<int*int,CompositeCell>) =
+        /// Store start rowCount here, so it does not get changed midway through
+        let rowCount = getRowCount values
+        let columnCount = getColumnCount headers
+        let increaseRowIndices =  
+            // Only do this if column is inserted and not appended!
+            if index < rowCount then
+                /// Get last row index
+                let lastRowIndex = System.Math.Max(rowCount - 1, 0) // If there are no rows. We get negative last column index. In this case just return 0.
+                // start with last row index and go down to `index`
+                for rowIndex = lastRowIndex downto index do
+                    for columnIndex in 0 .. (columnCount-1) do
+                        moveCellTo(columnIndex,rowIndex,columnIndex,rowIndex+1) values
+        let mutable currentRowIndex = index
+        for row in newRows do
+            /// Then we can set the new row at `index`
+            let setNewCells =
+                row |> Array.iteri (fun columnIndex cell ->
+                    setCellAt (columnIndex,currentRowIndex,cell) values
+                )
+            currentRowIndex <- currentRowIndex + 1
+
 /// Functions for transforming base level ARC Table and ISA Json Objects
 module JsonTypes = 
 

--- a/src/ISA/ISA/ArcTypes/ArcTableAux.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTableAux.fs
@@ -332,6 +332,7 @@ module Unchecked =
         /// Store start rowCount here, so it does not get changed midway through
         let rowCount = getRowCount values
         let columnCount = getColumnCount headers
+        let numNewRows = newRows.Length
         let increaseRowIndices =  
             // Only do this if column is inserted and not appended!
             if index < rowCount then
@@ -340,7 +341,7 @@ module Unchecked =
                 // start with last row index and go down to `index`
                 for rowIndex = lastRowIndex downto index do
                     for columnIndex in 0 .. (columnCount-1) do
-                        moveCellTo(columnIndex,rowIndex,columnIndex,rowIndex+1) values
+                        moveCellTo(columnIndex,rowIndex,columnIndex,rowIndex+numNewRows) values
         let mutable currentRowIndex = index
         for row in newRows do
             /// Then we can set the new row at `index`

--- a/tests/ISA/ISA.Spreadsheet.Tests/Performance.Tests.fs
+++ b/tests/ISA/ISA.Spreadsheet.Tests/Performance.Tests.fs
@@ -25,15 +25,9 @@ let private tests_Investigation = testList "Investigation" [
         for i = 0 to 1500 do 
             let s = ArcStudy.init($"Study{i}")
             inv.AddRegisteredStudy(s)
-        let timer = Stopwatch()
-        timer.Start()
-        let wb = ArcInvestigation.toFsWorkbook inv
-        timer.Stop()
-        let runtime = timer.Elapsed.Milliseconds
-        let expected = 1000 // this is too high and should be reduced
-
+        let testF = fun () -> ArcInvestigation.toFsWorkbook inv
+        let wb = Expect.wantFaster testF 1000 "Parsing investigation to Workbook is too slow"    
         Expect.equal (wb.GetWorksheets().Count) 1 "Worksheet count"
-        Expect.isTrue (runtime <= expected) $"Expected conversion to be finished in under {expected}, but it took {runtime}"
 ]
 
 let Main = testList "Performance" [

--- a/tests/ISA/ISA.Spreadsheet.Tests/Performance.Tests.fs
+++ b/tests/ISA/ISA.Spreadsheet.Tests/Performance.Tests.fs
@@ -19,6 +19,24 @@ let private tests_Study = testList "Study" [
         convertToArcFile fswb
 ]
 
+let private tests_Investigation = testList "Investigation" [
+    testCase "WriteManyStudies" <| fun _ ->
+        let inv = ArcInvestigation.init("MyInvestigation")
+        for i = 0 to 1500 do 
+            let s = ArcStudy.init($"Study{i}")
+            inv.AddRegisteredStudy(s)
+        let timer = Stopwatch()
+        timer.Start()
+        let wb = ArcInvestigation.toFsWorkbook inv
+        timer.Stop()
+        let runtime = timer.Elapsed.Milliseconds
+        let expected = 1000 // this is too high and should be reduced
+
+        Expect.equal (wb.GetWorksheets().Count) 1 "Worksheet count"
+        Expect.isTrue (runtime <= expected) $"Expected conversion to be finished in under {expected}, but it took {runtime}"
+]
+
 let Main = testList "Performance" [
     tests_Study
+    tests_Investigation
 ]

--- a/tests/ISA/ISA.Tests/ArcTable.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcTable.Tests.fs
@@ -1993,13 +1993,8 @@ let private tests_AddRows =
             let rows = 
                  Array.init 10000 (fun i -> 
                     [|CompositeCell.FreeText $"Source_{i}"; CompositeCell.FreeText $"FT1_{i}"; CompositeCell.FreeText $"FT2_{i}"; CompositeCell.FreeText $"Sample_{i}"; |])
-            let stopwatch = Stopwatch()
-            stopwatch.Start()
-            table.AddRows(rows)
-            stopwatch.Stop()
-            let expectedTime = 100
-            let elapsed = stopwatch.Elapsed.Milliseconds
-            Expect.isTrue (elapsed < expectedTime) $"Elapsed time should be less than {expectedTime}ms, but was {elapsed}ms"       
+            let testF = fun () -> table.AddRows(rows)
+            Expect.wantFaster testF 100 $"AddRows is too slow." |> ignore     
         )
     ]
 
@@ -2299,14 +2294,8 @@ let private tests_fillMissing = testList "fillMissing" [
                 ArcTableAux.Unchecked.setCellAt(4,i,(CompositeCell.FreeText $"FT4_{i}")) values
                 ArcTableAux.Unchecked.setCellAt(5,i,(CompositeCell.FreeText $"FT5_{i}")) values
                 ArcTableAux.Unchecked.setCellAt(6,i,(CompositeCell.FreeText $"Sample_{i}")) values
-        let stopwatch = Stopwatch()
-        stopwatch.Start()
-        ArcTableAux.Unchecked.fillMissingCells headers values
-        stopwatch.Stop()
-        let expectedTime = 200 // 80ms in dotnet, 150ms in javascript
-        let elapsed = stopwatch.Elapsed.Milliseconds
-        Expect.isTrue (elapsed < expectedTime) $"Elapsed time should be less than {expectedTime}ms, but was {elapsed}ms"
-
+        let testF = fun () -> ArcTableAux.Unchecked.fillMissingCells headers values   
+        Expect.wantFaster testF 200 "fillMissing is too slow." |> ignore
     ]
 
 

--- a/tests/ISA/ISA.Tests/ArcTable.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcTable.Tests.fs
@@ -2280,6 +2280,36 @@ let private tests_equality = testList "equality" [
     ]
 ]
 
+
+let private tests_fillMissing = testList "fillMissing" [
+    testCase "performance" <| fun _ ->
+        
+        let headers = ResizeArray [CompositeHeader.Input IOType.Sample;CompositeHeader.FreeText "Freetext1" ; CompositeHeader.FreeText "Freetext2"; CompositeHeader.Output IOType.Sample]
+        let values = System.Collections.Generic.Dictionary()
+        for i = 0 to 20000 do       
+            if i%2 = 0 then
+                ArcTableAux.Unchecked.setCellAt(0,i,(CompositeCell.FreeText $"Source_{i}")) values
+                ArcTableAux.Unchecked.setCellAt(1,i,(CompositeCell.FreeText $"FT1_{i}")) values
+                ArcTableAux.Unchecked.setCellAt(2,i,(CompositeCell.FreeText $"FT2_{i}")) values
+                ArcTableAux.Unchecked.setCellAt(3,i,(CompositeCell.FreeText $"FT3_{i}")) values
+                ArcTableAux.Unchecked.setCellAt(6,i,(CompositeCell.FreeText $"Sample_{i}")) values
+            else
+                ArcTableAux.Unchecked.setCellAt(0,i,(CompositeCell.FreeText $"Source_{i}")) values
+                ArcTableAux.Unchecked.setCellAt(3,i,(CompositeCell.FreeText $"FT3_{i}")) values
+                ArcTableAux.Unchecked.setCellAt(4,i,(CompositeCell.FreeText $"FT4_{i}")) values
+                ArcTableAux.Unchecked.setCellAt(5,i,(CompositeCell.FreeText $"FT5_{i}")) values
+                ArcTableAux.Unchecked.setCellAt(6,i,(CompositeCell.FreeText $"Sample_{i}")) values
+        let stopwatch = Stopwatch()
+        stopwatch.Start()
+        ArcTableAux.Unchecked.fillMissingCells headers values
+        stopwatch.Stop()
+        let expectedTime = 200 // 80ms in dotnet, 150ms in javascript
+        let elapsed = stopwatch.Elapsed.Milliseconds
+        Expect.isTrue (elapsed < expectedTime) $"Elapsed time should be less than {expectedTime}ms, but was {elapsed}ms"
+
+    ]
+
+
 let main = 
     testList "ArcTable" [
         tests_SanityChecks
@@ -2303,4 +2333,5 @@ let main =
         tests_IterColumns
         tests_GetHashCode
         tests_equality
+        tests_fillMissing
     ]

--- a/tests/ISA/ISA.Tests/ArcTable.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcTable.Tests.fs
@@ -1988,6 +1988,19 @@ let private tests_AddRows =
                     else
                         Expect.equal table.Values.[columnIndex, rowIndex] newTable.Values.[columnIndex, rowIndex-newColumnCount] $"Cell {columnIndex},{rowIndex}"
         )
+        testCase "performance" (fun () ->
+            let table = ArcTable("MyTable",ResizeArray [CompositeHeader.Input IOType.Sample;CompositeHeader.FreeText "Freetext1" ; CompositeHeader.FreeText "Freetext2"; CompositeHeader.Output IOType.Sample], System.Collections.Generic.Dictionary())
+            let rows = 
+                 Array.init 10000 (fun i -> 
+                    [|CompositeCell.FreeText $"Source_{i}"; CompositeCell.FreeText $"FT1_{i}"; CompositeCell.FreeText $"FT2_{i}"; CompositeCell.FreeText $"Sample_{i}"; |])
+            let stopwatch = Stopwatch()
+            stopwatch.Start()
+            table.AddRows(rows)
+            stopwatch.Stop()
+            let expectedTime = 100
+            let elapsed = stopwatch.Elapsed.Milliseconds
+            Expect.isTrue (elapsed < expectedTime) $"Elapsed time should be less than {expectedTime}ms, but was {elapsed}ms"       
+        )
     ]
 
 let private tests_UpdateRefWithSheet =

--- a/tests/ISA/ISA.Tests/ArcTable.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcTable.Tests.fs
@@ -471,6 +471,29 @@ let private tests_UpdateCell =
             let eval() = table.UpdateCellAt(0,0,cell)
             Expect.throws eval ""
         )
+
+        // Commented this test out, as the behaviour is different in dotnet and js, but both implementations are very close together performance-wise
+
+        //testCase "performance" (fun () ->
+        //    // Test, that for most cases (because of performance), setter should be used
+        //    let f1 = fun () ->
+        //        let table = ArcTable.init("Table")
+        //        for i = 0 to 10 do
+        //            table.Headers.Insert(i,CompositeHeader.FreeText $"Header_{i}")
+        //            for j = 0 to 5000 do
+        //                ArcTableAux.Unchecked.setCellAt(i,j,CompositeCell.createFreeText $"Cell_{i}_{j}") table.Values
+        //    let f2 = fun () ->
+        //        let table = ArcTable.init("Table")
+        //        for i = 0 to 10 do
+        //            table.Headers.Insert(i,CompositeHeader.FreeText $"Header_{i}")
+        //            for j = 0 to 5000 do
+        //                ArcTableAux.Unchecked.addCellAt(i,j,CompositeCell.createFreeText $"Cell_{i}_{j}") table.Values
+        //    Expect.isFasterThan f1 f2 "SetCell Implementation should be faster than reference"
+        
+        
+        
+        //)
+
     ]
 
 let private tests_UpdateColumn = 
@@ -2295,7 +2318,7 @@ let private tests_fillMissing = testList "fillMissing" [
                 ArcTableAux.Unchecked.setCellAt(5,i,(CompositeCell.FreeText $"FT5_{i}")) values
                 ArcTableAux.Unchecked.setCellAt(6,i,(CompositeCell.FreeText $"Sample_{i}")) values
         let testF = fun () -> ArcTableAux.Unchecked.fillMissingCells headers values   
-        Expect.wantFaster testF 200 "fillMissing is too slow." |> ignore
+        Expect.wantFaster testF 220 "fillMissing is too slow." |> ignore // 130ms in javascript, dotnet faster than 100ms
     ]
 
 

--- a/tests/ISA/ISA.Tests/Library.fs
+++ b/tests/ISA/ISA.Tests/Library.fs
@@ -132,3 +132,20 @@ module Test =
 
 
     let testList = testList
+
+open System
+open Fable.Core
+
+[<AttachMembers>]
+type Stopwatch() =
+    member val StartTime: DateTime option = None with get, set
+    member val StopTime: DateTime option = None with get, set
+    member this.Start() = this.StartTime <- Some DateTime.Now
+    member this.Stop() = 
+        match this.StartTime with
+        | Some _ -> this.StopTime <- Some DateTime.Now
+        | None -> failwith "Error. Unable to call `Stop` before `Start`."
+    member this.Elapsed : TimeSpan = 
+        match this.StartTime, this.StopTime with
+        | Some start, Some stop -> stop - start
+        | _, _ -> failwith "Error. Unable to call `Elapsed` without calling `Start` and `Stop` before."

--- a/tests/ISA/ISA.Tests/Library.fs
+++ b/tests/ISA/ISA.Tests/Library.fs
@@ -48,6 +48,23 @@ module Result =
         | Ok m -> m
         | Error m -> m
 
+open System
+open Fable.Core
+
+[<AttachMembers>]
+type Stopwatch() =
+    member val StartTime: DateTime option = None with get, set
+    member val StopTime: DateTime option = None with get, set
+    member this.Start() = this.StartTime <- Some DateTime.Now
+    member this.Stop() = 
+        match this.StartTime with
+        | Some _ -> this.StopTime <- Some DateTime.Now
+        | None -> failwith "Error. Unable to call `Stop` before `Start`."
+    member this.Elapsed : TimeSpan = 
+        match this.StartTime, this.StopTime with
+        | Some start, Some stop -> stop - start
+        | _, _ -> failwith "Error. Unable to call `Elapsed` without calling `Start` and `Stop` before."
+
 /// Fable compatible Expecto/Mocha/Pyxpecto unification
 module Expect = 
     open Utils
@@ -78,6 +95,30 @@ module Expect =
 
     let exists actual asserter message = Expect.exists actual asserter message 
     let containsAll actual expected message = Expect.containsAll actual expected message
+
+    let wantFaster (f : unit -> 'T) (maxMilliseconds : int) (message : string) = 
+        let stopwatch = Stopwatch()
+        stopwatch.Start()
+        let res = f()
+        stopwatch.Stop()
+        let elapsed = stopwatch.Elapsed
+        if elapsed.TotalMilliseconds > float maxMilliseconds then
+            failwithf $"{message}. Expected to be faster than {maxMilliseconds}ms, but took {elapsed.TotalMilliseconds}ms"
+        res
+
+    let isFasterThan (f1 : unit -> _) (f2 : unit -> _) (message : string) =
+        let stopwatch = Stopwatch()
+        stopwatch.Start()
+        f1()
+        stopwatch.Stop()
+        let elapsed1 = stopwatch.Elapsed
+        stopwatch.Start()
+        f2()
+        stopwatch.Stop()
+        let elapsed2 = stopwatch.Elapsed
+        if elapsed1.TotalMilliseconds > elapsed2.TotalMilliseconds then
+            failwithf $"{message}. Expected {elapsed1.TotalMilliseconds}ms to be faster than {elapsed2.TotalMilliseconds}ms"
+        ()
 
     /// Expects the `actual` sequence to equal the `expected` one.
     let sequenceEqual actual expected message =
@@ -133,19 +174,4 @@ module Test =
 
     let testList = testList
 
-open System
-open Fable.Core
 
-[<AttachMembers>]
-type Stopwatch() =
-    member val StartTime: DateTime option = None with get, set
-    member val StopTime: DateTime option = None with get, set
-    member this.Start() = this.StartTime <- Some DateTime.Now
-    member this.Stop() = 
-        match this.StartTime with
-        | Some _ -> this.StopTime <- Some DateTime.Now
-        | None -> failwith "Error. Unable to call `Stop` before `Start`."
-    member this.Elapsed : TimeSpan = 
-        match this.StartTime, this.StopTime with
-        | Some start, Some stop -> stop - start
-        | _, _ -> failwith "Error. Unable to call `Elapsed` without calling `Start` and `Stop` before."

--- a/tests/Speedtest/AddRows.fs
+++ b/tests/Speedtest/AddRows.fs
@@ -1,0 +1,39 @@
+﻿module AddRows
+
+open ARCtrl.ISA
+open ArcTableAux
+
+
+let addRowsOld (this:ArcTable) (rows:CompositeCell [] []) (index:int option) = 
+
+    let mutable index = defaultArg index this.RowCount
+    // Sanity checks
+    SanityChecks.validateRowIndex index this.RowCount true
+    rows |> Array.iter (fun row -> SanityChecks.validateRowLength row this.ColumnCount)
+    for row in rows do
+        for columnIndex in 0 .. this.ColumnCount-1 do
+            let h = this.Headers.[columnIndex]
+            let column = CompositeColumn.create(h,[|row.[columnIndex]|])
+            SanityChecks.validateColumn column
+    rows
+        |> Array.iter (fun row ->
+            Unchecked.addRow index row this.Headers this.Values
+            index <- index + 1
+        )
+
+
+let table() = ArcTable("MyTable",ResizeArray [CompositeHeader.Input IOType.Sample;CompositeHeader.FreeText "Freetext1" ; CompositeHeader.FreeText "Freetext2"; CompositeHeader.Output IOType.Sample], System.Collections.Generic.Dictionary())
+let rows = 
+        Array.init 10000 (fun i -> 
+        [|CompositeCell.FreeText $"Source_{i}"; CompositeCell.FreeText $"FT1_{i}"; CompositeCell.FreeText $"FT2_{i}"; CompositeCell.FreeText $"Sample_{i}"; |])
+   
+let prepareTables() =
+    let t1 = table()
+    let t2 = table()
+    t1,t2
+
+let oldF (t) =
+    addRowsOld t rows None
+let newF (t:ArcTable) = 
+    t.AddRows(rows)
+

--- a/tests/Speedtest/FillMissing.fs
+++ b/tests/Speedtest/FillMissing.fs
@@ -1,0 +1,64 @@
+﻿module FillMissing
+
+open ARCtrl.ISA
+open ArcTableAux
+
+open System.Collections.Generic
+
+let fillMissingOld (headers: ResizeArray<CompositeHeader>) (values:Dictionary<int*int,CompositeCell>) = 
+    let rowCount = getRowCount values
+    let columnCount = getColumnCount headers
+    let maxRows = rowCount
+    let lastColumnIndex = columnCount - 1
+    /// Get all keys, to map over relevant rows afterwards
+    let keys = values.Keys
+    // iterate over columns
+    for columnIndex in 0 .. lastColumnIndex do
+        /// Only get keys for the relevant column
+        let colKeys = keys |> Seq.filter (fun (c,_) -> c = columnIndex) |> Set.ofSeq 
+        /// Create set of expected keys
+        let expectedKeys = Seq.init maxRows (fun i -> columnIndex,i) |> Set.ofSeq 
+        /// Get the missing keys
+        let missingKeys = Set.difference expectedKeys colKeys 
+        // if no missing keys, we are done and skip the rest, if not empty missing keys we ...
+        if missingKeys.IsEmpty |> not then
+            /// .. first check which empty filler `CompositeCells` we need. 
+            ///
+            /// We use header to decide between CompositeCell.Term/CompositeCell.Unitized and CompositeCell.FreeText
+            let relatedHeader = headers.[columnIndex]
+            /// We use the first cell in the column to decide between CompositeCell.Term and CompositeCell.Unitized
+            ///
+            /// Not sure if we can add a better logic to infer if empty cells should be term or unitized ~Kevin F
+            let tryExistingCell = if colKeys.IsEmpty then None else Some values.[colKeys.MinimumElement]
+            let empty = Unchecked.getEmptyCellForHeader relatedHeader tryExistingCell
+            for missingColumn,missingRow in missingKeys do
+                Unchecked.setCellAt (missingColumn,missingRow,empty) values
+
+
+let table() = 
+
+    let name = "MyTable"
+    let headers = ResizeArray [CompositeHeader.Input IOType.Sample;CompositeHeader.FreeText "Freetext1" ; CompositeHeader.FreeText "Freetext2"; CompositeHeader.Output IOType.Sample]
+    let values = System.Collections.Generic.Dictionary()
+    for i = 0 to 10000 do       
+        if i%2 = 0 then
+            Unchecked.setCellAt(0,i,(CompositeCell.FreeText $"Source_{i}")) values
+            Unchecked.setCellAt(2,i,(CompositeCell.FreeText $"FT2_{i}")) values
+        else
+            
+            Unchecked.setCellAt(1,i,(CompositeCell.FreeText $"FT1_{i}")) values
+            Unchecked.setCellAt(3,i,(CompositeCell.FreeText $"Sample_{i}")) values
+
+    ArcTable(name, headers, values)
+    
+let prepareTables() =
+    let t1 = table()
+    let t2 = table()
+    t1,t2
+
+let oldF (t:ArcTable) =
+    fillMissingOld t.Headers t.Values
+
+let newF (t:ArcTable) = 
+    Unchecked.fillMissingCells t.Headers t.Values
+

--- a/tests/Speedtest/FillMissing.fs
+++ b/tests/Speedtest/FillMissing.fs
@@ -5,6 +5,67 @@ open ArcTableAux
 
 open System.Collections.Generic
 
+
+// We need to calculate the max number of rows between the new columns and the existing columns in the table.
+// `maxRows` will be the number of rows all columns must have after adding the new columns.
+// This behaviour should be intuitive for the user, as Excel handles this case in the same way.
+let fillMissingCellsSeq (headers: ResizeArray<CompositeHeader>) (values:Dictionary<int*int,CompositeCell>) =
+    let rowCount = getRowCount values
+    let columnCount = getColumnCount headers
+
+    let columnKeyGroups = 
+        values.Keys // Get all keys, to map over relevant rows afterwards
+        |> Seq.groupBy fst // Group by column index
+        |> Map.ofSeq
+
+    for columnIndex = 0 to columnCount - 1 do
+        let header = headers.[columnIndex]
+        match Map.tryFind columnIndex columnKeyGroups with
+        // Some values existed in this column. Fill with default cells
+        | Some col ->
+            let firstCell = Some (values.[Seq.head col])
+            let defaultCell = Unchecked.getEmptyCellForHeader header firstCell
+            let rowKeys = col |> Seq.map snd |> Set.ofSeq
+            for rowIndex = 0 to rowCount - 1 do
+                if not <| rowKeys.Contains rowIndex then
+                    Unchecked.setCellAt (columnIndex,rowIndex,defaultCell) values
+        // No values existed in this column. Fill with default cells
+        | None ->
+            let defaultCell = Unchecked.getEmptyCellForHeader header None
+            for rowIndex = 0 to rowCount - 1 do
+                Unchecked.setCellAt (columnIndex,rowIndex,defaultCell) values
+
+let fillMissingCellsArray (headers: ResizeArray<CompositeHeader>) (values:Dictionary<int*int,CompositeCell>) =
+    let rowCount = getRowCount values
+    let columnCount = getColumnCount headers
+
+    let columnKeyGroups = 
+        values.Keys // Get all keys, to map over relevant rows afterwards
+        |> Seq.toArray
+        |> Array.groupBy fst // Group by column index
+        |> Map.ofArray
+
+    for columnIndex = 0 to columnCount - 1 do
+        let header = headers.[columnIndex]
+        match Map.tryFind columnIndex columnKeyGroups with
+        // All values existed in this column. Nothing to do
+        | Some col when col.Length = rowCount ->
+            ()
+        // Some values existed in this column. Fill with default cells
+        | Some col ->
+            let firstCell = Some (values.[Seq.head col])
+            let defaultCell = Unchecked.getEmptyCellForHeader header firstCell
+            let rowKeys = Array.map snd col |> Set.ofArray
+            for rowIndex = 0 to rowCount - 1 do
+                if not <| rowKeys.Contains rowIndex then
+                    Unchecked.setCellAt (columnIndex,rowIndex,defaultCell) values
+        // No values existed in this column. Fill with default cells
+        | None ->
+            let defaultCell = Unchecked.getEmptyCellForHeader header None
+            for rowIndex = 0 to rowCount - 1 do
+                Unchecked.setCellAt (columnIndex,rowIndex,defaultCell) values
+
+
 let fillMissingOld (headers: ResizeArray<CompositeHeader>) (values:Dictionary<int*int,CompositeCell>) = 
     let rowCount = getRowCount values
     let columnCount = getColumnCount headers
@@ -40,21 +101,32 @@ let table() =
     let name = "MyTable"
     let headers = ResizeArray [CompositeHeader.Input IOType.Sample;CompositeHeader.FreeText "Freetext1" ; CompositeHeader.FreeText "Freetext2"; CompositeHeader.Output IOType.Sample]
     let values = System.Collections.Generic.Dictionary()
-    for i = 0 to 10000 do       
+    for i = 0 to 20000 do       
         if i%2 = 0 then
             Unchecked.setCellAt(0,i,(CompositeCell.FreeText $"Source_{i}")) values
-            Unchecked.setCellAt(2,i,(CompositeCell.FreeText $"FT2_{i}")) values
-        else
-            
             Unchecked.setCellAt(1,i,(CompositeCell.FreeText $"FT1_{i}")) values
-            Unchecked.setCellAt(3,i,(CompositeCell.FreeText $"Sample_{i}")) values
+            Unchecked.setCellAt(2,i,(CompositeCell.FreeText $"FT2_{i}")) values
+            Unchecked.setCellAt(3,i,(CompositeCell.FreeText $"FT3_{i}")) values
+            Unchecked.setCellAt(6,i,(CompositeCell.FreeText $"Sample_{i}")) values
+        else
+            Unchecked.setCellAt(0,i,(CompositeCell.FreeText $"Source_{i}")) values
+            Unchecked.setCellAt(3,i,(CompositeCell.FreeText $"FT3_{i}")) values
+            Unchecked.setCellAt(4,i,(CompositeCell.FreeText $"FT4_{i}")) values
+            Unchecked.setCellAt(5,i,(CompositeCell.FreeText $"FT5_{i}")) values
+            Unchecked.setCellAt(6,i,(CompositeCell.FreeText $"Sample_{i}")) values
 
     ArcTable(name, headers, values)
     
 let prepareTables() =
     let t1 = table()
     let t2 = table()
-    t1,t2
+    let t3 = table()
+    let t4 = table()
+    t1,t2,t3,t4
+
+
+let firstF (t:ArcTable) =
+    fillMissingOld t.Headers t.Values
 
 let oldF (t:ArcTable) =
     fillMissingOld t.Headers t.Values
@@ -62,3 +134,5 @@ let oldF (t:ArcTable) =
 let newF (t:ArcTable) = 
     Unchecked.fillMissingCells t.Headers t.Values
 
+let newSeqF (t:ArcTable) = 
+    fillMissingCellsSeq t.Headers t.Values

--- a/tests/Speedtest/ManyStudies.fs
+++ b/tests/Speedtest/ManyStudies.fs
@@ -1,0 +1,13 @@
+﻿module ManyStudies
+
+open ARCtrl.ISA.Spreadsheet
+open ARCtrl.ISA
+
+
+let write () =
+
+    let inv = ArcInvestigation.init("MyInvestigation")
+    for i = 0 to 1500 do 
+        let s = ArcStudy.init($"Study{i}")
+        inv.AddRegisteredStudy(s)
+    ArcInvestigation.toFsWorkbook inv

--- a/tests/Speedtest/Program.fs
+++ b/tests/Speedtest/Program.fs
@@ -21,11 +21,11 @@ let main argv =
         AddRows.newF t2
         1  
     elif Array.contains "--fillMissing" argv then
-        let t1,t2 = FillMissing.prepareTables()
-        FillMissing.newF t2
-        FillMissing.oldF t1
-        FillMissing.oldF t1
-        FillMissing.newF t2
+        let t1,t2,t3,t4 = FillMissing.prepareTables()
+        FillMissing.firstF t1
+        FillMissing.oldF t2
+        FillMissing.newF t3
+        FillMissing.newSeqF t4
         1
 
     else 

--- a/tests/Speedtest/Program.fs
+++ b/tests/Speedtest/Program.fs
@@ -1,5 +1,6 @@
 ﻿
-
+open ARCtrl
+open ARCtrl.ISA
 
 [<EntryPoint>]
 let main argv =
@@ -14,5 +15,18 @@ let main argv =
         |> LargeStudy.fromWorkbook
         |> ignore
         1
+    elif Array.contains "--addRows" argv then
+        let t1,t2 = AddRows.prepareTables()
+        AddRows.oldF t1
+        AddRows.newF t2
+        1  
+    elif Array.contains "--fillMissing" argv then
+        let t1,t2 = FillMissing.prepareTables()
+        FillMissing.newF t2
+        FillMissing.oldF t1
+        FillMissing.oldF t1
+        FillMissing.newF t2
+        1
+
     else 
         0

--- a/tests/Speedtest/Program.fs
+++ b/tests/Speedtest/Program.fs
@@ -4,8 +4,15 @@
 [<EntryPoint>]
 let main argv =
     
-    LargeStudy.createStudy 10000
-    |> LargeStudy.toWorkbook
-    |> LargeStudy.fromWorkbook
-    |> ignore
-    1
+    if Array.contains "--manyStudies" argv then
+        ManyStudies.write() |> ignore
+        1
+    elif Array.contains "--largeStudy" argv then
+
+        LargeStudy.createStudy 10000
+        |> LargeStudy.toWorkbook
+        |> LargeStudy.fromWorkbook
+        |> ignore
+        1
+    else 
+        0

--- a/tests/Speedtest/Speedtest.fsproj
+++ b/tests/Speedtest/Speedtest.fsproj
@@ -6,8 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="FillMissing.fs" />
     <Compile Include="ManyStudies.fs" />
     <Compile Include="LargeStudy.fs" />
+    <Compile Include="AddRows.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/tests/Speedtest/Speedtest.fsproj
+++ b/tests/Speedtest/Speedtest.fsproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="ManyStudies.fs" />
     <Compile Include="LargeStudy.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/tests/TestingUtils/Library.fs
+++ b/tests/TestingUtils/Library.fs
@@ -132,6 +132,23 @@ module Expect =
     Expected:
     {anyExpected}"
 
+open System
+open Fable.Core
+
+[<AttachMembers>]
+type Stopwatch() =
+    member val StartTime: DateTime option = None with get, set
+    member val StopTime: DateTime option = None with get, set
+    member this.Start() = this.StartTime <- Some DateTime.Now
+    member this.Stop() = 
+        match this.StartTime with
+        | Some _ -> this.StopTime <- Some DateTime.Now
+        | None -> failwith "Error. Unable to call `Stop` before `Start`."
+    member this.Elapsed : TimeSpan = 
+        match this.StartTime, this.StopTime with
+        | Some start, Some stop -> stop - start
+        | _, _ -> failwith "Error. Unable to call `Elapsed` without calling `Start` and `Stop` before."
+
 /// Fable compatible Expecto/Mocha/Pyxpecto unification
 [<AutoOpen>]
 module Test =

--- a/tests/TestingUtils/Library.fs
+++ b/tests/TestingUtils/Library.fs
@@ -49,6 +49,23 @@ module Result =
         | Ok m -> m
         | Error m -> m
 
+open System
+open Fable.Core
+
+[<AttachMembers>]
+type Stopwatch() =
+    member val StartTime: DateTime option = None with get, set
+    member val StopTime: DateTime option = None with get, set
+    member this.Start() = this.StartTime <- Some DateTime.Now
+    member this.Stop() = 
+        match this.StartTime with
+        | Some _ -> this.StopTime <- Some DateTime.Now
+        | None -> failwith "Error. Unable to call `Stop` before `Start`."
+    member this.Elapsed : TimeSpan = 
+        match this.StartTime, this.StopTime with
+        | Some start, Some stop -> stop - start
+        | _, _ -> failwith "Error. Unable to call `Elapsed` without calling `Start` and `Stop` before."
+
 /// Fable compatible Expecto/Mocha/Pyxpecto unification
 module Expect = 
     open Utils
@@ -79,6 +96,30 @@ module Expect =
 
     let exists actual asserter message = Expect.exists actual asserter message 
     let containsAll actual expected message = Expect.containsAll actual expected message
+
+    let wantFaster (f : unit -> 'T) (maxMilliseconds : int) (message : string) = 
+        let stopwatch = Stopwatch()
+        stopwatch.Start()
+        let res = f()
+        stopwatch.Stop()
+        let elapsed = stopwatch.Elapsed
+        if elapsed.TotalMilliseconds > float maxMilliseconds then
+            failwithf $"{message}. Expected to be faster than {maxMilliseconds}ms, but took {elapsed.TotalMilliseconds}ms"
+        res
+
+    let isFasterThan (f1 : unit -> _) (f2 : unit -> _) (message : string) =
+        let stopwatch = Stopwatch()
+        stopwatch.Start()
+        f1()
+        stopwatch.Stop()
+        let elapsed1 = stopwatch.Elapsed
+        stopwatch.Start()
+        f2()
+        stopwatch.Stop()
+        let elapsed2 = stopwatch.Elapsed
+        if elapsed1.TotalMilliseconds > elapsed2.TotalMilliseconds then
+            failwithf $"{message}. Expected {elapsed1.TotalMilliseconds}ms to be faster than {elapsed2.TotalMilliseconds}ms"
+        ()
 
     /// Expects the `actual` sequence to equal the `expected` one.
     let sequenceEqual actual expected message =
@@ -132,22 +173,7 @@ module Expect =
     Expected:
     {anyExpected}"
 
-open System
-open Fable.Core
 
-[<AttachMembers>]
-type Stopwatch() =
-    member val StartTime: DateTime option = None with get, set
-    member val StopTime: DateTime option = None with get, set
-    member this.Start() = this.StartTime <- Some DateTime.Now
-    member this.Stop() = 
-        match this.StartTime with
-        | Some _ -> this.StopTime <- Some DateTime.Now
-        | None -> failwith "Error. Unable to call `Stop` before `Start`."
-    member this.Elapsed : TimeSpan = 
-        match this.StartTime, this.StopTime with
-        | Some start, Some stop -> stop - start
-        | _, _ -> failwith "Error. Unable to call `Elapsed` without calling `Start` and `Stop` before."
 
 /// Fable compatible Expecto/Mocha/Pyxpecto unification
 [<AutoOpen>]


### PR DESCRIPTION
## Improve speed of investigation file writer
Writing investigation file with many rows (e.g. 5000 studies) was very slow with quadratic time. Fixed by using the improved `rowWithRange` function form FsSpreadsheet, which skips checking all rows on every call.

## Improve speed of Reading
- Improved fillMissing by roughly a factor of 8
  
![image](https://github.com/nfdi4plants/ARCtrl/assets/17880410/d8780e72-de96-40cf-8948-95f5f894b23f)

- Improved addRows, which had a quadratic time dependency because of using `getRowCount` in every step
![image](https://github.com/nfdi4plants/ARCtrl/assets/17880410/cc5da003-2a55-4192-93f9-310c86db8812)
