### PR TITLE
Json compression

### DIFF
--- a/src/ISA/ISA.Json/ARCtrl.ISA.Json.fsproj
+++ b/src/ISA/ISA.Json/ARCtrl.ISA.Json.fsproj
@@ -28,10 +28,10 @@
     <Compile Include="Study.fs" />
     <Compile Include="Investigation.fs" />
     <Compile Include="ArcTypes\OATable.fs" />
-	<Compile Include="ArcTypes\CompositeCell.fs" />
-	<Compile Include="ArcTypes\CellTable.fs" />
-	<Compile Include="ArcTypes\IOType.fs" />
-	<Compile Include="ArcTypes\CompositeHeader.fs" />
+	  <Compile Include="ArcTypes\CompositeCell.fs" />
+	  <Compile Include="ArcTypes\CellTable.fs" />
+	  <Compile Include="ArcTypes\IOType.fs" />
+	  <Compile Include="ArcTypes\CompositeHeader.fs" />
     <Compile Include="ArcTypes\ArcTable.fs" />
     <Compile Include="ArcTypes\ArcAssay.fs" />
     <Compile Include="ArcTypes\ArcStudy.fs" />
@@ -51,6 +51,9 @@
       <NpmPackage Name="jsonschema" Version="gte 1.1.0 lt 2.0.0" ResolutionStrategy="Max" />
     </NpmDependencies>
   </PropertyGroup>
+  <ItemGroup>
+    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
+  </ItemGroup>
   <PropertyGroup>
     <Authors>nfdi4plants, Lukas Weil, Florian Wetzels, Kevin Frey</Authors>
     <Description>ARC and ISA json compliant parser for experimental metadata toolkit in F#. This project is meant as an easy means to open, manipulate and save ISA (Investigation,Study,Assay) metadata files in isa-json format.</Description>

--- a/src/ISA/ISA.Json/ARCtrl.ISA.Json.fsproj
+++ b/src/ISA/ISA.Json/ARCtrl.ISA.Json.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Decode.fs" />
     <Compile Include="GEncode.fs" />
     <Compile Include="Comment.fs" />
+    <Compile Include="StringTable.fs" />
     <Compile Include="Ontology.fs" />
     <Compile Include="Factor.fs" />
     <Compile Include="Protocol.fs" />
@@ -26,7 +27,9 @@
     <Compile Include="Assay.fs" />
     <Compile Include="Study.fs" />
     <Compile Include="Investigation.fs" />
+    <Compile Include="ArcTypes\OATable.fs" />
 	<Compile Include="ArcTypes\CompositeCell.fs" />
+	<Compile Include="ArcTypes\CellTable.fs" />
 	<Compile Include="ArcTypes\IOType.fs" />
 	<Compile Include="ArcTypes\CompositeHeader.fs" />
     <Compile Include="ArcTypes\ArcTable.fs" />
@@ -48,9 +51,6 @@
       <NpmPackage Name="jsonschema" Version="gte 1.1.0 lt 2.0.0" ResolutionStrategy="Max" />
     </NpmDependencies>
   </PropertyGroup>
-	<ItemGroup>
-		<Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
-	</ItemGroup>
   <PropertyGroup>
     <Authors>nfdi4plants, Lukas Weil, Florian Wetzels, Kevin Frey</Authors>
     <Description>ARC and ISA json compliant parser for experimental metadata toolkit in F#. This project is meant as an easy means to open, manipulate and save ISA (Investigation,Study,Assay) metadata files in isa-json format.</Description>

--- a/src/ISA/ISA.Json/ArcTypes/ArcAssay.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcAssay.fs
@@ -169,3 +169,5 @@ module ArcAssayExtensions =
                     "assay", arcAssay
                 ] 
             Encode.toString spaces jObject
+
+        static member toCompressedJsonString (a:ArcAssay) = a.ToCompressedJsonString()

--- a/src/ISA/ISA.Json/ArcTypes/ArcStudy.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcStudy.fs
@@ -81,7 +81,7 @@ module ArcStudy =
                 "Comments", EncoderComments study.Comments
         ]
 
-    let compressedDecoder (stringTable : StringTableArray) (oaTable : OATableArray) (cellTable : CellTableArray)  : Decoder<ArcStudy> =
+    let compressedDecoder (stringTable : StringTableArray) (oaTable : OATableArray) (cellTable : CellTableArray) : Decoder<ArcStudy> =
         Decode.object (fun get ->
             let tables = 
                 get.Optional.Field("Tables") (Decode.array (ArcTable.compressedDecoder stringTable oaTable cellTable))
@@ -168,3 +168,6 @@ module ArcStudyExtensions =
                     "study", arcStudy
                 ] 
             Encode.toString spaces jObject
