### PR TITLE
Implement Update logic

### DIFF
--- a/src/ARCtrl/ARC.fs
+++ b/src/ARCtrl/ARC.fs
@@ -297,7 +297,7 @@ type ARC(?isa : ISA.ArcInvestigation, ?cwl : CWL.CWL, ?fs : FileSystem.FileSyste
     /// <summary>
     /// This function returns the all update Contracts for the current state of the ARC. Only update contracts for those ISA objects that have been changed will be returned. If an ISA object was added to the ARC, instead a write contract for the complete object folder will be returned. 
     /// 
-    /// 
+    /// An obect is considered changed if its hash code has changed compared with the StaticHash. An object is considered added if its StaticHash code is 0.
     /// 
     /// ISA contracts do contain the object data as spreadsheets, while the other contracts only contain the path.
     /// </summary>  

--- a/src/ARCtrl/Contracts/Contracts.ArcTypes.fs
+++ b/src/ARCtrl/Contracts/Contracts.ArcTypes.fs
@@ -82,7 +82,7 @@ module ArcTypeExtensions =
             [|
                 if withFolder then 
                     let folderFS = FileSystemTree.createStudiesFolder ([|FileSystemTree.createStudyFolder this.Identifier|])
-                    for p in folderFS.ToFilePaths() do
+                    for p in folderFS.ToFilePaths(false) do
                         if p <> path then Contract.createCreate(p, DTOType.PlainText)
                 c
             |]
@@ -123,7 +123,7 @@ module ArcTypeExtensions =
             [|
                 if withFolder then 
                     let folderFS = FileSystemTree.createAssayFolder this.Identifier
-                    for p in folderFS.ToFilePaths() do
+                    for p in folderFS.ToFilePaths(false) do
                         if p <> path then Contract.createCreate(p, DTOType.PlainText)
                 c
             |]

--- a/src/ARCtrl/Contracts/Contracts.ArcTypes.fs
+++ b/src/ARCtrl/Contracts/Contracts.ArcTypes.fs
@@ -74,10 +74,18 @@ module ArcTypeExtensions =
 
     type ArcStudy with
 
-        member this.ToCreateContract () =
+        member this.ToCreateContract (?WithFolder) =
+            let withFolder = defaultArg WithFolder false
             let path = Identifier.Study.fileNameFromIdentifier this.Identifier
             let c = Contract.createCreate(path, DTOType.ISA_Study, DTO.Spreadsheet (this |> ArcStudy.toFsWorkbook))
-            c
+            
+            [|
+                if withFolder then 
+                    let folderFS = FileSystemTree.createStudiesFolder ([|FileSystemTree.createStudyFolder this.Identifier|])
+                    for p in folderFS.ToFilePaths() do
+                        if p <> path then Contract.createCreate(p, DTOType.PlainText)
+                c
+            |]
 
         member this.ToUpdateContract () =
             let path = Identifier.Study.fileNameFromIdentifier this.Identifier
@@ -92,8 +100,8 @@ module ArcTypeExtensions =
         static member toDeleteContract (study: ArcStudy) : Contract =
             study.ToDeleteContract()
 
-        static member toCreateContract (study: ArcStudy) : Contract =
-            study.ToCreateContract()
+        static member toCreateContract (study: ArcStudy, ?WithFolder) : Contract [] =
+            study.ToCreateContract(?WithFolder = WithFolder)
 
         static member toUpdateContract (study: ArcStudy) : Contract =
             study.ToUpdateContract()           
@@ -108,10 +116,18 @@ module ArcTypeExtensions =
 
     type ArcAssay with
 
-        member this.ToCreateContract () =
+        member this.ToCreateContract (?WithFolder) =
+            let withFolder = defaultArg WithFolder false
             let path = Identifier.Assay.fileNameFromIdentifier this.Identifier
             let c = Contract.createCreate(path, DTOType.ISA_Assay, DTO.Spreadsheet (this |> ArcAssay.toFsWorkbook))
-            c
+            [|
+                if withFolder then 
+                    let folderFS = FileSystemTree.createAssayFolder this.Identifier
+                    for p in folderFS.ToFilePaths() do
+                        if p <> path then Contract.createCreate(p, DTOType.PlainText)
+                c
+            |]
+
 
         member this.ToUpdateContract () =
             let path = Identifier.Assay.fileNameFromIdentifier this.Identifier
@@ -126,8 +142,8 @@ module ArcTypeExtensions =
         static member toDeleteContract (assay: ArcAssay) : Contract =
             assay.ToDeleteContract()
 
-        static member toCreateContract (assay: ArcAssay) : Contract =
-            assay.ToCreateContract()
+        static member toCreateContract (assay: ArcAssay,?WithFolder) : Contract [] =
+            assay.ToCreateContract(?WithFolder = WithFolder)
 
         static member toUpdateContract (assay: ArcAssay) : Contract =
             assay.ToUpdateContract()

--- a/src/ISA/ISA/ArcTypes/ArcTable.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTable.fs
@@ -780,18 +780,11 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
     // it's good practice to ensure that this behaves using the same fields as Equals does:
     override this.GetHashCode() = 
         //let v1,v2 = 
-        let v =
-            [|
-                for KeyValue(k,v) in this.Values do
-                    yield k, v
-            |] 
-            |> Array.sortBy fst
-            // must remove tuples. Tuples handle unpredictable for GetHashCode in javascript.
-            |> Array.map (fun ((k1,k2),v) -> [|box k1; box k2; box v|] |> Aux.HashCodes.boxHashArray) 
+        let vHash =  ArcTableAux.boxHashValues this.ColumnCount this.Values
         [|
             box this.Name
-            Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Headers
-            Array.ofSeq >> Aux.HashCodes.boxHashArray <| v
+            this.Headers |> Aux.HashCodes.boxHashSeq 
+            vHash
         |]
         |> Aux.HashCodes.boxHashArray 
         |> fun x -> x :?> int

--- a/src/ISA/ISA/ArcTypes/ArcTableAux.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTableAux.fs
@@ -24,6 +24,15 @@ let getRowCount (values:Dictionary<int*int,CompositeCell>) =
     if values.Count = 0 then 0 else
         values.Keys |> Seq.maxBy snd |> snd |> (+) 1
 
+let boxHashValues colCount (values:Dictionary<int*int,CompositeCell>) =
+    let mutable hash = 0
+    let rowCount = getRowCount values
+    for col = 0 to colCount - 1 do
+        for row = 0 to rowCount - 1 do
+            hash <- 0x9e3779b9 + values.[col,row].GetHashCode() + (hash <<< 6) + (hash >>> 2)
+    hash    
+    |> box
+
 // TODO: Move to CompositeHeader?
 let (|IsUniqueExistingHeader|_|) existingHeaders (input: CompositeHeader) = 
     match input with

--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -88,7 +88,7 @@ module ArcTypesAux =
         
 
 [<AttachMembers>]
-type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?technologyType : OntologyAnnotation, ?technologyPlatform : OntologyAnnotation, ?tables: ResizeArray<ArcTable>, ?performers : Person [], ?comments : Comment []) = 
+type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?technologyType : OntologyAnnotation, ?technologyPlatform : OntologyAnnotation, ?tables: ResizeArray<ArcTable>, ?performers : Person [], ?comments : Comment []) as this = 
     inherit ArcTables(defaultArg tables <| ResizeArray())
     
     let performers = defaultArg performers [||]
@@ -100,6 +100,7 @@ type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?techno
     let mutable technologyPlatform : OntologyAnnotation option = technologyPlatform
     let mutable performers : Person [] = performers
     let mutable comments : Comment [] = comments
+    let mutable staticHash : int = 0
 
     /// Must be unique in one study
     member this.Identifier with get() = identifier and internal set(i) = identifier <- i
@@ -110,6 +111,7 @@ type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?techno
     member this.TechnologyPlatform with get() = technologyPlatform and set(n) = technologyPlatform <- n
     member this.Performers with get() = performers and set(n) = performers <- n
     member this.Comments with get() = comments and set(n) = comments <- n
+    member this.StaticHash with get() = staticHash and set(h) = staticHash <- h
 
     static member init (identifier : string) = ArcAssay(identifier)
     static member create (identifier: string, ?measurementType : OntologyAnnotation, ?technologyType : OntologyAnnotation, ?technologyPlatform : OntologyAnnotation, ?tables: ResizeArray<ArcTable>, ?performers : Person [], ?comments : Comment []) = 
@@ -557,7 +559,7 @@ type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?techno
         |> fun x -> x :?> int
 
 [<AttachMembers>]
-type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publicReleaseDate, ?publications, ?contacts, ?studyDesignDescriptors, ?tables, ?registeredAssayIdentifiers: ResizeArray<string>, ?factors, ?comments) = 
+type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publicReleaseDate, ?publications, ?contacts, ?studyDesignDescriptors, ?tables, ?registeredAssayIdentifiers: ResizeArray<string>, ?factors, ?comments) as this = 
     inherit ArcTables(defaultArg tables <| ResizeArray())
 
     let publications = defaultArg publications [||]