+
+        static member toCompressedJsonString (s : ArcStudy) = 
+            s.ToCompressedJsonString()

--- a/src/ISA/ISA.Json/ArcTypes/ArcStudy.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcStudy.fs
@@ -54,6 +54,55 @@ module ArcStudy =
                 (tryGetComments get "Comments")
     )
 
+    let compressedEncoder (stringTable : StringTableMap) (oaTable : OATableMap) (cellTable : CellTableMap) (study:ArcStudy) =
+        Encode.object [ 
+            "Identifier", Encode.string study.Identifier
+            if study.Title.IsSome then
+                "Title", Encode.string study.Title.Value
+            if study.Description.IsSome then
+                "Description", Encode.string study.Description.Value
+            if study.SubmissionDate.IsSome then
+                "SubmissionDate", Encode.string study.SubmissionDate.Value
+            if study.PublicReleaseDate.IsSome then
+                "PublicReleaseDate", Encode.string study.PublicReleaseDate.Value
+            if study.Publications.Length <> 0 then
+                "Publications", EncoderPublications study.Publications
+            if study.Contacts.Length <> 0 then
+                "Contacts", EncoderPersons study.Contacts
+            if study.StudyDesignDescriptors.Length <> 0 then
+                "StudyDesignDescriptors", EncoderOAs study.StudyDesignDescriptors
+            if study.TableCount <> 0 then
+                "Tables", Encode.seq (Seq.map (ArcTable.compressedEncoder stringTable oaTable cellTable) study.Tables) 
+            if study.RegisteredAssayIdentifiers.Count <> 0 then
+                "RegisteredAssayIdentifiers", Encode.seq (Seq.map Encode.string study.RegisteredAssayIdentifiers)
+            if study.Factors.Length <> 0 then
+                "Factors", EncoderFactors study.Factors
+            if study.Comments.Length <> 0 then
+                "Comments", EncoderComments study.Comments
+        ]
+
+    let compressedDecoder (stringTable : StringTableArray) (oaTable : OATableArray) (cellTable : CellTableArray)  : Decoder<ArcStudy> =
+        Decode.object (fun get ->
+            let tables = 
+                get.Optional.Field("Tables") (Decode.array (ArcTable.compressedDecoder stringTable oaTable cellTable))
+                |> Option.map ResizeArray 
+                |> Option.defaultValue (ResizeArray())
+            ArcStudy.make 
+                (get.Required.Field("Identifier") Decode.string)
+                (get.Optional.Field("Title") Decode.string)
+                (get.Optional.Field("Description") Decode.string)
+                (get.Optional.Field("SubmissionDate") Decode.string)
+                (get.Optional.Field("PublicReleaseDate") Decode.string)
+                (tryGetPublications get "Publications")
+                (tryGetPersons get "Contacts")
+                (tryGetOAs get "StudyDesignDescriptors")
+                tables
+                (tryGetStringResizeArray get "RegisteredAssayIdentifiers")
+                (tryGetFactors get "Factors")
+                (tryGetComments get "Comments")
+        )
+
+
     /// exports in json-ld format
     let toStringLD (a:ArcStudy) (assays: ResizeArray<ArcAssay>) = 
         Study.encoder (ConverterOptions(SetID=true,IncludeType=true)) (a.ToStudy(assays))
@@ -78,6 +127,8 @@ module ArcStudy =
 
 [<AutoOpen>]
 module ArcStudyExtensions =
+    
+    open System.Collections.Generic
 
     type ArcStudy with
         static member fromArcJsonString (jsonString: string) : ArcStudy = 
@@ -90,3 +141,30 @@ module ArcStudyExtensions =
             Encode.toString spaces (ArcStudy.encoder this)
 
         static member toArcJsonString(a:ArcStudy) = a.ToArcJsonString()