@@ -579,6 +581,8 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
     let mutable registeredAssayIdentifiers : ResizeArray<string> = registeredAssayIdentifiers
     let mutable factors : Factor [] = factors
     let mutable comments : Comment [] = comments
+    let mutable staticHash : int = 0
+
     /// Must be unique in one investigation
     member this.Identifier with get() = identifier and internal set(i) = identifier <- i
     // read-only
@@ -593,6 +597,7 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
     member this.RegisteredAssayIdentifiers with get() = registeredAssayIdentifiers and set(n) = registeredAssayIdentifiers <- n
     member this.Factors with get() = factors and set(n) = factors <- n
     member this.Comments with get() = comments and set(n) = comments <- n
+    member this.StaticHash with get() = staticHash and set(h) = staticHash <- h
 
     static member init(identifier : string) = ArcStudy identifier
 
@@ -1150,6 +1155,23 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
         |> Aux.HashCodes.boxHashArray 
         |> fun x -> x :?> int
 
+    member this.GetLightHashCode() = 
+        [|
+            box this.Identifier
+            Aux.HashCodes.boxHashOption this.Title
+            Aux.HashCodes.boxHashOption this.Description
+            Aux.HashCodes.boxHashOption this.SubmissionDate
+            Aux.HashCodes.boxHashOption this.PublicReleaseDate
+            Aux.HashCodes.boxHashArray this.Publications
+            Aux.HashCodes.boxHashArray this.Contacts
+            Aux.HashCodes.boxHashArray this.StudyDesignDescriptors
+            Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Tables
+            Aux.HashCodes.boxHashArray this.Factors
+            Aux.HashCodes.boxHashArray this.Comments
+        |]
+        |> Aux.HashCodes.boxHashArray 
+        |> fun x -> x :?> int
+
 [<AttachMembers>]
 type ArcInvestigation(identifier : string, ?title : string, ?description : string, ?submissionDate : string, ?publicReleaseDate : string, ?ontologySourceReferences : OntologySourceReference [], ?publications : Publication [], ?contacts : Person [], ?assays : ResizeArray<ArcAssay>, ?studies : ResizeArray<ArcStudy>, ?registeredStudyIdentifiers : ResizeArray<string>, ?comments : Comment [], ?remarks : Remark []) as this = 
 
@@ -1183,6 +1205,8 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
     let mutable registeredStudyIdentifiers : ResizeArray<string> = registeredStudyIdentifiers
     let mutable comments : Comment [] = comments
     let mutable remarks : Remark [] = remarks
+    let mutable staticHash : int = 0
+
     /// Must be unique in one investigation
     member this.Identifier with get() = identifier and internal set(i) = identifier <- i
     member this.Title with get() = title and set(n) = title <- n
@@ -1197,6 +1221,7 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
     member this.RegisteredStudyIdentifiers with get() = registeredStudyIdentifiers and set(n) = registeredStudyIdentifiers <- n
     member this.Comments with get() = comments and set(n) = comments <- n
     member this.Remarks with get() = remarks and set(n) = remarks <- n
+    member this.StaticHash with get() = staticHash and set(h) = staticHash <- h
 
     static member FileName = ARCtrl.Path.InvestigationFileName
 
@@ -1920,6 +1945,22 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Assays
             Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.Studies
             Array.ofSeq >> Aux.HashCodes.boxHashArray <| this.RegisteredStudyIdentifiers