+
+        static member fromCompressedJsonString (jsonString: string) : ArcStudy = 
+            let decoder = 
+                Decode.object(fun get ->
+                    let stringTable = get.Required.Field "stringTable" (StringTable.decoder)
+                    let oaTable = get.Required.Field "oaTable" (OATable.decoder stringTable)
+                    let cellTable = get.Required.Field "cellTable" (CellTable.decoder stringTable oaTable)
+                    get.Required.Field "study" (ArcStudy.compressedDecoder stringTable oaTable cellTable)
+                )
+            match Decode.fromString decoder jsonString with
+            | Ok r -> r
+            | Error e -> failwithf "Error. Unable to parse json string to ArcAssay: %s" e
+
+        member this.ToCompressedJsonString(?spaces) : string =
+            let spaces = defaultArg spaces 0
+            let stringTable = Dictionary()
+            let oaTable = Dictionary()
+            let cellTable = Dictionary()
+            let arcStudy = ArcStudy.compressedEncoder stringTable oaTable cellTable this
+            let jObject = 
+                Encode.object [
+                    "cellTable", CellTable.arrayFromMap cellTable |> CellTable.encoder stringTable oaTable
+                    "oaTable", OATable.arrayFromMap oaTable |> OATable.encoder stringTable
+                    "stringTable", StringTable.arrayFromMap stringTable |> StringTable.encoder
+                    "study", arcStudy
+                ] 
+            Encode.toString spaces jObject

--- a/src/ISA/ISA.Json/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcTable.fs
@@ -35,6 +35,8 @@ module ArcTable =
             )
         )
 
+    //let compressedColumnEncoder (columnIndex : int) (rowCount : int) header (cellTable : CellTableMap) (table: ArcTable) =
+
     let compressedEncoder (stringTable : StringTableMap) (oaTable : OATableMap) (cellTable : CellTableMap) (table: ArcTable) =
         let keyEncoder : Encoder<int*int> = Encode.tuple2 Encode.int Encode.int
         Encode.object [
@@ -102,4 +104,4 @@ module ArcTableExtensions =
                 ] 
             Encode.toString spaces jObject
 
-        static member toCompressedJsonString(a:ArcTable) = a.ToJsonString()
+        static member toCompressedJsonString(a:ArcTable) = a.ToCompressedJsonString()

--- a/src/ISA/ISA.Json/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcTable.fs
@@ -8,31 +8,71 @@ open Thoth.Json.Net
 open ARCtrl.ISA
 
 module ArcTable =
-   let encoder (table: ArcTable) =
-      let keyEncoder : Encoder<int*int> = Encode.tuple2 Encode.int Encode.int
-      let valueEncoder = CompositeCell.encoder
-      Encode.object [
+    let encoder (table: ArcTable) =
+        let keyEncoder : Encoder<int*int> = Encode.tuple2 Encode.int Encode.int
+        let valueEncoder = CompositeCell.encoder
+        Encode.object [
         "name", Encode.string table.Name
         if table.Headers.Count <> 0 then
-          "header", Encode.list [
-              for h in table.Headers do yield CompositeHeader.encoder h
-          ]
+            "header", Encode.list [
+                for h in table.Headers do yield CompositeHeader.encoder h
+            ]
         if table.Values.Count <> 0 then
-          "values", Encode.map keyEncoder valueEncoder ([for KeyValue(k,v) in table.Values do yield k, v] |> Map)
-      ] 
+            "values", Encode.map keyEncoder valueEncoder ([for KeyValue(k,v) in table.Values do yield k, v] |> Map)
+        ] 
 
-   let decoder : Decoder<ArcTable> =
-       Decode.object(fun get ->
-           let decodedHeader = get.Optional.Field "header" (Decode.list CompositeHeader.decoder) |> Option.defaultValue List.empty |> ResizeArray 
-           let keyDecoder : Decoder<int*int> = Decode.tuple2 Decode.int Decode.int
-           let valueDecoder = CompositeCell.decoder
-           let decodedValues = get.Optional.Field "values" (Decode.map' keyDecoder valueDecoder) |> Option.defaultValue Map.empty |> System.Collections.Generic.Dictionary
-           ArcTable.create(
-               get.Required.Field "name" Decode.string,
-               decodedHeader,
-               decodedValues
-           )
-       )
+    let decoder : Decoder<ArcTable> =
+        Decode.object(fun get ->
+            let decodedHeader = get.Optional.Field "header" (Decode.list CompositeHeader.decoder) |> Option.defaultValue List.empty |> ResizeArray 
+            let keyDecoder : Decoder<int*int> = Decode.tuple2 Decode.int Decode.int
+            let valueDecoder = CompositeCell.decoder
+            let decodedValues = get.Optional.Field "values" (Decode.map' keyDecoder valueDecoder) |> Option.defaultValue Map.empty |> System.Collections.Generic.Dictionary
+            ArcTable.create(
+                get.Required.Field "name" Decode.string,
+                decodedHeader,
+                decodedValues
+            )
+        )
+
+    let compressionEncoder (table: ArcTable) =
+        let objectTableMap = System.Collections.Generic.Dictionary()
+        let keyEncoder : Encoder<int*int> = Encode.tuple2 Encode.int Encode.int
+        let valueEncoder (cc : CompositeCell) = 
+            match ARCtrl.ISA.Aux.Dict.tryFind cc objectTableMap with
+            | Some i -> Encode.int i
+            | None -> 
+                let i = objectTableMap.Count
+                objectTableMap.Add(cc,i)
+                Encode.int i
+        Encode.object [
+            "name", Encode.string table.Name
+            if table.Headers.Count <> 0 then
+                "header", Encode.list [
+                    for h in table.Headers do yield CompositeHeader.encoder h
+                ]
+            if table.Values.Count <> 0 then
+                "values", Encode.map keyEncoder valueEncoder ([for KeyValue(k,v) in table.Values do yield k, v] |> Map)
+            if objectTableMap.Count <> 0 then
+                "objectTable", objectTableMap |> ObjectTable.arrayFromMap |> ObjectTable.encoder
+        ] 
+
+    let compressionDecoder : Decoder<ArcTable> =
+        Decode.object(fun get ->
+            let objectTable = get.Optional.Field "objectTable" (Decode.array CompositeCell.decoder) |> Option.defaultValue Array.empty
+            let decodedHeader = get.Optional.Field "header" (Decode.list CompositeHeader.decoder) |> Option.defaultValue List.empty |> ResizeArray 
+            let keyDecoder : Decoder<int*int> = Decode.tuple2 Decode.int Decode.int
+            let valueDecoder = 
+                fun s js -> 
+                    match Decode.int s js with
+                    | Ok i -> Ok objectTable[i]
+                    | Error err -> Error err
+            let decodedValues = get.Optional.Field "values" (Decode.map' keyDecoder valueDecoder) |> Option.defaultValue Map.empty |> System.Collections.Generic.Dictionary
+            ArcTable.create(
+                get.Required.Field "name" Decode.string,
+                decodedHeader,
+                decodedValues
+            )
+        )
 
 [<AutoOpen>]
 module ArcTableExtensions =

--- a/src/ISA/ISA.Json/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcTable.fs
@@ -52,7 +52,7 @@ module ArcTable =
             let decodedHeader = get.Optional.Field "h" (Decode.list CompositeHeader.decoder) |> Option.defaultValue List.empty |> ResizeArray 
             let keyDecoder : Decoder<int*int> = Decode.tuple2 Decode.int Decode.int
             let valueDecoder = CellTable.decodeCell cellTable
-            let decodedValues = get.Optional.Field "v" (Decode.map' keyDecoder valueDecoder) |> Option.defaultValue Map.empty |> System.Collections.Generic.Dictionary
+            let decodedValues = get.Optional.Field "c" (Decode.map' keyDecoder valueDecoder) |> Option.defaultValue Map.empty |> System.Collections.Generic.Dictionary
             ArcTable.create(
                 get.Required.Field "n" (StringTable.decodeString stringTable),
                 decodedHeader,
@@ -79,7 +79,7 @@ module ArcTableExtensions =
             let decoder = 
                 Decode.object(fun get ->
                     let stringTable = get.Required.Field "stringTable" (StringTable.decoder)
-                    let oaTable = get.Required.Field "stringTable" (OATable.decoder stringTable)
+                    let oaTable = get.Required.Field "oaTable" (OATable.decoder stringTable)
                     let cellTable = get.Required.Field "cellTable" (CellTable.decoder stringTable oaTable)
                     get.Required.Field "table" (ArcTable.compressedDecoder stringTable oaTable cellTable)
                 )

--- a/src/ISA/ISA.Json/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcTable.fs
@@ -6,6 +6,7 @@ open Thoth.Json
 open Thoth.Json.Net
 #endif
 open ARCtrl.ISA
+open System.Collections.Generic
 
 module ArcTable =
     let encoder (table: ArcTable) =
@@ -34,41 +35,26 @@ module ArcTable =
             )
         )
 
-    let compressionEncoder (table: ArcTable) =
-        let objectTableMap = System.Collections.Generic.Dictionary()
+    let compressedEncoder (stringTable : StringTableMap) (oaTable : OATableMap) (cellTable : CellTableMap) (table: ArcTable) =
         let keyEncoder : Encoder<int*int> = Encode.tuple2 Encode.int Encode.int
-        let valueEncoder (cc : CompositeCell) = 
-            match ARCtrl.ISA.Aux.Dict.tryFind cc objectTableMap with
-            | Some i -> Encode.int i
-            | None -> 
-                let i = objectTableMap.Count
-                objectTableMap.Add(cc,i)
-                Encode.int i
         Encode.object [
-            "name", Encode.string table.Name
+            "n", StringTable.encodeString stringTable table.Name
             if table.Headers.Count <> 0 then
-                "header", Encode.list [
+                "h", Encode.list [
                     for h in table.Headers do yield CompositeHeader.encoder h
                 ]
             if table.Values.Count <> 0 then
-                "values", Encode.map keyEncoder valueEncoder ([for KeyValue(k,v) in table.Values do yield k, v] |> Map)
-            if objectTableMap.Count <> 0 then
-                "objectTable", objectTableMap |> ObjectTable.arrayFromMap |> ObjectTable.encoder
+                "c", Encode.map keyEncoder (CellTable.encodeCell cellTable) ([for KeyValue(k,v) in table.Values do yield k, v] |> Map)
         ] 
 
-    let compressionDecoder : Decoder<ArcTable> =
+    let compressedDecoder (stringTable : StringTableArray) (oaTable : OATableArray) (cellTable : CellTableArray)  : Decoder<ArcTable> =
         Decode.object(fun get ->
-            let objectTable = get.Optional.Field "objectTable" (Decode.array CompositeCell.decoder) |> Option.defaultValue Array.empty
-            let decodedHeader = get.Optional.Field "header" (Decode.list CompositeHeader.decoder) |> Option.defaultValue List.empty |> ResizeArray 
+            let decodedHeader = get.Optional.Field "h" (Decode.list CompositeHeader.decoder) |> Option.defaultValue List.empty |> ResizeArray 
             let keyDecoder : Decoder<int*int> = Decode.tuple2 Decode.int Decode.int
-            let valueDecoder = 
-                fun s js -> 
-                    match Decode.int s js with
-                    | Ok i -> Ok objectTable[i]
-                    | Error err -> Error err
-            let decodedValues = get.Optional.Field "values" (Decode.map' keyDecoder valueDecoder) |> Option.defaultValue Map.empty |> System.Collections.Generic.Dictionary
+            let valueDecoder = CellTable.decodeCell cellTable
+            let decodedValues = get.Optional.Field "v" (Decode.map' keyDecoder valueDecoder) |> Option.defaultValue Map.empty |> System.Collections.Generic.Dictionary
             ArcTable.create(
-                get.Required.Field "name" Decode.string,
+                get.Required.Field "n" (StringTable.decodeString stringTable),
                 decodedHeader,
                 decodedValues
             )
@@ -88,3 +74,32 @@ module ArcTableExtensions =
             Encode.toString spaces (ArcTable.encoder this)
 
         static member toJsonString(a:ArcTable) = a.ToJsonString()
+
+        static member fromCompressedJsonString (jsonString: string) : ArcTable = 
+            let decoder = 
+                Decode.object(fun get ->
+                    let stringTable = get.Required.Field "stringTable" (StringTable.decoder)
+                    let oaTable = get.Required.Field "stringTable" (OATable.decoder stringTable)
+                    let cellTable = get.Required.Field "cellTable" (CellTable.decoder stringTable oaTable)
+                    get.Required.Field "table" (ArcTable.compressedDecoder stringTable oaTable cellTable)
+                )
+            match Decode.fromString decoder jsonString with
+            | Ok r -> r
+            | Error e -> failwithf "Error. Unable to parse json string to ArcTable: %s" e
+
+        member this.ToCompressedJsonString(?spaces) : string =
+            let spaces = defaultArg spaces 0
+            let stringTable = Dictionary()
+            let oaTable = Dictionary()
+            let cellTable = Dictionary()
+            let arcTable = ArcTable.compressedEncoder stringTable oaTable cellTable this
+            let jObject = 
+                Encode.object [
+                    "cellTable", CellTable.arrayFromMap cellTable |> CellTable.encoder stringTable oaTable
+                    "oaTable", OATable.arrayFromMap oaTable |> OATable.encoder stringTable
+                    "stringTable", StringTable.arrayFromMap stringTable |> StringTable.encoder
+                    "table", arcTable
+                ] 
+            Encode.toString spaces jObject
+
+        static member toCompressedJsonString(a:ArcTable) = a.ToJsonString()

--- a/src/ISA/ISA.Json/ArcTypes/CellTable.fs
+++ b/src/ISA/ISA.Json/ArcTypes/CellTable.fs
@@ -1,0 +1,47 @@
+﻿namespace rec ARCtrl.ISA.Json
+
+#if FABLE_COMPILER
+open Thoth.Json
+#else
+open Thoth.Json.Net
+#endif
+open ARCtrl.ISA
+
+open ARCtrl.ISA.Aux
+
+type CellTableMap = System.Collections.Generic.Dictionary<CompositeCell,int>
+
+type CellTableArray = array<CompositeCell>
+
+module CellTable =
+
+    let [<Literal>] CellType = "celltype"
+    let [<Literal>] CellValues = "values"
+
+    let arrayFromMap (otm : CellTableMap) : CellTableArray=
+        otm
+        |> Seq.sortBy (fun kv -> kv.Value)
+        |> Seq.map (fun kv -> kv.Key)
+        |> Seq.toArray
+
+    let encoder (stringTable : StringTableMap) (oaTable : OATableMap) (ot: CellTableArray) =
+        ot
+        |> Array.map (CompositeCell.compressedEncoder stringTable oaTable)
+        |> Encode.array
+
+    let decoder (stringTable : StringTableArray) (oaTable : OATableArray) : Decoder<CellTableArray> =
+        Decode.array (CompositeCell.compressedDecoder stringTable oaTable)
+        
+    let encodeCell (otm : CellTableMap) (cc : CompositeCell) =
+        match Dict.tryFind cc otm with
+        | Some i -> Encode.int i
+        | None ->
+            let i = otm.Count
+            otm.Add(cc,i)
+            Encode.int i
+
+    let decodeCell (ot : CellTableArray) : Decoder<CompositeCell> = 
+        fun s o -> 
+            match Decode.int s o with
+            | Ok i -> Ok ot.[i]
+            | Error err -> Error err

--- a/src/ISA/ISA.Json/ArcTypes/CompositeCell.fs
+++ b/src/ISA/ISA.Json/ArcTypes/CompositeCell.fs
@@ -7,10 +7,15 @@ open Thoth.Json.Net
 #endif
 open ARCtrl.ISA
 
+open ARCtrl.ISA.Aux
+
 module CompositeCell =
 
     let [<Literal>] CellType = "celltype"
     let [<Literal>] CellValues = "values"
+
+    let [<Literal>] CompressedCellType = "t"
+    let [<Literal>] CompressedCellValues = "v"
 
     let encoder (cc: CompositeCell) =
         let oaToJsonString (oa:OntologyAnnotation) = OntologyAnnotation.encoder (ConverterOptions()) oa
@@ -40,7 +45,34 @@ module CompositeCell =
             | anyelse -> failwithf "Error reading CompositeCell from json string: %A" anyelse 
         ) 
 
+    let compressedEncoder (stringTable : StringTableMap) (oaTable : OATableMap) (cc: CompositeCell) =
+
+        let t, v =
+            match cc with
+            | CompositeCell.FreeText s -> "FreeText", [StringTable.encodeString stringTable s]
+            | CompositeCell.Term t -> "Term", [OATable.encodeOA oaTable t]
+            | CompositeCell.Unitized (v, unit) -> "Unitized", [StringTable.encodeString stringTable v; OATable.encodeOA oaTable unit]
+        Encode.object [
+            CompressedCellType, StringTable.encodeString stringTable t
+            CompressedCellValues, v |> Encode.list
+    ]
     
+    let compressedDecoder (stringTable : StringTableArray) (oaTable : OATableArray) : Decoder<CompositeCell> =
+
+        Decode.object (fun get ->
+            match get.Required.Field (CompressedCellType) (StringTable.decodeString stringTable) with
+            | "FreeText" -> 
+                let s = get.Required.Field (CompressedCellValues) (Decode.index 0 (StringTable.decodeString stringTable))
+                CompositeCell.FreeText s
+            | "Term" -> 
+                let oa = get.Required.Field (CompressedCellValues) (Decode.index 0 <| OATable.decodeOA oaTable )
+                CompositeCell.Term oa
+            | "Unitized" -> 
+                let v = get.Required.Field (CompressedCellValues) (Decode.index 0 <| (StringTable.decodeString stringTable) )
+                let oa = get.Required.Field (CompressedCellValues) (Decode.index 1 <| OATable.decodeOA oaTable )
+                CompositeCell.Unitized (v, oa)
+            | anyelse -> failwithf "Error reading CompositeCell from json string: %A" anyelse 
+        ) 
 
 [<AutoOpen>]
 module CompositeCellExtensions =
@@ -56,29 +88,4 @@ module CompositeCellExtensions =
             Encode.toString spaces (CompositeCell.encoder this)
 
         static member toJsonString(a:CompositeCell) = a.ToJsonString()
-
-
-
-type ObjectTableMap = System.Collections.Generic.Dictionary<CompositeCell,int>
-
-type ObjectTableArray = array<CompositeCell>
-
-module ObjectTable =
-
-    let [<Literal>] CellType = "celltype"
-    let [<Literal>] CellValues = "values"
-
-    let arrayFromMap (otm : ObjectTableMap) : ObjectTableArray=
-        otm
-        |> Seq.sortBy (fun kv -> kv.Value)
-        |> Seq.map (fun kv -> kv.Key)
-        |> Seq.toArray
-
-    let encoder (ot: ObjectTableArray) =
-        ot
-        |> Array.map CompositeCell.encoder 
-        |> Encode.array
-
-    let decoder : Decoder<ObjectTableArray> =
-        Decode.array CompositeCell.decoder 
         

--- a/src/ISA/ISA.Json/ArcTypes/OATable.fs
+++ b/src/ISA/ISA.Json/ArcTypes/OATable.fs
@@ -1,0 +1,44 @@
+﻿namespace rec ARCtrl.ISA.Json
+
+#if FABLE_COMPILER
+open Thoth.Json
+#else
+open Thoth.Json.Net
+#endif
+open ARCtrl.ISA
+
+open ARCtrl.ISA.Aux
+
+type OATableMap = System.Collections.Generic.Dictionary<OntologyAnnotation,int>
+
+type OATableArray = array<OntologyAnnotation>
+
+module OATable =
+
+    let arrayFromMap (otm : OATableMap) : OATableArray=
+        otm
+        |> Seq.sortBy (fun kv -> kv.Value)
+        |> Seq.map (fun kv -> kv.Key)
+        |> Seq.toArray
+
+    let encoder (stringTable : StringTableMap) (ot: OATableArray) =
+        ot
+        |> Array.map (OntologyAnnotation.compressedEncoder stringTable (ConverterOptions()))
+        |> Encode.array
+
+    let decoder stringTable : Decoder<OATableArray> =
+        Decode.array (OntologyAnnotation.compressedDecoder stringTable (ConverterOptions())) 
+        
+    let encodeOA (otm : OATableMap) (oa : OntologyAnnotation) =
+        match Dict.tryFind oa otm with
+        | Some i -> Encode.int i
+        | None ->
+            let i = otm.Count
+            otm.Add(oa,i)
+            Encode.int i
+
+    let decodeOA (ot : OATableArray) : Decoder<OntologyAnnotation> = 
+        fun s o -> 
+            match Decode.int s o with
+            | Ok i -> Ok ot.[i]
+            | Error err -> Error err

--- a/src/ISA/ISA.Json/StringTable.fs
+++ b/src/ISA/ISA.Json/StringTable.fs
@@ -1,0 +1,45 @@
+﻿namespace rec ARCtrl.ISA.Json
+
+#if FABLE_COMPILER
+open Thoth.Json
+#else
+open Thoth.Json.Net
+#endif
+open ARCtrl.ISA
+
+open ARCtrl.ISA.Aux
+
+type StringTableMap = System.Collections.Generic.Dictionary<string,int>
+
+type StringTableArray = array<string>
+
+module StringTable =
+
+    let arrayFromMap (otm : StringTableMap) : StringTableArray=
+        otm
+        |> Seq.sortBy (fun kv -> kv.Value)
+        |> Seq.map (fun kv -> kv.Key)
+        |> Seq.toArray
+
+    let encoder (ot: StringTableArray) =
+        ot
+        |> Array.map Encode.string
+        |> Encode.array
+
+    let decoder : Decoder<StringTableArray> =
+        Decode.array Decode.string
+        
+    let encodeString (otm : StringTableMap) (s : obj) =
+        let s = s :?> string
+        match Dict.tryFind s otm with
+        | Some i -> Encode.int i
+        | None ->
+            let i = otm.Count
+            otm.Add(s,i)
+            Encode.int i
+
+    let decodeString (ot : StringTableArray) : Decoder<string> = 
+        fun s o -> 
+            match Decode.int s o with
+            | Ok i -> Ok ot.[i]
+            | Error err -> Error err

--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -23,6 +23,7 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
     member this.Headers
         with get() = headers
         and set(newHeaders) = headers <- newHeaders
+    /// column * row index
     member this.Values
         with get() = values
         and set(newValues) = values <- newValues

--- a/tests/ISA/ISA.Json.Tests/ArcTypes.Tests.fs
+++ b/tests/ISA/ISA.Json.Tests/ArcTypes.Tests.fs
@@ -186,6 +186,16 @@ let tests_ArcTable = testList "ArcTable" [
       let actual = Expect.wantOk actual "wantok"
       Expect.equal actual expected ""
   ]
+  testList "compressedIO" [
+    testCase "Empty" <| fun _ ->
+      let encoded = ArcTable.toCompressedJsonString init
+      let decoded = ArcTable.fromCompressedJsonString encoded
+      Expect.equal decoded init "empty table is wrong after compressed encoding and decoding"
+    testCase "Filled" <| fun _ ->
+      let encoded = ArcTable.toCompressedJsonString filled
+      let decoded = ArcTable.fromCompressedJsonString encoded
+      Expect.equal decoded filled "empty table is wrong after compressed encoding and decoding"
+  ]
 ]
 
 let tests_ArcAssay = testList "ArcAssay" [
@@ -225,6 +235,16 @@ let tests_ArcAssay = testList "ArcAssay" [
       let expected = filled
       let actual = Expect.wantOk actual "wantok"
       Expect.equal actual expected ""
+  ]
+  testList "compressedIO" [
+    testCase "Empty" <| fun _ ->
+      let encoded = ArcAssay.toCompressedJsonString init
+      let decoded = ArcAssay.fromCompressedJsonString encoded
+      Expect.equal decoded init "empty table is wrong after compressed encoding and decoding"
+    testCase "Filled" <| fun _ ->
+      let encoded = ArcAssay.toCompressedJsonString filled
+      let decoded = ArcAssay.fromCompressedJsonString encoded
+      Expect.equal decoded filled "empty table is wrong after compressed encoding and decoding"
   ]
 ]
 

--- a/tests/ISA/ISA.Json.Tests/ArcTypes.Tests.fs
+++ b/tests/ISA/ISA.Json.Tests/ArcTypes.Tests.fs
@@ -195,6 +195,37 @@ let tests_ArcTable = testList "ArcTable" [
       let encoded = ArcTable.toCompressedJsonString filled
       let decoded = ArcTable.fromCompressedJsonString encoded
       Expect.equal decoded filled "empty table is wrong after compressed encoding and decoding"
+    // Set to pTest in Fable, as compressed parsing is around 10times slower than uncompressed parsing. This is weird, since in dotnet it is around 10times faster
+    #if FABLE_COMPILER 
+    ptestCase "Performance" <| fun _ ->
+    #else
+    testCase "Performance" <| fun _ ->
+    #endif
+        let t = TestObjects.Spreadsheet.Study.LargeFile.table
+        Expect.isFasterThan (t.ToCompressedJsonString >> ignore) (t.ToJsonString  >> ignore) "toCompressedJsonString is slower than to uncompressed"
+        let json = t.ToJsonString()
+        let compressed = Expect.wantFaster (t.ToCompressedJsonString) 1000 "toCompressedJsonString should be faster"
+        Expect.isTrue (compressed.Length*5 < json.Length) $"compressed should be more than 10 times smaller than uncompressed, but was only {float json.Length / float compressed.Length}x smaller"
+    testCase "rangeColumnSize" <| fun _ ->
+        // testTable column should be saved as range column, this should make it smaller than the IO column even though it has more cells
+        let testTable = ArcTable.init("Test")
+        testTable.AddColumn (CompositeHeader.FreeText "ABC", [|for i = 0 to 200 do yield CompositeCell.FreeText "TestValue"|])
+        let referenceTable = ArcTable.init("Test")
+        referenceTable.AddColumn (CompositeHeader.Input IOType.Source, [|for i = 0 to 100 do yield CompositeCell.FreeText "TestValue"|])
+        let compressedTest = testTable.ToCompressedJsonString()
+        let compressedReference = referenceTable.ToCompressedJsonString()
+        Expect.isTrue (compressedTest.Length < compressedReference.Length) "range column should be smaller than IO column"
+        let decompressedTest = ArcTable.fromCompressedJsonString compressedTest
+        Expect.arcTableEqual decompressedTest testTable "decompressed table should be equal to original table"
+    testCase "rangeColumnCorrectness" <| fun _ ->
+        let testTable = ArcTable.init("Test")
+        testTable.AddColumn (CompositeHeader.FreeText "ABC")
+        for i = 0 to 100 do testTable.AddRow ([|CompositeCell.FreeText "TestValue1"|])
+        for i = 101 to 200 do testTable.AddRow ([|CompositeCell.FreeText "TestValue2"|])
+        testTable.AddRow ([|CompositeCell.FreeText "TestValue3"|])
+        let encoded = testTable.ToCompressedJsonString()
+        let decoded = ArcTable.fromCompressedJsonString encoded
+        Expect.arcTableEqual decoded testTable "decompressed table should be equal to original table"
   ]
 ]
 


### PR DESCRIPTION
Added compressed json encoders to reduce size of output json. These make use of Cell-, OntologyAnnotation- and Stringtables to deduplicate information.
In DotNet it's not only much smaller, but also much faster. Unfortunately, this is not the case for JS. Therefore the performance test is pending in Fable.