+            Aux.HashCodes.boxHashArray this.Comments
+            Aux.HashCodes.boxHashArray this.Remarks
+        |]
+        |> Aux.HashCodes.boxHashArray 
+        |> fun x -> x :?> int
+
+    member this.GetLightHashCode() =
+        [|
+            box this.Identifier
+            Aux.HashCodes.boxHashOption this.Title
+            Aux.HashCodes.boxHashOption this.Description
+            Aux.HashCodes.boxHashOption this.SubmissionDate
+            Aux.HashCodes.boxHashOption this.PublicReleaseDate
+            Aux.HashCodes.boxHashArray this.Publications
+            Aux.HashCodes.boxHashArray this.Contacts
+            Aux.HashCodes.boxHashArray this.OntologySourceReferences
             Aux.HashCodes.boxHashArray this.Comments
             Aux.HashCodes.boxHashArray this.Remarks
         |]

--- a/src/ISA/ISA/ArcTypes/ArcTypes.fs
+++ b/src/ISA/ISA/ArcTypes/ArcTypes.fs
@@ -88,7 +88,7 @@ module ArcTypesAux =
         
 
 [<AttachMembers>]
-type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?technologyType : OntologyAnnotation, ?technologyPlatform : OntologyAnnotation, ?tables: ResizeArray<ArcTable>, ?performers : Person [], ?comments : Comment []) as this = 
+type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?technologyType : OntologyAnnotation, ?technologyPlatform : OntologyAnnotation, ?tables: ResizeArray<ArcTable>, ?performers : Person [], ?comments : Comment []) = 
     inherit ArcTables(defaultArg tables <| ResizeArray())
     
     let performers = defaultArg performers [||]
@@ -559,7 +559,7 @@ type ArcAssay(identifier: string, ?measurementType : OntologyAnnotation, ?techno
         |> fun x -> x :?> int
 
 [<AttachMembers>]
-type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publicReleaseDate, ?publications, ?contacts, ?studyDesignDescriptors, ?tables, ?registeredAssayIdentifiers: ResizeArray<string>, ?factors, ?comments) as this = 
+type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publicReleaseDate, ?publications, ?contacts, ?studyDesignDescriptors, ?tables, ?registeredAssayIdentifiers: ResizeArray<string>, ?factors, ?comments) = 
     inherit ArcTables(defaultArg tables <| ResizeArray())
 
     let publications = defaultArg publications [||]

--- a/tests/ISA/ISA.Tests/ArcTable.Tests.fs
+++ b/tests/ISA/ISA.Tests/ArcTable.Tests.fs
@@ -108,6 +108,13 @@ let private tests_GetHashCode = testList "GetHashCode" [
         let notActual = create_testTable()
         Expect.notEqual actual notActual "equal"
         Expect.notEqual (actual.GetHashCode()) (notActual.GetHashCode()) "Hash"
+    testCase "Performance" <| fun _ ->
+        let testTable = ArcTable.init("Test")
+        let values = Array.init 10000 (fun i -> CompositeCell.createFreeText (string i))
+        testTable.AddColumn(CompositeHeader.FreeText "Header", values)
+        let f1 () = testTable.GetHashCode()
+        // On i7-13800H, 2ms in Dotnet and 18ms in javascript
+        Expect.wantFaster f1 50 "GetHashCode is too slow" |> ignore
 ]
 
 let private tests_validate = 


### PR DESCRIPTION
Introduced a 
```fsharp
arc.GetUpdateContracts()
```
member, which only returns `Update` contracts for the entities that have been changed. If an entity is added, the appropriate `Create` contracts are returned. Accordingly, if the ARC is initilialized in memory and not written yet, all `Create` contracts are returned.

The check, whether an entity has changed or not is done by keeping a `StaticHash` field in `Assays`, `Studies` and `Investigations`. These are set either when using `SetISAFromContracts` (Read) or when using `GetWriteContracts/GetUpdateContracts` (Write).


- [x] Improve speed of GetHashCode
- [x] Remember Hash when parsing ARC components
- [x] Implement Update function which returns only contracts for the components that have changed
- [x] Tests

closes #309 
closes #131