### PR TITLE
Jsonld Export with new bioschemas types

### DIFF
--- a/src/ISA/ISA.Json/ArcTypes/ArcAssay.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcAssay.fs
@@ -103,11 +103,11 @@ module ArcAssay =
 
     /// exports in json-ld format
     let toJsonldString (a:ArcAssay) = 
-        Assay.encoder (ConverterOptions(SetID=true,IncludeType=true)) None (a.ToAssay())
+        Assay.encoder (ConverterOptions(SetID=true,IsJsonLD=true)) None (a.ToAssay())
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:ArcAssay) = 
-        Assay.encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) None (a.ToAssay())
+        Assay.encoder (ConverterOptions(SetID=true,IsJsonLD=true)) None (a.ToAssay())
         |> GEncode.toJsonString 2
 
     let fromJsonString (s:string) = 

--- a/src/ISA/ISA.Json/ArcTypes/ArcInvestigation.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcInvestigation.fs
@@ -59,11 +59,11 @@ module ArcInvestigation =
 
     /// exports in json-ld format
     let toJsonldString (a:ArcInvestigation) = 
-        Investigation.encoder (ConverterOptions(SetID=true,IncludeType=true)) (a.ToInvestigation())
+        Investigation.encoder (ConverterOptions(SetID=true,IsJsonLD=true)) (a.ToInvestigation())
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:ArcInvestigation) = 
-        Investigation.encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) (a.ToInvestigation())
+        Investigation.encoder (ConverterOptions(SetID=true,IsJsonLD=true)) (a.ToInvestigation())
         |> GEncode.toJsonString 2
 
     let fromJsonString (s:string) = 

--- a/src/ISA/ISA.Json/ArcTypes/ArcStudy.fs
+++ b/src/ISA/ISA.Json/ArcTypes/ArcStudy.fs
@@ -102,11 +102,11 @@ module ArcStudy =
 
     /// exports in json-ld format
     let toJsonldString (a:ArcStudy) (assays: ResizeArray<ArcAssay>) = 
-        Study.encoder (ConverterOptions(SetID=true,IncludeType=true)) (a.ToStudy(assays))
+        Study.encoder (ConverterOptions(SetID=true,IsJsonLD=true)) (a.ToStudy(assays))
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:ArcStudy) (assays: ResizeArray<ArcAssay>) = 
-        Study.encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) (a.ToStudy(assays))
+        Study.encoder (ConverterOptions(SetID=true,IsJsonLD=true)) (a.ToStudy(assays))
         |> GEncode.toJsonString 2
 
     let fromJsonString (s:string) = 

--- a/src/ISA/ISA.Json/Assay.fs
+++ b/src/ISA/ISA.Json/Assay.fs
@@ -87,6 +87,8 @@ module Assay =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (p:Assay) = 
         encoder (ConverterOptions()) None p

--- a/src/ISA/ISA.Json/Comment.fs
+++ b/src/ISA/ISA.Json/Comment.fs
@@ -25,11 +25,11 @@ module Comment =
                 "@id", Encode.string (comment |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (comment.ID)
-            if options.IncludeType then 
+            if options.IsJsonLD then 
                 "@type", Encode.string "Comment"
             GEncode.tryInclude "name" Encode.string (comment.Name)
             GEncode.tryInclude "value" Encode.string (comment.Value)
-            if options.IncludeContext then
+            if options.IsJsonLD then
                 "@context", ROCrateContext.Comment.context_jsonvalue
         ]
         |> GEncode.choose
@@ -53,11 +53,11 @@ module Comment =
 
     /// exports in json-ld format
     let toJsonldString (c:Comment) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) c
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) c
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:Comment) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 

--- a/src/ISA/ISA.Json/Comment.fs
+++ b/src/ISA/ISA.Json/Comment.fs
@@ -46,6 +46,8 @@ module Comment =
 
     let fromJsonString (s:string)  = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (c:Comment) = 
         encoder (ConverterOptions()) c

--- a/src/ISA/ISA.Json/ConverterOptions.fs
+++ b/src/ISA/ISA.Json/ConverterOptions.fs
@@ -3,15 +3,9 @@
 type ConverterOptions() = 
 
     let mutable setID = false
-    let mutable includeType = false
-    let mutable includeContext = false
-    let mutable isRoCrate = false
+    let mutable isJsonLD = false
 
     member this.SetID with get() = setID
                       and set(setId) = setID <- setId
-    member this.IncludeType with get() = includeType
-                            and set(iT) = includeType <- iT
-    member this.IncludeContext with get() = includeContext
-                               and set(iC) = includeContext <- iC
-    member this.IsRoCrate with get() = isRoCrate
-                          and set(iR) = isRoCrate <- iR
+    member this.IsJsonLD with get() = isJsonLD
+                            and set(iJ) = isJsonLD <- iJ

--- a/src/ISA/ISA.Json/Data.fs
+++ b/src/ISA/ISA.Json/Data.fs
@@ -72,6 +72,8 @@ module Data =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (m:Data) = 
         encoder (ConverterOptions()) m
@@ -133,6 +135,8 @@ module Source =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (m:Source) = 
         encoder (ConverterOptions()) m
@@ -193,11 +197,12 @@ module Sample =
                 FactorValues = get.Optional.Field "factorValues" (Decode.list (FactorValue.decoder options))
                 DerivesFrom = get.Optional.Field "derivesFrom" (Decode.list (Source.decoder options))
             }
-            
         )
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (m:Sample) = 
         encoder (ConverterOptions()) m

--- a/src/ISA/ISA.Json/Data.fs
+++ b/src/ISA/ISA.Json/Data.fs
@@ -46,12 +46,12 @@ module Data =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [Encode.string "Data"; Encode.string "ArcData"])
+            if options.IsJsonLD then 
+                "@type", (Encode.list [Encode.string "Data"])
             GEncode.tryInclude "name" Encode.string (oa.Name)
             GEncode.tryInclude "type" (DataFile.encoder options) (oa.DataType)
             GEncode.tryIncludeList "comments" (Comment.encoder options) (oa.Comments)
-            if options.IncludeContext then
+            if options.IsJsonLD then
                 "@context", ROCrateContext.Data.context_jsonvalue
         ]
         |> GEncode.choose
@@ -79,10 +79,10 @@ module Data =
     
     /// exports in json-ld format
     let toJsonldString (d:Data) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) d
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) d
         |> GEncode.toJsonString 2
     let toJsonldStringWithContext (a:Data) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 
@@ -108,11 +108,11 @@ module Source =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [ Encode.string "Source"; Encode.string "ArcSource"])
+            if options.IsJsonLD then 
+                "@type", (Encode.list [ Encode.string "Source"])
             GEncode.tryInclude "name" Encode.string (oa.Name)
             GEncode.tryIncludeList "characteristics" (MaterialAttributeValue.encoder options) (oa.Characteristics)      
-            if options.IncludeContext then
+            if options.IsJsonLD then
                 "@context", ROCrateContext.Source.context_jsonvalue
             ]
         |> GEncode.choose
@@ -140,11 +140,11 @@ module Source =
     
     /// exports in json-ld format
     let toJsonldString (s:Source) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) s
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) s
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:Source) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 
@@ -169,13 +169,14 @@ module Sample =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [ Encode.string "Sample";  Encode.string "ArcSample"])
+            if options.IsJsonLD then 
+                "@type", (Encode.list [ Encode.string "Sample"])
             GEncode.tryInclude "name" Encode.string (oa.Name)
             GEncode.tryIncludeList "characteristics" (MaterialAttributeValue.encoder options) (oa.Characteristics)
             GEncode.tryIncludeList "factorValues" (FactorValue.encoder options) (oa.FactorValues)
-            GEncode.tryIncludeList "derivesFrom" (Source.encoder options) (oa.DerivesFrom)
-            if options.IncludeContext then
+            if not options.IsJsonLD then 
+                GEncode.tryIncludeList "derivesFrom" (Source.encoder options) (oa.DerivesFrom)
+            if options.IsJsonLD then
                 "@context", ROCrateContext.Sample.context_jsonvalue
         ]
         |> GEncode.choose
@@ -204,11 +205,11 @@ module Sample =
     
     /// exports in json-ld format
     let toJsonldString (s:Sample) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) s
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) s
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:Sample) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 

--- a/src/ISA/ISA.Json/Factor.fs
+++ b/src/ISA/ISA.Json/Factor.fs
@@ -41,7 +41,9 @@ module Value =
 
 
     let fromJsonString (s:string) = 
-        GDecode.fromJsonString (decoder (ConverterOptions())) s        
+        GDecode.fromJsonString (decoder (ConverterOptions())) s   
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s     
 
     let toJsonString (v:Value) = 
         encoder (ConverterOptions()) v
@@ -98,6 +100,8 @@ module Factor =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (f:Factor) = 
         encoder (ConverterOptions()) f
@@ -169,6 +173,8 @@ module FactorValue =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (f:FactorValue) = 
         encoder (ConverterOptions()) f

--- a/src/ISA/ISA.Json/Factor.fs
+++ b/src/ISA/ISA.Json/Factor.fs
@@ -69,12 +69,18 @@ module Factor =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [Encode.string "Factor"; Encode.string "ArcFactor"])
+            if options.IsJsonLD then 
+                "@type", (Encode.list [Encode.string "Factor"])
             GEncode.tryInclude "factorName" Encode.string (oa.Name)
-            GEncode.tryInclude "factorType" (OntologyAnnotation.encoder options) (oa.FactorType)
+            if options.IsJsonLD then
+                if oa.FactorType.IsSome then
+                    GEncode.tryInclude "annotationValue" Encode.string (oa.Name)
+                    GEncode.tryInclude "termSource" Encode.string (oa.FactorType.Value.TermSourceREF)
+                    GEncode.tryInclude "termAccession" Encode.string (oa.FactorType.Value.TermAccessionNumber)
+            else
+                GEncode.tryInclude "factorType" (OntologyAnnotation.encoder options) (oa.FactorType)
             GEncode.tryIncludeArray "comments" (Comment.encoder options) (oa.Comments)
-            if options.IncludeContext then
+            if options.IsJsonLD then
                 "@context", ROCrateContext.Factor.context_jsonvalue
         ]
         |> GEncode.choose
@@ -99,11 +105,11 @@ module Factor =
     
     /// exports in json-ld format
     let toJsonldString (f:Factor) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) f
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) f
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:Factor) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 
@@ -127,12 +133,25 @@ module FactorValue =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [Encode.string "FactorValue"; Encode.string "ArcFactorValue"])
-            GEncode.tryInclude "category" (Factor.encoder options) (oa.Category)
-            GEncode.tryInclude "value" (Value.encoder options) (oa.Value)
-            GEncode.tryInclude "unit" (OntologyAnnotation.encoder options) (oa.Unit)
-            if options.IncludeContext then
+            if options.IsJsonLD then 
+                "@type", (Encode.list [Encode.string "FactorValue"])
+            if options.IsJsonLD then
+                if oa.Category.IsSome then
+                    GEncode.tryInclude "categoryName" Encode.string (oa.Category.Value.Name)
+                if oa.Category.IsSome && oa.Category.Value.FactorType.IsSome then
+                    GEncode.tryInclude "category" Encode.string (oa.Category.Value.FactorType.Value.Name)
+                if oa.Category.IsSome && oa.Category.Value.FactorType.IsSome then
+                    GEncode.tryInclude "categoryCode" Encode.string (oa.Category.Value.FactorType.Value.TermAccessionNumber)
+                if oa.Value.IsSome then "value", Encode.string (oa.ValueText)
+                if oa.Value.IsSome && oa.Value.Value.IsAnOntology then
+                    GEncode.tryInclude "valueCode" Encode.string (oa.Value.Value.AsOntology()).TermAccessionNumber
+                if oa.Unit.IsSome then GEncode.tryInclude "unit" Encode.string (oa.Unit.Value.Name)
+                if oa.Unit.IsSome then GEncode.tryInclude "unitCode" Encode.string (oa.Unit.Value.TermAccessionNumber)
+            else
+                GEncode.tryInclude "category" (Factor.encoder options) (oa.Category)
+                GEncode.tryInclude "value" (Value.encoder options) (oa.Value)
+                GEncode.tryInclude "unit" (OntologyAnnotation.encoder options) (oa.Unit)
+            if options.IsJsonLD then
                 "@context", ROCrateContext.FactorValue.context_jsonvalue
         ]
         |> GEncode.choose
@@ -157,11 +176,11 @@ module FactorValue =
     
     /// exports in json-ld format
     let toJsonldString (f:FactorValue) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) f
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) f
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:FactorValue) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 

--- a/src/ISA/ISA.Json/Investigation.fs
+++ b/src/ISA/ISA.Json/Investigation.fs
@@ -81,6 +81,8 @@ module Investigation =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (p:Investigation) = 
         encoder (ConverterOptions()) p

--- a/src/ISA/ISA.Json/Investigation.fs
+++ b/src/ISA/ISA.Json/Investigation.fs
@@ -25,7 +25,7 @@ module Investigation =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
+            if options.IsJsonLD then 
                 "@type", Encode.string "Investigation"
             GEncode.tryInclude "filename" Encode.string (oa.FileName)
             GEncode.tryInclude "identifier" Encode.string (oa.Identifier)
@@ -33,12 +33,13 @@ module Investigation =
             GEncode.tryInclude "description" Encode.string (oa.Description)
             GEncode.tryInclude "submissionDate" Encode.string (oa.SubmissionDate)
             GEncode.tryInclude "publicReleaseDate" Encode.string (oa.PublicReleaseDate)
-            GEncode.tryIncludeList "ontologySourceReferences" (OntologySourceReference.encoder options) (oa.OntologySourceReferences)
+            if not options.IsJsonLD then
+                GEncode.tryIncludeList "ontologySourceReferences" (OntologySourceReference.encoder options) (oa.OntologySourceReferences)
             GEncode.tryIncludeList "publications" (Publication.encoder options) (oa.Publications)
             GEncode.tryIncludeList "people" (Person.encoder options) (oa.Contacts)
             GEncode.tryIncludeList "studies" (Study.encoder options) (oa.Studies)
             GEncode.tryIncludeList "comments" (Comment.encoder options) (oa.Comments)
-            if options.IncludeContext then
+            if options.IsJsonLD then
                 "@context", ROCrateContext.Investigation.context_jsonvalue
         ]
         |> GEncode.choose
@@ -50,7 +51,7 @@ module Investigation =
             GEncode.tryInclude "@id" Encode.string (Some "ro-crate-metadata.json")
             GEncode.tryInclude "about" (encoder options) (Some oa)
             "conformsTo", ROCrateContext.ROCrate.conformsTo_jsonvalue
-            if options.IncludeContext then
+            if options.IsJsonLD then
                 "@context", ROCrateContext.ROCrate.context_jsonvalue
             ]
         |> GEncode.choose
@@ -87,13 +88,13 @@ module Investigation =
 
     /// exports in json-ld format
     let toJsonldString (i:Investigation) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) i
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) i
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (i:Investigation) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) i
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) i
         |> GEncode.toJsonString 2
 
     let toRoCrateString (i:Investigation) = 
-        encodeRoCrate (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true,IsRoCrate=true)) i
+        encodeRoCrate (ConverterOptions(SetID=true,IsJsonLD=true)) i
         |> GEncode.toJsonString 2

--- a/src/ISA/ISA.Json/Material.fs
+++ b/src/ISA/ISA.Json/Material.fs
@@ -65,6 +65,8 @@ module MaterialAttribute =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (m:MaterialAttribute) = 
         encoder (ConverterOptions()) m
@@ -133,6 +135,8 @@ module MaterialAttributeValue =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (m:MaterialAttributeValue) = 
         encoder (ConverterOptions()) m
@@ -197,6 +201,8 @@ module Material =
         
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (m:Material) = 
         encoder (ConverterOptions()) m

--- a/src/ISA/ISA.Json/Material.fs
+++ b/src/ISA/ISA.Json/Material.fs
@@ -36,19 +36,24 @@ module MaterialAttribute =
             | None -> "#EmptyMaterialAttribute"
 
     let encoder (options : ConverterOptions) (oa : MaterialAttribute) = 
-        [
-            if options.SetID then 
-                "@id", Encode.string (oa |> genID)
-            else 
-                GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [Encode.string "MaterialAttribute"; Encode.string "ArcMaterialAttribute"])
-            GEncode.tryInclude "characteristicType" (OntologyAnnotation.encoder options) (oa.CharacteristicType)
-            if options.IncludeContext then
-                "@context", ROCrateContext.MaterialAttribute.context_jsonvalue
-        ]
-        |> GEncode.choose
-        |> Encode.object
+        if options.IsJsonLD then
+            match oa.CharacteristicType with
+            | Some t -> OntologyAnnotation.encoder options t
+            | None -> [] |> GEncode.choose |> Encode.object
+        else
+            [
+                if options.SetID then 
+                    "@id", Encode.string (oa |> genID)
+                else 
+                    GEncode.tryInclude "@id" Encode.string (oa.ID)
+                if options.IsJsonLD then 
+                    "@type", (Encode.list [Encode.string "MaterialAttribute"])
+                GEncode.tryInclude "characteristicType" (OntologyAnnotation.encoder options) (oa.CharacteristicType)
+                if options.IsJsonLD then
+                    "@context", ROCrateContext.MaterialAttribute.context_jsonvalue
+            ]
+            |> GEncode.choose
+            |> Encode.object
 
     let decoder (options : ConverterOptions) : Decoder<MaterialAttribute> =
         Decode.object (fun get ->
@@ -67,11 +72,11 @@ module MaterialAttribute =
     
     /// exports in json-ld format
     let toJsonldString (m:MaterialAttribute) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) m
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) m
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:MaterialAttribute) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 
@@ -94,12 +99,23 @@ module MaterialAttributeValue =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [Encode.string "MaterialAttributeValue"; Encode.string "ArcMaterialAttributeValue"])
-            GEncode.tryInclude "category" (MaterialAttribute.encoder options) (oa.Category)
-            GEncode.tryInclude "value" (Value.encoder options) (oa.Value)
-            GEncode.tryInclude "unit" (OntologyAnnotation.encoder options) (oa.Unit)
-            if options.IncludeContext then 
+            if options.IsJsonLD then 
+                "@type", (Encode.list [Encode.string "MaterialAttributeValue"])
+            if options.IsJsonLD then
+                if oa.Category.IsSome && oa.Category.Value.CharacteristicType.IsSome then
+                    GEncode.tryInclude "category" Encode.string (oa.Category.Value.CharacteristicType.Value.Name)
+                if oa.Category.IsSome && oa.Category.Value.CharacteristicType.IsSome then
+                    GEncode.tryInclude "categoryCode" Encode.string (oa.Category.Value.CharacteristicType.Value.TermAccessionNumber)
+                if oa.Value.IsSome then "value", Encode.string (oa.ValueText)
+                if oa.Value.IsSome && oa.Value.Value.IsAnOntology then
+                    GEncode.tryInclude "valueCode" Encode.string (oa.Value.Value.AsOntology()).TermAccessionNumber
+                if oa.Unit.IsSome then GEncode.tryInclude "unit" Encode.string (oa.Unit.Value.Name)
+                if oa.Unit.IsSome then GEncode.tryInclude "unitCode" Encode.string (oa.Unit.Value.TermAccessionNumber)
+            else
+                GEncode.tryInclude "category" (MaterialAttribute.encoder options) (oa.Category)
+                GEncode.tryInclude "value" (Value.encoder options) (oa.Value)
+                GEncode.tryInclude "unit" (OntologyAnnotation.encoder options) (oa.Unit)
+            if options.IsJsonLD then 
                 "@context", ROCrateContext.MaterialAttributeValue.context_jsonvalue
         ]
         |> GEncode.choose
@@ -124,11 +140,11 @@ module MaterialAttributeValue =
     
     /// exports in json-ld format
     let toJsonldString (m:MaterialAttributeValue) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) m
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) m
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:MaterialAttributeValue) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 
@@ -154,13 +170,13 @@ module Material =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [Encode.string "Material"; Encode.string "ArcMaterial"])
+            if options.IsJsonLD then 
+                "@type", (Encode.list [Encode.string "Material"])
             GEncode.tryInclude "name" Encode.string (oa.Name)
             GEncode.tryInclude "type" (MaterialType.encoder options) (oa.MaterialType)
             GEncode.tryIncludeList "characteristics" (MaterialAttributeValue.encoder options) (oa.Characteristics)
             GEncode.tryIncludeList "derivesFrom" (encoder options) (oa.DerivesFrom)
-            if options.IncludeContext then 
+            if options.IsJsonLD then 
                 "@context", ROCrateContext.Material.context_jsonvalue
         ]
         |> GEncode.choose
@@ -188,11 +204,11 @@ module Material =
     
     /// exports in json-ld format
     let toJsonldString (m:Material) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) m
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) m
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:Material) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 

--- a/src/ISA/ISA.Json/Ontology.fs
+++ b/src/ISA/ISA.Json/Ontology.fs
@@ -67,7 +67,9 @@ module OntologySourceReference =
         )
 
     let fromJsonString (s:string) = 
-        GDecode.fromJsonString (decoder (ConverterOptions())) s        
+        GDecode.fromJsonString (decoder (ConverterOptions())) s  
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s      
 
     let toJsonString (oa:OntologySourceReference) = 
         encoder (ConverterOptions()) oa
@@ -159,7 +161,9 @@ module OntologyAnnotation =
         )
 
     let fromJsonString (s:string) = 
-        GDecode.fromJsonString (decoder (ConverterOptions())) s        
+        GDecode.fromJsonString (decoder (ConverterOptions())) s      
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s  
 
     let toJsonString (oa:OntologyAnnotation) = 
         encoder (ConverterOptions()) oa

--- a/src/ISA/ISA.Json/Ontology.fs
+++ b/src/ISA/ISA.Json/Ontology.fs
@@ -42,14 +42,14 @@ module OntologySourceReference =
         [
             if options.SetID then 
                 "@id", Encode.string (osr |> genID)
-            if options.IncludeType then 
+            if options.IsJsonLD then 
                 "@type", Encode.string "OntologySourceReference"
             GEncode.tryInclude "description" Encode.string (osr.Description)
             GEncode.tryInclude "file" Encode.string (osr.File)
             GEncode.tryInclude "name" Encode.string (osr.Name)
             GEncode.tryInclude "version" Encode.string (osr.Version)
             GEncode.tryIncludeArray "comments" (Comment.encoder options) (osr.Comments)
-            if options.IncludeContext then
+            if options.IsJsonLD then
                 "@context", ROCrateContext.OntologySourceReference.context_jsonvalue
         ]
         |> GEncode.choose
@@ -75,11 +75,11 @@ module OntologySourceReference =
 
     /// exports in json-ld format
     let toJsonldString (oa:OntologySourceReference) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) oa
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) oa
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:OntologySourceReference) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     // let fromFile (path : string) = 
@@ -108,13 +108,13 @@ module OntologyAnnotation =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
+            if options.IsJsonLD then 
                 "@type", Encode.string "OntologyAnnotation"
             GEncode.tryInclude "annotationValue" Encode.string (oa.Name)
             GEncode.tryInclude "termSource" Encode.string (oa.TermSourceREF)
             GEncode.tryInclude "termAccession" Encode.string (oa.TermAccessionNumber)
             GEncode.tryIncludeArray "comments" (Comment.encoder options) (oa.Comments)
-            if options.IncludeContext then
+            if options.IsJsonLD then
                 "@context", ROCrateContext.OntologyAnnotation.context_jsonvalue
         ]
         |> GEncode.choose
@@ -137,7 +137,7 @@ module OntologyAnnotation =
         [
             if options.SetID then "@id", Encode.string (oa |> genID)
                 else GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then "@type", Encode.string "OntologyAnnotation"
+            if options.IsJsonLD then "@type", Encode.string "OntologyAnnotation"
             GEncode.tryInclude "a" (StringTable.encodeString stringTable) (oa.Name)
             GEncode.tryInclude "ts" (StringTable.encodeString stringTable) (oa.TermSourceREF)
             GEncode.tryInclude "ta" (StringTable.encodeString stringTable) (oa.TermAccessionNumber)
@@ -167,11 +167,11 @@ module OntologyAnnotation =
     
     /// exports in json-ld format
     let toJsonldString (oa:OntologyAnnotation) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) oa
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) oa
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:OntologyAnnotation) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 

--- a/src/ISA/ISA.Json/Person.fs
+++ b/src/ISA/ISA.Json/Person.fs
@@ -41,6 +41,14 @@ module Person =
             |> Encode.object
         else
             Encode.string affiliation
+    
+    let affiliationDecoder (options : ConverterOptions) : Decoder<string> =
+        if options.IsJsonLD then
+            Decode.object (fun get ->
+                get.Required.Field "name" Decode.string
+            ) 
+        else
+            Decode.string
 
 
     let rec encoder (options : ConverterOptions) (oa : Person) = 
@@ -82,7 +90,7 @@ module Person =
                 Phone = get.Optional.Field "phone" Decode.string
                 Fax = get.Optional.Field "fax" Decode.string
                 Address = get.Optional.Field "address" Decode.string
-                Affiliation = get.Optional.Field "affiliation" Decode.string
+                Affiliation = get.Optional.Field "affiliation" (affiliationDecoder options)
                 Roles = get.Optional.Field "roles" (Decode.array (OntologyAnnotation.decoder options))
                 Comments = get.Optional.Field "comments" (Decode.array (Comment.decoder options))
             }
@@ -92,6 +100,9 @@ module Person =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (p:Person) = 
         encoder (ConverterOptions()) p

--- a/src/ISA/ISA.Json/Person.fs
+++ b/src/ISA/ISA.Json/Person.fs
@@ -29,12 +29,13 @@ module Person =
                                 | _ -> "#EmptyPerson"
 
     let affiliationEncoder (options : ConverterOptions) (affiliation : string) =
-        if options.IsRoCrate then
+        if options.IsJsonLD then
+            let idStr = $"#Organization_{affiliation}"
             [
                 ("@type",Encode.string "Organization")
-                ("@id",Encode.string $"Organization/{affiliation}")
+                ("@id",Encode.string (idStr.Replace(" ","_")))
                 ("name",Encode.string affiliation)               
-                if options.IncludeContext then
+                if options.IsJsonLD then
                     "@context", ROCrateContext.Organization.context_jsonvalue
             ]
             |> Encode.object
@@ -49,7 +50,7 @@ module Person =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
+            if options.IsJsonLD then 
                 "@type", Encode.string "Person"
             GEncode.tryInclude "firstName" Encode.string (oa.FirstName)
             GEncode.tryInclude "lastName" Encode.string (oa.LastName)
@@ -61,7 +62,7 @@ module Person =
             GEncode.tryInclude "affiliation" (affiliationEncoder options) (oa.Affiliation)
             GEncode.tryIncludeArray "roles" (OntologyAnnotation.encoder options) (oa.Roles)
             GEncode.tryIncludeArray "comments" (Comment.encoder options) (oa.Comments)
-            if options.IncludeContext then 
+            if options.IsJsonLD then 
                 "@context", ROCrateContext.Person.context_jsonvalue
         ]
         |> GEncode.choose
@@ -98,11 +99,11 @@ module Person =
 
     /// exports in json-ld format
     let toJsonldString (p:Person) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) p
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) p
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:Person) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 

--- a/src/ISA/ISA.Json/Process.fs
+++ b/src/ISA/ISA.Json/Process.fs
@@ -54,16 +54,55 @@ module ProcessParameterValue =
         |> Encode.object
 
     let decoder (options : ConverterOptions) : Decoder<ProcessParameterValue> =
-        Decode.object (fun get ->
-            {
-                Category = get.Optional.Field "category" (ProtocolParameter.decoder options)
-                Value = get.Optional.Field "value" (Value.decoder options)
-                Unit = get.Optional.Field "unit" (OntologyAnnotation.decoder options)
-            }
-        )
+        if not options.IsJsonLD then
+            Decode.object (fun get ->
+                {
+                    Category = get.Optional.Field "category" (ProtocolParameter.decoder options)
+                    Value = get.Optional.Field "value" (Value.decoder options)
+                    Unit = get.Optional.Field "unit" (OntologyAnnotation.decoder options)
+                }
+            )
+        else
+            Decode.object (fun get ->
+                let categoryName = get.Optional.Field "category" (Decode.string)
+                let categoryCode = get.Optional.Field "categoryCode" (Decode.string)
+                let category =
+                    match categoryName,categoryCode with
+                    | None,None -> None
+                    | _ -> Some (ProtocolParameter.make None (Some (OntologyAnnotation.make None categoryName None categoryCode None)))
+                let valueName = get.Optional.Field "value" (Value.decoder options)
+                let valueCode = get.Optional.Field "valueCode" (Decode.string)
+                let value =
+                    match valueName,valueCode with
+                    | Some (Value.Name name), Some code ->
+                        let oa = OntologyAnnotation.make None (Some name) None (Some (URI.fromString code)) None
+                        let vo = Value.Ontology(oa)
+                        Some vo
+                    | None, Some code ->
+                        let oa = OntologyAnnotation.make None None None (Some (URI.fromString code)) None
+                        let vo = Value.Ontology(oa)
+                        Some vo
+                    | Some (Value.Name name), None -> valueName
+                    | Some (Value.Float name), None -> valueName
+                    | Some (Value.Int name), None -> valueName
+                    | _ -> None
+                let unitName = get.Optional.Field "unit" (Decode.string)
+                let unitCode = get.Optional.Field "unitCode" (Decode.string)
+                let unit = 
+                    match unitName,unitCode with
+                    | None,None -> None
+                    | _ -> Some (OntologyAnnotation.make None unitName None unitCode None)
+                {
+                    Category = category
+                    Value = value
+                    Unit = unit
+                }
+            )
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (p:ProcessParameterValue) = 
         encoder (ConverterOptions()) p
@@ -120,6 +159,8 @@ module ProcessInput =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (m:ProcessInput) = 
         encoder (ConverterOptions()) m
@@ -169,6 +210,8 @@ module ProcessOutput =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (m:ProcessOutput) = 
         encoder (ConverterOptions()) m
@@ -239,6 +282,8 @@ module Process =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (p:Process) = 
         encoder (ConverterOptions()) None None p

--- a/src/ISA/ISA.Json/Publication.fs
+++ b/src/ISA/ISA.Json/Publication.fs
@@ -20,7 +20,7 @@ module Publication =
         [
             if options.SetID then 
                 "@id", Encode.string (oa |> genID)
-            if options.IncludeType then 
+            if options.IsJsonLD then 
                 "@type", Encode.string "Publication"
             GEncode.tryInclude "pubMedID" Encode.string (oa.PubMedID)
             GEncode.tryInclude "doi" Encode.string (oa.DOI)
@@ -28,7 +28,7 @@ module Publication =
             GEncode.tryInclude "title" Encode.string (oa.Title)
             GEncode.tryInclude "status" (OntologyAnnotation.encoder options) (oa.Status)
             GEncode.tryIncludeArray "comments" (Comment.encoder options) (oa.Comments)
-            if options.IncludeContext then 
+            if options.IsJsonLD then 
                 "@context", ROCrateContext.Publication.context_jsonvalue
         ]
         |> GEncode.choose
@@ -58,11 +58,11 @@ module Publication =
 
     /// exports in json-ld format
     let toJsonldString (p:Publication) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) p
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) p
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:Publication) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2
 
     //let fromFile (path : string) = 

--- a/src/ISA/ISA.Json/Publication.fs
+++ b/src/ISA/ISA.Json/Publication.fs
@@ -51,6 +51,8 @@ module Publication =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (p:Publication) = 
         encoder (ConverterOptions()) p

--- a/src/ISA/ISA.Json/Study.fs
+++ b/src/ISA/ISA.Json/Study.fs
@@ -34,7 +34,7 @@ module Study =
         match s.ID with
         | Some id -> URI.toString id
         | None -> match s.FileName with
-                  | Some n -> n.Replace(" ","_").Remove(0,1 + (max (n.LastIndexOf('/')) (n.LastIndexOf('\\'))))
+                  | Some n -> n.Replace(" ","_")//.Remove(0,1 + (max (n.LastIndexOf('/')) (n.LastIndexOf('\\'))))
                   | None -> match s.Identifier with
                             | Some id -> "#Study_" + id.Replace(" ","_")
                             | None -> match s.Title with
@@ -47,8 +47,8 @@ module Study =
                 "@id", Encode.string (oa |> genID)
             else 
                 GEncode.tryInclude "@id" Encode.string (oa.ID)
-            if options.IncludeType then 
-                "@type", (Encode.list [Encode.string "Study"; Encode.string "ArcStudy"])
+            if options.IsJsonLD then 
+                "@type", (Encode.list [Encode.string "Study"])
             GEncode.tryInclude "filename" Encode.string (oa.FileName)
             GEncode.tryInclude "identifier" Encode.string (oa.Identifier)
             GEncode.tryInclude "title" Encode.string (oa.Title)
@@ -57,26 +57,24 @@ module Study =
             GEncode.tryInclude "publicReleaseDate" Encode.string (oa.PublicReleaseDate)
             GEncode.tryIncludeList "publications" (Publication.encoder options) (oa.Publications)
             GEncode.tryIncludeList "people" (Person.encoder options) (oa.Contacts)
-            GEncode.tryIncludeList "studyDesignDescriptors" (OntologyAnnotation.encoder options) (oa.StudyDesignDescriptors)
-            if not options.IsRoCrate then 
+            if not options.IsJsonLD then
+                GEncode.tryIncludeList "studyDesignDescriptors" (OntologyAnnotation.encoder options) (oa.StudyDesignDescriptors) 
                 GEncode.tryIncludeList "protocols" (Protocol.encoder options None None None) (oa.Protocols)
-            if options.IsRoCrate then
-                match oa.Materials with
-                | Some m -> 
-                    GEncode.tryIncludeList "samples" (Sample.encoder options) (m.Samples)
-                    GEncode.tryIncludeList "sources" (Source.encoder options) (m.Sources)
-                    GEncode.tryIncludeList "materials" (Material.encoder options) (m.OtherMaterials)
-                | None -> ()
-            
-            if not options.IsRoCrate then 
                 GEncode.tryInclude "materials" (StudyMaterials.encoder options) (oa.Materials)
+                GEncode.tryIncludeList "factors" (Factor.encoder options) (oa.Factors)
+                GEncode.tryIncludeList "characteristicCategories" (MaterialAttribute.encoder options) (oa.CharacteristicCategories)            
+                GEncode.tryIncludeList "unitCategories" (OntologyAnnotation.encoder options) (oa.UnitCategories)
+            // if options.IsJsonLD then
+            //     match oa.Materials with
+            //     | Some m -> 
+            //         GEncode.tryIncludeList "samples" (Sample.encoder options) (m.Samples)
+            //         GEncode.tryIncludeList "sources" (Source.encoder options) (m.Sources)
+            //         GEncode.tryIncludeList "materials" (Material.encoder options) (m.OtherMaterials)
+            //     | None -> ()
             GEncode.tryIncludeList "processSequence" (Process.encoder options oa.Identifier None) (oa.ProcessSequence)
             GEncode.tryIncludeList "assays" (Assay.encoder options oa.Identifier) (oa.Assays)            
-            GEncode.tryIncludeList "factors" (Factor.encoder options) (oa.Factors)
-            GEncode.tryIncludeList "characteristicCategories" (MaterialAttribute.encoder options) (oa.CharacteristicCategories)            
-            GEncode.tryIncludeList "unitCategories" (OntologyAnnotation.encoder options) (oa.UnitCategories)
             GEncode.tryIncludeList "comments" (Comment.encoder options) (oa.Comments)
-            if options.IncludeContext then 
+            if options.IsJsonLD then 
                 "@context", ROCrateContext.Study.context_jsonvalue
         ]
         |> GEncode.choose
@@ -117,9 +115,9 @@ module Study =
 
     /// exports in json-ld format
     let toJsonldString (s:Study) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true)) s
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) s
         |> GEncode.toJsonString 2
 
     let toJsonldStringWithContext (a:Study) = 
-        encoder (ConverterOptions(SetID=true,IncludeType=true,IncludeContext=true)) a
+        encoder (ConverterOptions(SetID=true,IsJsonLD=true)) a
         |> GEncode.toJsonString 2

--- a/src/ISA/ISA.Json/Study.fs
+++ b/src/ISA/ISA.Json/Study.fs
@@ -108,6 +108,8 @@ module Study =
 
     let fromJsonString (s:string) = 
         GDecode.fromJsonString (decoder (ConverterOptions())) s
+    let fromJsonldString (s:string) = 
+        GDecode.fromJsonString (decoder (ConverterOptions(IsJsonLD=true))) s
 
     let toJsonString (p:Study) = 
         encoder (ConverterOptions()) p

--- a/src/ISA/ISA.Json/context/rocrate/isa_assay_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_assay_context.fs
@@ -29,24 +29,17 @@ module Assay =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "Assay", Encode.string "sdo:Dataset"
-      "ArcAssay", Encode.string "arc:ARC#ARC_00000042"
 
       "measurementType", Encode.string "sdo:variableMeasured"
       "technologyType", Encode.string "sdo:measurementTechnique"
       "technologyPlatform", Encode.string "sdo:instrument"
       "dataFiles", Encode.string "sdo:hasPart"
 
-      "materials", Encode.string "arc:ARC#ARC_00000074"
-      "otherMaterials", Encode.string "arc:ARC#ARC_00000074"
-      "samples", Encode.string "arc:ARC#ARC_00000074"
-      "characteristicCategories", Encode.string "arc:ARC#ARC_00000049"
-      "processSequences", Encode.string "arc:ARC#ARC_00000047"
-      "unitCategories", Encode.string "arc:ARC#ARC_00000051"
+      "processSequences", Encode.string "sdo:about"
 
-      "comments", Encode.string "sdo:disambiguatingDescription"
+      "comments", Encode.string "sdo:comment"
       "filename", Encode.string "sdo:url"
     ]
 
@@ -55,22 +48,15 @@ module Assay =
 {
   "@context": {
     "sdo": "https://schema.org/",
-    "arc": "http://purl.org/nfdi4plants/ontology/",
 
     "Assay": "sdo:Dataset",
-    "ArcAssay": "arc:ARC#ARC_00000042",
 
     "measurementType": "sdo:variableMeasured",
     "technologyType": "sdo:measurementTechnique",
     "technologyPlatform": "sdo:instrument",
     "dataFiles": "sdo:hasPart",
 
-    "materials": "arc:ARC#ARC_00000074",
-    "otherMaterials": "arc:ARC#ARC_00000074",
-    "samples": "arc:ARC#ARC_00000074",
-    "characteristicCategories": "arc:ARC#ARC_00000049",
-    "processSequences": "arc:ARC#ARC_00000047",
-    "unitCategories": "arc:ARC#ARC_00000051",
+    "processSequences": "sdo:about",
 
     "comments": "sdo:disambiguatingDescription",
     "filename": "sdo:url"

--- a/src/ISA/ISA.Json/context/rocrate/isa_comment_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_comment_context.fs
@@ -16,7 +16,6 @@ module Comment =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
     
       "Comment", Encode.string "sdo:Comment"
       "name", Encode.string "sdo:name"
@@ -28,7 +27,6 @@ module Comment =
 {
   "@context": {
     "sdo": "http://schema.org/",
-    "arc": "http://purl.org/nfdi4plants/ontology/",
     
     "Comment": "sdo:Comment",
     "name": "sdo:name",

--- a/src/ISA/ISA.Json/context/rocrate/isa_component_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_component_context.fs
@@ -16,13 +16,15 @@ module Component =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
     
-      "Component", Encode.string "sdo:Thing"
-      "ArcComponent", Encode.string "arc:ARC#ARC_00000065"
+      "Component", Encode.string "sdo:PropertyValue"
 
-      "componentName", Encode.string "arc:ARC#ARC_00000019"
-      "componentType", Encode.string "arc:ARC#ARC_00000102"
+      "category", Encode.string "sdo:name"
+      "categoryCode", Encode.string "sdo:propertyID"
+      "value", Encode.string "sdo:value"
+      "valueCode", Encode.string "sdo:valueReference"
+      "unit", Encode.string "sdo:unitText"
+      "unitCode", Encode.string "sdo:unitCode"
     ]
 
   let context_str =
@@ -30,12 +32,10 @@ module Component =
 {
   "@context": {
     "sdo": "http://schema.org/",
-    "arc": "http://purl.org/nfdi4plants/ontology/",
     
-    "Component": "sdo:Thing",
-    "ArcComponent": "arc:ARC#ARC_00000065",
+    "Component": "sdo:PropertyValue",
 
-    "componentName": "arc:ARC#ARC_00000019",
+    "componentName": "sdo",
     "componentType": "arc:ARC#ARC_00000102"
   }
 }

--- a/src/ISA/ISA.Json/context/rocrate/isa_data_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_data_context.fs
@@ -18,15 +18,13 @@ module Data =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "Data", Encode.string "sdo:MediaObject"
-      "ArcData", Encode.string "arc:ARC#ARC_00000076"
 
-      "type", Encode.string "arc:ARC#ARC_00000107"
+      "type", Encode.string "sdo:disambiguatingDescription"
 
       "name", Encode.string "sdo:name"
-      "comments", Encode.string "sdo:disambiguatingDescription"
+      "comments", Encode.string "sdo:comment"
     ]
 
   let context_str =

--- a/src/ISA/ISA.Json/context/rocrate/isa_factor_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_factor_context.fs
@@ -18,14 +18,13 @@ module Factor =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
-      "Factor", Encode.string "sdo:Thing"
-      "ArcFactor", Encode.string "arc:ARC#ARC_00000044"
+      "Factor", Encode.string "sdo:DefinedTerm"
 
-      "factorName", Encode.string "arc:ARC#ARC_00000019"
-      "factorType", Encode.string "arc:ARC#ARC_00000078"
-
+      "factorName", Encode.string "sdo:name"
+      "annotationValue", Encode.string "sdo:name"
+      "termSource", Encode.string "sdo:inDefinedTermSet"
+      "termAccession", Encode.string "sdo:termCode"
       "comments", Encode.string "sdo:disambiguatingDescription"
     ]
 

--- a/src/ISA/ISA.Json/context/rocrate/isa_factor_value_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_factor_value_context.fs
@@ -18,14 +18,16 @@ module FactorValue =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "FactorValue", Encode.string "sdo:PropertyValue"
-      "ArcFactorValue", Encode.string "arc:ARC#ARC_00000084"
 
-      "category", Encode.string "arc:category"
-      "value", Encode.string "arc:ARC#ARC_00000044"
-      "unit", Encode.string "arc:ARC#ARC_00000106"
+      "category", Encode.string "sdo:name"
+      "categoryName", Encode.string "sdo:alternateName"
+      "categoryCode", Encode.string "sdo:propertyID"
+      "value", Encode.string "sdo:value"
+      "valueCode", Encode.string "sdo:valueReference"
+      "unit", Encode.string "sdo:unitText"
+      "unitCode", Encode.string "sdo:unitCode"
     ]
 
   let context_str =

--- a/src/ISA/ISA.Json/context/rocrate/isa_investigation_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_investigation_context.fs
@@ -28,7 +28,6 @@ module Investigation =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "Investigation", Encode.string "sdo:Dataset"
 
@@ -42,8 +41,6 @@ module Investigation =
       "studies", Encode.string "sdo:hasPart"
       "ontologySourceReferences", Encode.string "sdo:mentions"
       "comments", Encode.string "sdo:disambiguatingDescription"
-
-      "publications?", Encode.string "sdo:subjectOf?"
       "filename", Encode.string "sdo:alternateName"
     ]
 

--- a/src/ISA/ISA.Json/context/rocrate/isa_material_attribute_value_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_material_attribute_value_context.fs
@@ -17,14 +17,15 @@ module MaterialAttributeValue =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "MaterialAttributeValue", Encode.string "sdo:PropertyValue"
-      "ArcMaterialAttributeValue", Encode.string "arc:ARC#ARC_00000079"
 
-      "category", Encode.string "arc:ARC#ARC_00000049"
-      "value", Encode.string "arc:ARC#ARC_00000036"
-      "unit", Encode.string "arc:ARC#ARC_00000106"
+      "category", Encode.string "sdo:name"
+      "categoryCode", Encode.string "sdo:propertyID"
+      "value", Encode.string "sdo:value"
+      "valueCode", Encode.string "sdo:valueReference"
+      "unit", Encode.string "sdo:unitText"
+      "unitCode", Encode.string "sdo:unitCode"
     ]
 
   let context_str =

--- a/src/ISA/ISA.Json/context/rocrate/isa_material_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_material_context.fs
@@ -19,15 +19,13 @@ module Material =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
+      "bio", Encode.string "https://bioschemas.org/"
 
-      "ArcMaterial", Encode.string "arc:ARC#ARC_00000108"
-      "Material", Encode.string "sdo:Thing"
+      "Material", Encode.string "bio:Sample"
 
-      "type", Encode.string "arc:ARC#ARC_00000085"
-      "name", Encode.string "arc:ARC#ARC_00000019"
-      "characteristics", Encode.string "arc:ARC#ARC_00000080"
-      "derivesFrom", Encode.string "arc:ARC#ARC_00000082"
+      "type", Encode.string "sdo:disambiguatingDescription"
+      "name", Encode.string "sdo:name"
+      "characteristics", Encode.string "bio:additionalProperty"
     ]
 
   let context_str =

--- a/src/ISA/ISA.Json/context/rocrate/isa_ontology_annotation_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_ontology_annotation_context.fs
@@ -18,7 +18,6 @@ module OntologyAnnotation =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "OntologyAnnotation", Encode.string "sdo:DefinedTerm"
       

--- a/src/ISA/ISA.Json/context/rocrate/isa_ontology_source_reference_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_ontology_source_reference_context.fs
@@ -20,7 +20,6 @@ module OntologySourceReference =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "OntologySourceReference", Encode.string "sdo:DefinedTermSet"
       

--- a/src/ISA/ISA.Json/context/rocrate/isa_organization_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_organization_context.fs
@@ -16,7 +16,6 @@ module Organization =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "Organization", Encode.string "sdo:Organization"
       

--- a/src/ISA/ISA.Json/context/rocrate/isa_person_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_person_context.fs
@@ -25,7 +25,6 @@ module Person =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "Person", Encode.string "sdo:Person"
       

--- a/src/ISA/ISA.Json/context/rocrate/isa_process_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_process_context.fs
@@ -26,19 +26,17 @@ module Process =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
+      "bio", Encode.string "https://bioschemas.org/"
 
-      "Process", Encode.string "sdo:Thing"
-      "ArcProcess", Encode.string "arc:ARC#ARC_00000048"
+      "Process", Encode.string "bio:LabProcess"
 
-      "name", Encode.string "arc:ARC#ARC_00000019"
-      "executesProtocol", Encode.string "arc:ARC#ARC_00000086"
-      "performer", Encode.string "arc:ARC#ARC_00000089"
-      "date", Encode.string "arc:ARC#ARC_00000090"
-      "previousProcess", Encode.string "arc:ARC#ARC_00000091"
-      "nextProcess", Encode.string "arc:ARC#ARC_00000092"
-      "input", Encode.string "arc:ARC#ARC_00000095"
-      "output", Encode.string "arc:ARC#ARC_00000096"
+      "name", Encode.string "sdo:name"
+      "executesProtocol", Encode.string "bio:executesProtocol"
+      "parameterValues", Encode.string "bio:parameterValues"
+      "performer", Encode.string "sdo:agent"
+      "date", Encode.string "sdo:endTime"
+      "input", Encode.string "sdo:object"
+      "output", Encode.string "sdo:result"
 
       "comments", Encode.string "sdo:disambiguatingDescription"
     ]

--- a/src/ISA/ISA.Json/context/rocrate/isa_process_parameter_value_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_process_parameter_value_context.fs
@@ -18,14 +18,15 @@ module ProcessParameterValue =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "ProcessParameterValue", Encode.string "sdo:PropertyValue"
-      "ArcProcessParameterValue", Encode.string "arc:ARC#ARC_00000088"
 
-      "category", Encode.string "arc:ARC#ARC_00000062"
-      "value", Encode.string "arc:ARC#ARC_00000087"
-      "unit", Encode.string "arc:ARC#ARC_00000106"
+      "category", Encode.string "sdo:name"
+      "categoryCode", Encode.string "sdo:propertyID"
+      "value", Encode.string "sdo:value"
+      "valueCode", Encode.string "sdo:valueReference"
+      "unit", Encode.string "sdo:unitText"
+      "unitCode", Encode.string "sdo:unitCode"
     ]
 
   let context_str =

--- a/src/ISA/ISA.Json/context/rocrate/isa_protocol_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_protocol_context.fs
@@ -24,19 +24,17 @@ module Protocol =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
+      "bio", Encode.string "https://bioschemas.org/"
 
-      "Protocol", Encode.string "sdo:Thing"
-      "ArcProtocol", Encode.string "arc:ARC#ARC_00000040"
+      "Protocol", Encode.string "bio:LabProtocol"
 
-      "name", Encode.string "arc:ARC#ARC_00000019"
-      "protocolType", Encode.string "arc:ARC#ARC_00000060"
-      "description", Encode.string "arc:ARC#ARC_00000004"
-      "version", Encode.string "arc:ARC#ARC_00000020"
-      "components", Encode.string "arc:ARC#ARC_00000064"
-      "parameters", Encode.string "arc:ARC#ARC_00000062"
-      "uri", Encode.string "arc:ARC#ARC_00000061"
-      "comments", Encode.string "arc:ARC#ARC_00000016"
+      "name", Encode.string "sdo:name"
+      "protocolType", Encode.string "bio:intendedUse"
+      "description", Encode.string "sdo:description"
+      "version", Encode.string "sdo:version"
+      "components", Encode.string "bio:labEquipment"
+      "uri", Encode.string "sdo:url"
+      "comments", Encode.string "sdo:comment"
     ]
 
   let context_str =

--- a/src/ISA/ISA.Json/context/rocrate/isa_publication_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_publication_context.fs
@@ -21,7 +21,6 @@ module Publication =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "Publication", Encode.string "sdo:ScholarlyArticle"
       

--- a/src/ISA/ISA.Json/context/rocrate/isa_sample_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_sample_context.fs
@@ -20,15 +20,13 @@ module Sample =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
+      "bio", Encode.string "https://bioschemas.org/"
 
-      "Sample", Encode.string "sdo:Thing"
-      "ArcSample", Encode.string "arc:ARC#ARC_00000070"
+      "Sample", Encode.string "bio:Sample"
 
-      "name", Encode.string "arc:name"
-      "characteristics", Encode.string "arc:ARC#ARC_00000080"
-      "factorValues", Encode.string "arc:ARC#ARC_00000083"
-      "derivesFrom", Encode.string "arc:ARC#ARC_00000082"
+      "name", Encode.string "sdo:name"
+      "characteristics", Encode.string "bio:additionalProperty"
+      "factorValues", Encode.string "bio:additionalProperty"
     ]
 
   let context_str =

--- a/src/ISA/ISA.Json/context/rocrate/isa_source_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_source_context.fs
@@ -19,15 +19,12 @@ module Source =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
+      "bio", Encode.string "https://bioschemas.org/"
 
-      "Source", Encode.string "sdo:Thing"
-      "ArcSource", Encode.string "arc:ARC#ARC_00000071"
+      "Source", Encode.string "bio:Sample"
 
-      "identifier", Encode.string "sdo:identifier"
-
-      "name", Encode.string "arc:ARC#ARC_00000019"
-      "characteristics", Encode.string "arc:ARC#ARC_00000080"
+      "name", Encode.string "sdo:name"
+      "characteristics", Encode.string "bio:additionalProperty"
     ]
 
   let context_str =

--- a/src/ISA/ISA.Json/context/rocrate/isa_study_context.fs
+++ b/src/ISA/ISA.Json/context/rocrate/isa_study_context.fs
@@ -37,10 +37,8 @@ module Study =
   let context_jsonvalue =
     Encode.object [
       "sdo", Encode.string "http://schema.org/"
-      "arc", Encode.string "http://purl.org/nfdi4plants/ontology/"
 
       "Study", Encode.string "sdo:Dataset"
-      "ArcStudy", Encode.string "arc:ARC#ARC_00000014"
 
       "identifier", Encode.string "sdo:identifier"
       "title", Encode.string "sdo:headline"
@@ -53,15 +51,7 @@ module Study =
       "filename", Encode.string "sdo:description"
       "comments", Encode.string "sdo:disambiguatingDescription"
 
-      "protocols", Encode.string "arc:ARC#ARC_00000039"
-      "materials", Encode.string "arc:ARC#ARC_00000045"
-      "otherMaterials", Encode.string "arc:ARC#ARC_00000045"
-      "sources", Encode.string "arc:ARC#ARC_00000045"
-      "samples", Encode.string "arc:ARC#ARC_00000045"
-      "processSequence", Encode.string "arc:ARC#ARC_00000047"
-      "factors", Encode.string "arc:ARC#ARC_00000043"
-      "characteristicCategories", Encode.string "arc:ARC#ARC_00000049"
-      "unitCategories", Encode.string "arc:ARC#ARC_00000051"
+      "processSequence", Encode.string "sdo:about"
       "studyDesignDescriptors", Encode.string "arc:ARC#ARC_00000037"
     ]
 

--- a/tests/ISA/ISA.Json.Tests/Json.Tests.fs
+++ b/tests/ISA/ISA.Json.Tests/Json.Tests.fs
@@ -726,11 +726,11 @@ let testProcessFile =
 let testProcessFileLD =
 
     testList "ProcessLD" [
-        ptestCase "ReaderSuccess" (fun () -> 
+        testCase "ReaderSuccess" (fun () -> 
             
             let readingSuccess = 
                 try 
-                    Process.fromJsonString Process.processLD |> ignore
+                    Process.fromJsonldString Process.processLD |> ignore
                     Result.Ok "DidRun"
                 with
                 | err -> Result.Error(sprintf "Reading the test file failed: %s" err.Message)
@@ -789,6 +789,28 @@ let testProcessFileLD =
 
             let o =
                 Process.fromJsonString Process.processWithoutIDs
+                |> Process.toJsonldStringWithContext
+
+            let expected = 
+                Process.processWithDefaultLD
+                |> Utils.extractWords
+                |> Array.countBy id
+                |> Array.sortBy fst
+
+            let actual = 
+                o
+                |> Utils.extractWords
+                |> Array.countBy id
+                |> Array.sortBy fst
+
+            Expect.sequenceEqual actual expected "Written process file does not match read process file"
+        )
+
+        testCase "OutputMatchesInputLDtoLD" (fun () ->
+
+            let o_read = Process.fromJsonldString Process.processWithDefaultLD
+            let o =
+                o_read
                 |> Process.toJsonldStringWithContext
 
             let expected = 
@@ -915,11 +937,11 @@ let testPersonFile =
 let testPersonFileLD =
 
     testList "PersonLD" [
-        ptestCase "ReaderSuccess" (fun () -> 
+        testCase "ReaderSuccess" (fun () -> 
             
             let readingSuccess = 
                 try 
-                    Person.fromJsonString Person.personLD |> ignore
+                    Person.fromJsonldString Person.personLD |> ignore
                     Result.Ok "DidRun"
                 with
                 | err -> Result.Error(sprintf "Reading the test file failed: %s" err.Message)

--- a/tests/ISA/ISA.Json.Tests/Json.Tests.fs
+++ b/tests/ISA/ISA.Json.Tests/Json.Tests.fs
@@ -444,7 +444,7 @@ let testProcessInputLD =
             )
         ]
         testList "Sample" [
-            testCase "ReaderSuccessSimple" (fun () -> 
+            ptestCase "ReaderSuccessSimple" (fun () -> 
            
                 let result = ProcessInput.fromJsonString ProcessInput.sampleSimpleLD
 
@@ -459,33 +459,33 @@ let testProcessInputLD =
             )
             testCase "WriterOutputMatchesInputSimpleGivenID" (fun () -> 
             
-                    let o_read_in = ProcessInput.fromJsonString ProcessInput.sampleSimple
-                    let o_out = ProcessInput.toJsonldStringWithContext o_read_in
+                let o_read_in = ProcessInput.fromJsonString ProcessInput.sampleSimple
+                let o_out = ProcessInput.toJsonldStringWithContext o_read_in
 
-                    let expected = 
-                        ProcessInput.sampleSimpleLD
-                        |> Utils.wordFrequency
+                let expected = 
+                    ProcessInput.sampleSimpleLD
+                    |> Utils.wordFrequency
 
-                    let actual = 
-                        o_out
-                        |> Utils.wordFrequency
+                let actual = 
+                    o_out
+                    |> Utils.wordFrequency
 
-                    Expect.equal actual expected "Written processInput does not match read process input"
+                Expect.equal actual expected "Written processInput does not match read process input"
             )
             testCase "WriterOutputMatchesInputSimpleDefaultID" (fun () -> 
             
-                    let o_read_in = ProcessInput.fromJsonString ProcessInput.sampleSimpleWithoutID
-                    let o_out = ProcessInput.toJsonldStringWithContext o_read_in
+                let o_read_in = ProcessInput.fromJsonString ProcessInput.sampleSimpleWithoutID
+                let o_out = ProcessInput.toJsonldStringWithContext o_read_in
 
-                    let expected = 
-                        ProcessInput.sampleSimpleWithDefaultLD
-                        |> Utils.wordFrequency
+                let expected = 
+                    ProcessInput.sampleSimpleWithDefaultLD
+                    |> Utils.wordFrequency
 
-                    let actual = 
-                        o_out
-                        |> Utils.wordFrequency
+                let actual = 
+                    o_out
+                    |> Utils.wordFrequency
 
-                    Expect.equal actual expected "Written processInput does not match read process input"
+                Expect.equal actual expected "Written processInput does not match read process input"
             )
         ]
     ]
@@ -726,7 +726,7 @@ let testProcessFile =
 let testProcessFileLD =
 
     testList "ProcessLD" [
-        testCase "ReaderSuccess" (fun () -> 
+        ptestCase "ReaderSuccess" (fun () -> 
             
             let readingSuccess = 
                 try 
@@ -741,7 +741,7 @@ let testProcessFileLD =
 
         testCase "WriterSuccess" (fun () ->
 
-            let p = Process.fromJsonString Process.processLD
+            let p = Process.fromJsonString Process.process'
 
             let writingSuccess = 
                 try 
@@ -915,7 +915,7 @@ let testPersonFile =
 let testPersonFileLD =
 
     testList "PersonLD" [
-        testCase "ReaderSuccess" (fun () -> 
+        ptestCase "ReaderSuccess" (fun () -> 
             
             let readingSuccess = 
                 try 

--- a/tests/TestingUtils/TestObjects.Json/OntologyAnnotation.fs
+++ b/tests/TestingUtils/TestObjects.Json/OntologyAnnotation.fs
@@ -21,7 +21,6 @@ let peptidaseLD =
         "@type": "OntologyAnnotation",
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
 
             "OntologyAnnotation": "sdo:DefinedTerm",
             
@@ -39,7 +38,6 @@ let peptidaseLD =
                 "@type": "Comment",
                 "@context": {
                     "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
                     
                     "Comment": "sdo:Comment",
                     "name": "sdo:name",
@@ -70,7 +68,6 @@ let peptidaseWithDefaultLD =
         "@type": "OntologyAnnotation",
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
 
             "OntologyAnnotation": "sdo:DefinedTerm",
             
@@ -88,7 +85,6 @@ let peptidaseWithDefaultLD =
                 "@type": "Comment",
                 "@context": {
                     "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
                     
                     "Comment": "sdo:Comment",
                     "name": "sdo:name",

--- a/tests/TestingUtils/TestObjects.Json/Person.fs
+++ b/tests/TestingUtils/TestObjects.Json/Person.fs
@@ -52,7 +52,6 @@ let personLD =
   "@type": "Person",
   "@context": {
     "sdo": "http://schema.org/",
-    "arc": "http://purl.org/nfdi4plants/ontology/",
 
     "Person": "sdo:Person",
     
@@ -75,7 +74,6 @@ let personLD =
       "@type": "Comment",
       "@context": {
         "sdo": "http://schema.org/",
-        "arc": "http://purl.org/nfdi4plants/ontology/",
         
         "Comment": "sdo:Comment",
         "name": "sdo:name",
@@ -91,7 +89,6 @@ let personLD =
       "@type": "OntologyAnnotation",
       "@context": {
         "sdo": "http://schema.org/",
-        "arc": "http://purl.org/nfdi4plants/ontology/",
 
         "OntologyAnnotation": "sdo:DefinedTerm",
         
@@ -103,7 +100,15 @@ let personLD =
       "annotationValue": "author"
     }
   ],
-  "affiliation": "Faculty of Life Sciences, Michael Smith Building, University of Manchester"
+  "affiliation": {
+    "@type": "Organization",
+    "@id": "#Organization_Faculty_of_Life_Sciences,_Michael_Smith_Building,_University_of_Manchester",
+    "name": "Faculty of Life Sciences, Michael Smith Building, University of Manchester",
+    "@context": {
+      "sdo": "http://schema.org/",
+      "Organization": "sdo:Organization",
+      "name": "sdo:name"
+    }
 }
     """
 
@@ -139,7 +144,6 @@ let personWithDefaultLD =
   "@type": "Person",
   "@context": {
     "sdo": "http://schema.org/",
-    "arc": "http://purl.org/nfdi4plants/ontology/",
 
     "Person": "sdo:Person",
     
@@ -167,7 +171,6 @@ let personWithDefaultLD =
       "@type": "Comment",
       "@context": {
         "sdo": "http://schema.org/",
-        "arc": "http://purl.org/nfdi4plants/ontology/",
         
         "Comment": "sdo:Comment",
         "name": "sdo:name",
@@ -183,7 +186,6 @@ let personWithDefaultLD =
       "@type": "OntologyAnnotation",
       "@context": {
         "sdo": "http://schema.org/",
-        "arc": "http://purl.org/nfdi4plants/ontology/",
 
         "OntologyAnnotation": "sdo:DefinedTerm",
         
@@ -195,7 +197,15 @@ let personWithDefaultLD =
       "annotationValue": "author"
     }
   ],
-  "affiliation": "Faculty of Life Sciences, Michael Smith Building, University of Manchester"
+  "affiliation": {
+    "@type": "Organization",
+    "@id": "#Organization_Faculty_of_Life_Sciences,_Michael_Smith_Building,_University_of_Manchester",
+    "name": "Faculty of Life Sciences, Michael Smith Building, University of Manchester",
+    "@context": {
+      "sdo": "http://schema.org/",
+      "Organization": "sdo:Organization",
+      "name": "sdo:name"
+    }
 }
     """
 

--- a/tests/TestingUtils/TestObjects.Json/Process.fs
+++ b/tests/TestingUtils/TestObjects.Json/Process.fs
@@ -570,7 +570,7 @@ let processWithDefaultLD =
         "output": "sdo:result",
 
         "comments": "sdo:disambiguatingDescription"
-    }
+    },
     "name": "standard_trypsin_digestion",
     "executesProtocol": {
         "@id": "http://madeUpProtocolWebsize.org/protein_digestion",
@@ -630,7 +630,6 @@ let processWithDefaultLD =
                 "value": "digestion_stopper",
                 "category": "Formic Acid",
                 "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C83719"
-                }
             },
             {
                 "@id": "#Component_heater",
@@ -650,7 +649,6 @@ let processWithDefaultLD =
                 "value": "heater",
                 "category": "Heater Device",
                 "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C49986"
-                }
             }
             
         ],

--- a/tests/TestingUtils/TestObjects.Json/Process.fs
+++ b/tests/TestingUtils/TestObjects.Json/Process.fs
@@ -9,7 +9,6 @@ let process' =
     "executesProtocol": {
         "@id": "#protocols/peptide_digestion",
         "name": "peptide_digestion",
-    
         "protocolType": {
             "@id": "protein_digestion",
             "annotationValue": "Protein Digestion",
@@ -39,7 +38,6 @@ let process' =
                     "termSource": "Ontobee",
                     "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029",
                     "comments": []
-    
                 }
             },
             {
@@ -96,7 +94,6 @@ let process' =
                 "termSource": "NCI",
                 "termAccession": "http://purl.obolibrary.org/obo/MS_1001313",
                 "comments": []
-                
             }
         },
         {
@@ -108,7 +105,6 @@ let process' =
                     "termSource": "Ontobee",
                     "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029",
                     "comments": []
-
                 }
             },
             "value": 37,
@@ -168,7 +164,6 @@ let process' =
         }
     ],
     "comments": []
-
 }
     """
 
@@ -177,53 +172,47 @@ let processLD =
     """
     {
     "@id": "#process/standard_trypsin_digestion",
-    "@type": ["Process","ArcProcess"],
+    "@type": ["Process"],
     "@context": {
         "sdo": "http://schema.org/",
-        "arc": "http://purl.org/nfdi4plants/ontology/",
+        "bio": "https://bioschemas.org/",
 
-        "Process": "sdo:Thing",
-        "ArcProcess": "arc:ARC#ARC_00000048",
+        "Process": "bio:LabProcess",
 
-        "name": "arc:ARC#ARC_00000019",
-        "executesProtocol": "arc:ARC#ARC_00000086",
-        "performer": "arc:ARC#ARC_00000089",
-        "date": "arc:ARC#ARC_00000090",
-        "previousProcess": "arc:ARC#ARC_00000091",
-        "nextProcess": "arc:ARC#ARC_00000092",
-        "input": "arc:ARC#ARC_00000095",
-        "output": "arc:ARC#ARC_00000096",
+        "name": "sdo:name",
+        "executesProtocol": "bio:executesProtocol",
+        "parameterValues": "bio:parameterValues",
+        "performer": "sdo:agent",
+        "date": "sdo:endTime",
+        "input": "sdo:object",
+        "output": "sdo:result",
 
         "comments": "sdo:disambiguatingDescription"
     },
     "name": "standard_trypsin_digestion",
     "executesProtocol": {
         "@id": "#protocols/peptide_digestion",
-        "@type": ["Protocol","ArcProtocol"], 
+        "@type": ["Protocol"], 
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
+            "bio": "https://bioschemas.org/",
 
-            "Protocol": "sdo:Thing",
-            "ArcProtocol": "arc:ARC#ARC_00000040",
+            "Protocol": "bio:LabProtocol",
 
-            "name": "arc:ARC#ARC_00000019",
-            "protocolType": "arc:ARC#ARC_00000060",
-            "description": "arc:ARC#ARC_00000004",
-            "version": "arc:ARC#ARC_00000020",
-            "components": "arc:ARC#ARC_00000064",
-            "parameters": "arc:ARC#ARC_00000062",
-            "uri": "arc:ARC#ARC_00000061",
-            "comments": "arc:ARC#ARC_00000016"
+            "name": "sdo:name",
+            "protocolType": "bio:intendedUse",
+            "description": "sdo:description",
+            "version": "sdo:version",
+            "components": "bio:labEquipment",
+            "uri": "sdo:url",
+            "comments": "sdo:comment"
         },
         "name": "peptide_digestion",
-    
         "protocolType": {
             "@id": "protein_digestion",
             "@type": "OntologyAnnotation",
             "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "sdo": "http://schema.org/", 
 
                 "OntologyAnnotation": "sdo:DefinedTerm",
                 
@@ -240,524 +229,194 @@ let processLD =
         "description": "The isolated proteins get solubilized. Given protease is added and the solution is heated to a given temperature. After a given amount of time, the digestion is stopped by adding a denaturation agent.",
         "uri": "http://madeUpProtocolWebsize.org/protein_digestion",
         "version": "1.0.0",
-        "parameters": [
-            {
-                "@id": "protease",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "protease",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "Peptidase",
-                    "termSource": "MS",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                    "comments": []
-                }
-            },
-            {
-                "@id": "temperature",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "temperature",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "temperature",
-                    "termSource": "Ontobee",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                    "comments": []
-    
-                }
-            },
-            {
-                "@id": "time",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "time",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "time",
-                    "termSource": "EFO",
-                    "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                    "comments": []
-                }
-            }
-        ],
         "components": [
             {
                 "@id": "#Component_digestion_stopper",
-                "@type": ["Component","ArcComponent"],
+                "@type": ["Component"],
                 "@context": {
                     "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-                    
-                    "Component": "sdo:Thing",
-                    "ArcComponent": "arc:ARC#ARC_00000065",
+        
+                    "Component": "sdo:PropertyValue",
 
-                    "componentName": "arc:ARC#ARC_00000019",
-                    "componentType": "arc:ARC#ARC_00000102"
+                    "category": "sdo:name",
+                    "categoryCode": "sdo:propertyID",
+                    "value": "sdo:value",
+                    "valueCode": "sdo:valueReference",
+                    "unit": "sdo:unitText",
+                    "unitCode": "sdo:unitCode"
                 },
-                "componentName": "digestion_stopper",
-                "componentType": {
-                    "@id": "formic_acid",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "Formic Acid",
-                    "termSource": "NCIT",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C83719",
-                    "comments": []
-                }
+                "value": "digestion_stopper",
+                "category": "Formic Acid",
+                "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C83719"
             },
             {
                 "@id": "#Component_heater",
-                "@type": ["Component","ArcComponent"],
+                "@type": ["Component"],
                 "@context": {
                     "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-                    
-                    "Component": "sdo:Thing",
-                    "ArcComponent": "arc:ARC#ARC_00000065",
+        
+                    "Component": "sdo:PropertyValue",
 
-                    "componentName": "arc:ARC#ARC_00000019",
-                    "componentType": "arc:ARC#ARC_00000102"
+                    "category": "sdo:name",
+                    "categoryCode": "sdo:propertyID",
+                    "value": "sdo:value",
+                    "valueCode": "sdo:valueReference",
+                    "unit": "sdo:unitText",
+                    "unitCode": "sdo:unitCode"
                 },
-                "componentName": "heater",
-                "componentType": {
-                    "@id": "heater",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "Heater Device",
-                    "termSource": "NCIT",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C49986",
-                    "comments": []
-                }
+                "value": "heater",
+                "category": "Heater Device",
+                "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C49986"
             }
-            
         ],
         "comments": []
     },
     "parameterValues": [
         {
             "@id": "#Param_Peptidase_Trypsin/P",
-            "@type": ["ProcessParameterValue","ArcProcessParameterValue"],
+            "@type": ["ProcessParameterValue"],
             "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "sdo": "http://schema.org/", 
 
                 "ProcessParameterValue": "sdo:PropertyValue",
-                "ArcProcessParameterValue": "arc:ARC#ARC_00000088",
 
-                "category": "arc:ARC#ARC_00000062",
-                "value": "arc:ARC#ARC_00000087",
-                "unit": "arc:ARC#ARC_00000106"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "category": {
-                "@id": "protease",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "protease",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "Peptidase",
-                    "termSource": "MS",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                    "comments": []
-                }
-            },
-            "value": {
-                "@id": "trypsin",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "Trypsin/P",
-                "termSource": "NCI",
-                "termAccession": "http://purl.obolibrary.org/obo/MS_1001313",
-                "comments": []
-                
-            }
+            "category": "Peptidase",
+            "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C16965",
+            "value": "Trypsin/P",
+            "valueCode": "http://purl.obolibrary.org/obo/MS_1001313"
         },
         {
             "@id": "#Param_temperature_37",
-            "@type": ["ProcessParameterValue","ArcProcessParameterValue"],
+            "@type": ["ProcessParameterValue"],
             "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "sdo": "http://schema.org/", 
 
                 "ProcessParameterValue": "sdo:PropertyValue",
-                "ArcProcessParameterValue": "arc:ARC#ARC_00000088",
 
-                "category": "arc:ARC#ARC_00000062",
-                "value": "arc:ARC#ARC_00000087",
-                "unit": "arc:ARC#ARC_00000106"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "category": {
-                "@id": "temperature",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "temperature",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "temperature",
-                    "termSource": "Ontobee",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                    "comments": []
-
-                }
-            },
+            "category": "temperature",
+            "categoryCode": "http://purl.obolibrary.org/obo/NCRO_0000029",
             "value": 37,
-            "unit": {
-                "@id": "degree_celcius",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "degree Celsius",
-                "termSource": "OM2",
-                "termAccession": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius",
-                "comments": []
-            }
+            "unit": "degree Celsius",
+            "unitCode": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius"
         },
         {
             "@id": "#Param_time_1",
-            "@type": ["ProcessParameterValue","ArcProcessParameterValue"],
+            "@type": ["ProcessParameterValue"],
             "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "sdo": "http://schema.org/", 
 
                 "ProcessParameterValue": "sdo:PropertyValue",
-                "ArcProcessParameterValue": "arc:ARC#ARC_00000088",
 
-                "category": "arc:ARC#ARC_00000062",
-                "value": "arc:ARC#ARC_00000087",
-                "unit": "arc:ARC#ARC_00000106"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "category": {
-                "@id": "time",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "time",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "time",
-                    "termSource": "EFO",
-                    "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                    "comments": []
-                }
-            },
+            "category": "time",
+            "categoryCode": "http://www.ebi.ac.uk/efo/EFO_0000721",
             "value": 1,
-            "unit": {
-                "@id": "h",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "hour",
-                "termSource": "UO",
-                "termAccession": "http://purl.obolibrary.org/obo/UO_0000032",
-                "comments": []
-            }
+            "unit": "hour",
+            "unitCode": "http://purl.obolibrary.org/obo/UO_0000032"
         }
     ],
     "date": "2020-10-23",
     "performer": "TUKL",
-    "previousProcess": {
-        "@id": "#process/protein_extraction",
-        "@type": ["Process","ArcProcess"],
-        "@context": {
-            "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
-
-            "Process": "sdo:Thing",
-            "ArcProcess": "arc:ARC#ARC_00000048",
-
-            "name": "arc:ARC#ARC_00000019",
-            "executesProtocol": "arc:ARC#ARC_00000086",
-            "performer": "arc:ARC#ARC_00000089",
-            "date": "arc:ARC#ARC_00000090",
-            "previousProcess": "arc:ARC#ARC_00000091",
-            "nextProcess": "arc:ARC#ARC_00000092",
-            "input": "arc:ARC#ARC_00000095",
-            "output": "arc:ARC#ARC_00000096",
-
-            "comments": "sdo:disambiguatingDescription"
-        }
-    },
-    "nextProcess":  { 
-        "@id": "#process/massspec_measurement", 
-        "@type": ["Process","ArcProcess"],
-        "@context": {
-            "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
-
-            "Process": "sdo:Thing",
-            "ArcProcess": "arc:ARC#ARC_00000048",
-
-            "name": "arc:ARC#ARC_00000019",
-            "executesProtocol": "arc:ARC#ARC_00000086",
-            "performer": "arc:ARC#ARC_00000089",
-            "date": "arc:ARC#ARC_00000090",
-            "previousProcess": "arc:ARC#ARC_00000091",
-            "nextProcess": "arc:ARC#ARC_00000092",
-            "input": "arc:ARC#ARC_00000095",
-            "output": "arc:ARC#ARC_00000096",
-
-            "comments": "sdo:disambiguatingDescription"
-        }
-    },
     "inputs": [
         {
-            "@id": "#sample/WT_protein", "@type": ["Source","ArcSource"],
+            "@id": "#sample/WT_protein", "@type": ["Source"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Source": "sdo:Thing",
-                "ArcSource": "arc:ARC#ARC_00000071",
+                "Source": "bio:Sample",
 
-                "identifier": "sdo:identifier",
-
-                "name": "arc:ARC#ARC_00000019",
-                "characteristics": "arc:ARC#ARC_00000080"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty"
             }
         },
         {
-            "@id": "#sample/MUT1_protein", "@type": ["Source","ArcSource"],
+            "@id": "#sample/MUT1_protein", "@type": ["Source"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Source": "sdo:Thing",
-                "ArcSource": "arc:ARC#ARC_00000071",
+                "Source": "bio:Sample",
 
-                "identifier": "sdo:identifier",
-
-                "name": "arc:ARC#ARC_00000019",
-                "characteristics": "arc:ARC#ARC_00000080"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty"
             }
         },
         {
-            "@id": "#sample/MUT2_protein", "@type": ["Source","ArcSource"],
+            "@id": "#sample/MUT2_protein", "@type": ["Source"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Source": "sdo:Thing",
-                "ArcSource": "arc:ARC#ARC_00000071",
+                "Source": "bio:Sample",
 
-                "identifier": "sdo:identifier",
-
-                "name": "arc:ARC#ARC_00000019",
-                "characteristics": "arc:ARC#ARC_00000080"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty"
             }
         }
     ],
     "outputs": [
         {
-            "@id": "#sample/WT_digested", "@type": ["Sample","ArcSample"],
+            "@id": "#sample/WT_digested", "@type": ["Sample"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Sample": "sdo:Thing",
-                "ArcSample": "arc:ARC#ARC_00000070",
+                "Sample": "bio:Sample",
 
-                "name": "arc:name",
-                "characteristics": "arc:ARC#ARC_00000080",
-                "factorValues": "arc:ARC#ARC_00000083",
-                "derivesFrom": "arc:ARC#ARC_00000082"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty",
+                "factorValues": "bio:additionalProperty"
             }
         },
         {
-            "@id": "#sample/MUT1_digested", "@type": ["Sample","ArcSample"],
+            "@id": "#sample/MUT1_digested", "@type": ["Sample"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Sample": "sdo:Thing",
-                "ArcSample": "arc:ARC#ARC_00000070",
+                "Sample": "bio:Sample",
 
-                "name": "arc:name",
-                "characteristics": "arc:ARC#ARC_00000080",
-                "factorValues": "arc:ARC#ARC_00000083",
-                "derivesFrom": "arc:ARC#ARC_00000082"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty",
+                "factorValues": "bio:additionalProperty"
             }
         },
         {
-            "@id": "#sample/MUT2_digested", "@type": ["Sample","ArcSample"],
+            "@id": "#sample/MUT2_digested", "@type": ["Sample"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Sample": "sdo:Thing",
-                "ArcSample": "arc:ARC#ARC_00000070",
+                "Sample": "bio:Sample",
 
-                "name": "arc:name",
-                "characteristics": "arc:ARC#ARC_00000080",
-                "factorValues": "arc:ARC#ARC_00000083",
-                "derivesFrom": "arc:ARC#ARC_00000082"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty",
+                "factorValues": "bio:additionalProperty"
             }
         }
     ],
     "comments": []
-
 }
     """
 
@@ -887,7 +546,6 @@ let processWithoutIDs =
     "date": "2020-10-23",
     "performer": "TUKL",
     "comments": []
-
 }
     """
 
@@ -896,53 +554,47 @@ let processWithDefaultLD =
     """
     {
     "@id": "#Process_standard_trypsin_digestion",
-    "@type": ["Process","ArcProcess"],
+    "@type": ["Process"],
     "@context": {
         "sdo": "http://schema.org/",
-        "arc": "http://purl.org/nfdi4plants/ontology/",
+        "bio": "https://bioschemas.org/",
 
-        "Process": "sdo:Thing",
-        "ArcProcess": "arc:ARC#ARC_00000048",
+        "Process": "bio:LabProcess",
 
-        "name": "arc:ARC#ARC_00000019",
-        "executesProtocol": "arc:ARC#ARC_00000086",
-        "performer": "arc:ARC#ARC_00000089",
-        "date": "arc:ARC#ARC_00000090",
-        "previousProcess": "arc:ARC#ARC_00000091",
-        "nextProcess": "arc:ARC#ARC_00000092",
-        "input": "arc:ARC#ARC_00000095",
-        "output": "arc:ARC#ARC_00000096",
+        "name": "sdo:name",
+        "executesProtocol": "bio:executesProtocol",
+        "parameterValues": "bio:parameterValues",
+        "performer": "sdo:agent",
+        "date": "sdo:endTime",
+        "input": "sdo:object",
+        "output": "sdo:result",
 
         "comments": "sdo:disambiguatingDescription"
-    },
+    }
     "name": "standard_trypsin_digestion",
     "executesProtocol": {
         "@id": "http://madeUpProtocolWebsize.org/protein_digestion",
-        "@type": ["Protocol","ArcProtocol"], 
+        "@type": ["Protocol"], 
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
+            "bio": "https://bioschemas.org/",
 
-            "Protocol": "sdo:Thing",
-            "ArcProtocol": "arc:ARC#ARC_00000040",
+            "Protocol": "bio:LabProtocol",
 
-            "name": "arc:ARC#ARC_00000019",
-            "protocolType": "arc:ARC#ARC_00000060",
-            "description": "arc:ARC#ARC_00000004",
-            "version": "arc:ARC#ARC_00000020",
-            "components": "arc:ARC#ARC_00000064",
-            "parameters": "arc:ARC#ARC_00000062",
-            "uri": "arc:ARC#ARC_00000061",
-            "comments": "arc:ARC#ARC_00000016"
+            "name": "sdo:name",
+            "protocolType": "bio:intendedUse",
+            "description": "sdo:description",
+            "version": "sdo:version",
+            "components": "bio:labEquipment",
+            "uri": "sdo:url",
+            "comments": "sdo:comment"
         },
         "name": "peptide_digestion",
-    
         "protocolType": {
             "@id": "http://purl.obolibrary.org/obo/NCIT_C70845",
             "@type": "OntologyAnnotation",
             "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "sdo": "http://schema.org/", 
 
                 "OntologyAnnotation": "sdo:DefinedTerm",
                 
@@ -959,172 +611,45 @@ let processWithDefaultLD =
         "description": "The isolated proteins get solubilized. Given protease is added and the solution is heated to a given temperature. After a given amount of time, the digestion is stopped by adding a denaturation agent.",
         "uri": "http://madeUpProtocolWebsize.org/protein_digestion",
         "version": "1.0.0",
-        "parameters": [
-            {
-                "@id": "#EmptyProtocolParameter",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "Peptidase",
-                    "termSource": "MS",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                    "comments": []
-                }
-            },
-            {
-                "@id": "#EmptyProtocolParameter",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "temperature",
-                    "termSource": "Ontobee",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                    "comments": []
-    
-                }
-            },
-            {
-                "@id": "#Param_http://www.ebi.ac.uk/efo/EFO_0000721",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "time",
-                    "termSource": "EFO",
-                    "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                    "comments": []
-                }
-            }
-        ],
         "components": [
             {
                 "@id": "#Component_digestion_stopper",
-                "@type": ["Component","ArcComponent"],
+                "@type": ["Component"],
                 "@context": {
                     "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-                    
-                    "Component": "sdo:Thing",
-                    "ArcComponent": "arc:ARC#ARC_00000065",
+        
+                    "Component": "sdo:PropertyValue",
 
-                    "componentName": "arc:ARC#ARC_00000019",
-                    "componentType": "arc:ARC#ARC_00000102"
+                    "category": "sdo:name",
+                    "categoryCode": "sdo:propertyID",
+                    "value": "sdo:value",
+                    "valueCode": "sdo:valueReference",
+                    "unit": "sdo:unitText",
+                    "unitCode": "sdo:unitCode"
                 },
-                "componentName": "digestion_stopper",
-                "componentType": {
-                    "@id": "http://purl.obolibrary.org/obo/NCIT_C83719",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "Formic Acid",
-                    "termSource": "NCIT",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C83719",
-                    "comments": []
+                "value": "digestion_stopper",
+                "category": "Formic Acid",
+                "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C83719"
                 }
             },
             {
                 "@id": "#Component_heater",
-                "@type": ["Component","ArcComponent"],
+                "@type": ["Component"],
                 "@context": {
                     "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-                    
-                    "Component": "sdo:Thing",
-                    "ArcComponent": "arc:ARC#ARC_00000065",
+        
+                    "Component": "sdo:PropertyValue",
 
-                    "componentName": "arc:ARC#ARC_00000019",
-                    "componentType": "arc:ARC#ARC_00000102"
+                    "category": "sdo:name",
+                    "categoryCode": "sdo:propertyID",
+                    "value": "sdo:value",
+                    "valueCode": "sdo:valueReference",
+                    "unit": "sdo:unitText",
+                    "unitCode": "sdo:unitCode"
                 },
-                "componentName": "heater",
-                "componentType": {
-                    "@id": "http://purl.obolibrary.org/obo/NCIT_C49986",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "Heater Device",
-                    "termSource": "NCIT",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C49986",
-                    "comments": []
+                "value": "heater",
+                "category": "Heater Device",
+                "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C49986"
                 }
             }
             
@@ -1134,205 +659,65 @@ let processWithDefaultLD =
     "parameterValues": [
         {
             "@id": "#Param_Peptidase_Trypsin/P",
-            "@type": ["ProcessParameterValue","ArcProcessParameterValue"],
+            "@type": ["ProcessParameterValue"],
             "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "sdo": "http://schema.org/", 
 
                 "ProcessParameterValue": "sdo:PropertyValue",
-                "ArcProcessParameterValue": "arc:ARC#ARC_00000088",
 
-                "category": "arc:ARC#ARC_00000062",
-                "value": "arc:ARC#ARC_00000087",
-                "unit": "arc:ARC#ARC_00000106"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "category": {
-                "@id": "#Param_http://purl.obolibrary.org/obo/NCIT_C16965",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "Peptidase",
-                    "termSource": "MS",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                    "comments": []
-                }
-            },
-            "value": {
-                "@id": "http://purl.obolibrary.org/obo/MS_1001313",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "Trypsin/P",
-                "termSource": "NCI",
-                "termAccession": "http://purl.obolibrary.org/obo/MS_1001313",
-                "comments": []
-                
-            }
+            "category": "Peptidase",
+            "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C16965",
+            "value": "Trypsin/P",
+            "valueCode": "http://purl.obolibrary.org/obo/MS_1001313"
         },
         {
             "@id": "#Param_temperature_37",
-            "@type": ["ProcessParameterValue","ArcProcessParameterValue"],
+            "@type": ["ProcessParameterValue"],
             "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "sdo": "http://schema.org/", 
 
                 "ProcessParameterValue": "sdo:PropertyValue",
-                "ArcProcessParameterValue": "arc:ARC#ARC_00000088",
 
-                "category": "arc:ARC#ARC_00000062",
-                "value": "arc:ARC#ARC_00000087",
-                "unit": "arc:ARC#ARC_00000106"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "category": {
-                "@id": "#EmptyProtocolParameter",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "temperature",
-                    "termSource": "Ontobee",
-                    "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                    "comments": []
-
-                }
-            },
+            "category": "temperature",
+            "categoryCode": "http://purl.obolibrary.org/obo/NCRO_0000029",
             "value": 37,
-            "unit": {
-                "@id": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "degree Celsius",
-                "termSource": "OM2",
-                "termAccession": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius",
-                "comments": []
-            }
+            "unit": "degree Celsius",
+            "unitCode": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius"
         },
         {
             "@id": "#Param_time_1",
-            "@type": ["ProcessParameterValue","ArcProcessParameterValue"],
+            "@type": ["ProcessParameterValue"],
             "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "sdo": "http://schema.org/", 
 
                 "ProcessParameterValue": "sdo:PropertyValue",
-                "ArcProcessParameterValue": "arc:ARC#ARC_00000088",
 
-                "category": "arc:ARC#ARC_00000062",
-                "value": "arc:ARC#ARC_00000087",
-                "unit": "arc:ARC#ARC_00000106"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "category": {
-                "@id": "#EmptyProtocolParameter",
-                "@type": ["ProtocolParameter","ArcProtocolParameter"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "ProtocolParameter": "sdo:Thing",
-                    "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                    "parameterName": "arc:ARC#ARC_00000100"
-                },
-                "parameterName": {
-                    "@id": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                    "@type": "OntologyAnnotation",
-                    "@context": {
-                        "sdo": "http://schema.org/",
-                        "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                        "OntologyAnnotation": "sdo:DefinedTerm",
-                        
-                        "annotationValue": "sdo:name",
-                        "termSource": "sdo:inDefinedTermSet",
-                        "termAccession": "sdo:termCode",
-                        "comments": "sdo:disambiguatingDescription"
-                    },
-                    "annotationValue": "time",
-                    "termSource": "EFO",
-                    "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                    "comments": []
-                }
-            },
+            "category": "time",
+            "categoryCode": "http://www.ebi.ac.uk/efo/EFO_0000721",
             "value": 1,
-            "unit": {
-                "@id": "http://purl.obolibrary.org/obo/UO_0000032",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "hour",
-                "termSource": "UO",
-                "termAccession": "http://purl.obolibrary.org/obo/UO_0000032",
-                "comments": []
-            }
+            "unit": "hour",
+            "unitCode": "http://purl.obolibrary.org/obo/UO_0000032"
         }
     ],
     "date": "2020-10-23",

--- a/tests/TestingUtils/TestObjects.Json/ProcessInput.fs
+++ b/tests/TestingUtils/TestObjects.Json/ProcessInput.fs
@@ -12,36 +12,18 @@ let sampleSimpleLD =
     """
         {
             "@id": "#sample/sample-P-0.1-aliquot7",
-            "@type": ["Sample","ArcSample"],
+            "@type": ["Sample"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Sample": "sdo:Thing",
-                "ArcSample": "arc:ARC#ARC_00000070",
+                "Sample": "bio:Sample",
 
-                "name": "arc:name",
-                "characteristics": "arc:ARC#ARC_00000080",
-                "factorValues": "arc:ARC#ARC_00000083",
-                "derivesFrom": "arc:ARC#ARC_00000082"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty",
+                "factorValues": "bio:additionalProperty"
             },
-            "name": "sample-P-0.1-aliquot7",
-            "derivesFrom": [ { 
-                "@id": "#source/source-culture8", 
-                "@type": ["Source","ArcSource"],
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "Source": "sdo:Thing",
-                    "ArcSource": "arc:ARC#ARC_00000071",
-
-                    "identifier": "sdo:identifier",
-
-                    "name": "arc:ARC#ARC_00000019",
-                    "characteristics": "arc:ARC#ARC_00000080"
-                } 
-            } ]
+            "name": "sample-P-0.1-aliquot7"
         }
     """
 let sampleSimpleWithoutID = 
@@ -55,36 +37,18 @@ let sampleSimpleWithDefaultLD =
     """
         {
             "@id": "#Sample_sample-P-0.1-aliquot7",
-            "@type": ["Sample","ArcSample"],
+            "@type": ["Sample"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Sample": "sdo:Thing",
-                "ArcSample": "arc:ARC#ARC_00000070",
+                "Sample": "bio:Sample",
 
-                "name": "arc:name",
-                "characteristics": "arc:ARC#ARC_00000080",
-                "factorValues": "arc:ARC#ARC_00000083",
-                "derivesFrom": "arc:ARC#ARC_00000082"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty",
+                "factorValues": "bio:additionalProperty"
             },
-            "name": "sample-P-0.1-aliquot7",
-            "derivesFrom": [ { 
-                "@id": "#source/source-culture8", 
-                "@type": ["Source","ArcSource"] ,
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "Source": "sdo:Thing",
-                    "ArcSource": "arc:ARC#ARC_00000071",
-
-                    "identifier": "sdo:identifier",
-
-                    "name": "arc:ARC#ARC_00000019",
-                    "characteristics": "arc:ARC#ARC_00000080"
-                }
-            } ]
+            "name": "sample-P-0.1-aliquot7"
         }
     """
 
@@ -130,18 +94,15 @@ let sourceLD =
     """
         { 
             "@id": "#source/source-culture8",
-            "@type": ["Source", "ArcSource"],
+            "@type": ["Source"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Source": "sdo:Thing",
-                "ArcSource": "arc:ARC#ARC_00000071",
+                "Source": "bio:Sample",
 
-                "identifier": "sdo:identifier",
-
-                "name": "arc:ARC#ARC_00000019",
-                "characteristics": "arc:ARC#ARC_00000080"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty"
             },
             "name": "source-culture8"
         }
@@ -156,18 +117,15 @@ let sourceWithDefaultLD =
     """
         { 
             "@id": "#Source_source-culture8",
-            "@type": ["Source","ArcSource"],
+            "@type": ["Source"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-                "Source": "sdo:Thing",
-                "ArcSource": "arc:ARC#ARC_00000071",
+                "Source": "bio:Sample",
 
-                "identifier": "sdo:identifier",
-
-                "name": "arc:ARC#ARC_00000019",
-                "characteristics": "arc:ARC#ARC_00000080"
+                "name": "sdo:name",
+                "characteristics": "bio:additionalProperty"
             },
             "name": "source-culture8"
         }
@@ -186,18 +144,15 @@ let dataLD =
     """
     {
         "@id": "#data/rawspectraldatafile-JIC64_Nitrogen_0.07_External_1_3.txt",
-        "@type": ["Data","ArcData"],
+        "@type": ["Data"],
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
 
             "Data": "sdo:MediaObject",
-            "ArcData": "arc:ARC#ARC_00000076",
 
-            "type": "arc:ARC#ARC_00000107",
-
+            "type": "sdo:disambiguatingDescription",
             "name": "sdo:name",
-            "comments": "sdo:disambiguatingDescription"
+            "comments": "sdo:comment"
         },
         "comments": [],
         "name": "JIC64_Nitrogen_0.07_External_1_3.txt",
@@ -216,18 +171,15 @@ let dataWithDefaultLD =
     """
     {
         "@id": "JIC64_Nitrogen_0.07_External_1_3.txt",
-        "@type": ["Data","ArcData"],
+        "@type": ["Data"],
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
 
             "Data": "sdo:MediaObject",
-            "ArcData": "arc:ARC#ARC_00000076",
 
-            "type": "arc:ARC#ARC_00000107",
-
+            "type": "sdo:disambiguatingDescription",
             "name": "sdo:name",
-            "comments": "sdo:disambiguatingDescription"
+            "comments": "sdo:comment"
         },
         "comments": [],
         "name": "JIC64_Nitrogen_0.07_External_1_3.txt",
@@ -249,18 +201,16 @@ let materialLD =
     """
     {
         "@id": "#material/extract-G-0.1-aliquot1",
-        "@type": ["Material","ArcMaterial"],
+        "@type": ["Material"],
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-            "ArcMaterial": "arc:ARC#ARC_00000108",
-            "Material": "sdo:Thing",
+                "Material": "bio:Sample",
 
-            "type": "arc:ARC#ARC_00000085",
-            "name": "arc:ARC#ARC_00000019",
-            "characteristics": "arc:ARC#ARC_00000080",
-            "derivesFrom": "arc:ARC#ARC_00000082"
+                "name": "sdo:name",
+                "type": "sdo:disambiguatingDescription",
+                "characteristics": "bio:additionalProperty"
         },
         "characteristics": [],
         "name": "extract-G-0.1-aliquot1",
@@ -281,18 +231,16 @@ let materialWithDefaultLD =
     """
     {
         "@id": "#Material_extract-G-0.1-aliquot1",
-        "@type": ["Material","ArcMaterial"],
+        "@type": ["Material"],
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
+                "bio": "https://bioschemas.org/",
 
-            "ArcMaterial": "arc:ARC#ARC_00000108",
-            "Material": "sdo:Thing",
+                "Material": "bio:Sample",
 
-            "type": "arc:ARC#ARC_00000085",
-            "name": "arc:ARC#ARC_00000019",
-            "characteristics": "arc:ARC#ARC_00000080",
-            "derivesFrom": "arc:ARC#ARC_00000082"
+                "name": "sdo:name",
+                "type": "sdo:disambiguatingDescription",
+                "characteristics": "bio:additionalProperty"
         },
         "characteristics": [],
         "name": "extract-G-0.1-aliquot1",

--- a/tests/TestingUtils/TestObjects.Json/Protocol.fs
+++ b/tests/TestingUtils/TestObjects.Json/Protocol.fs
@@ -83,22 +83,20 @@ let protocolLD =
     """
     {
     "@id": "#protocols/peptide_digestion",
-    "@type": ["Protocol","ArcProtocol"],
+    "@type": ["Protocol"],
     "@context": {
         "sdo": "http://schema.org/",
-        "arc": "http://purl.org/nfdi4plants/ontology/",
+        "bio": "https://bioschemas.org/",
 
-        "Protocol": "sdo:Thing",
-        "ArcProtocol": "arc:ARC#ARC_00000040",
+        "Protocol": "bio:LabProtocol",
 
-        "name": "arc:ARC#ARC_00000019",
-        "protocolType": "arc:ARC#ARC_00000060",
-        "description": "arc:ARC#ARC_00000004",
-        "version": "arc:ARC#ARC_00000020",
-        "components": "arc:ARC#ARC_00000064",
-        "parameters": "arc:ARC#ARC_00000062",
-        "uri": "arc:ARC#ARC_00000061",
-        "comments": "arc:ARC#ARC_00000016"
+        "name": "sdo:name",
+        "protocolType": "bio:intendedUse",
+        "description": "sdo:description",
+        "version": "sdo:version",
+        "components": "bio:labEquipment",
+        "uri": "sdo:url",
+        "comments": "sdo:comment"
     },
     "name": "peptide_digestion",
     "protocolType": {
@@ -106,7 +104,6 @@ let protocolLD =
         "@type": "OntologyAnnotation",
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
 
             "OntologyAnnotation": "sdo:DefinedTerm",
             
@@ -123,174 +120,45 @@ let protocolLD =
     "description": "The isolated proteins get solubilized. Given protease is added and the solution is heated to a given temperature. After a given amount of time, the digestion is stopped by adding a denaturation agent.",
     "uri": "http://madeUpProtocolWebsize.org/protein_digestion",
     "version": "1.0.0",
-    "parameters": [
-        {
-            "@id": "protease",
-            "@type": ["ProtocolParameter","ArcProtocolParameter"],
-            "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                "ProtocolParameter": "sdo:Thing",
-                "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                "parameterName": "arc:ARC#ARC_00000100"
-            },
-            "parameterName": {
-                "@id": "protease",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "Peptidase",
-                "termSource": "MS",
-                "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                "comments": []
-            }
-        },
-        {
-            "@id": "temperature",
-            "@type": ["ProtocolParameter","ArcProtocolParameter"],
-            "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                "ProtocolParameter": "sdo:Thing",
-                "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                "parameterName": "arc:ARC#ARC_00000100"
-            },
-            "parameterName": {
-                "@id": "temperature",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "temperature",
-                "termSource": "Ontobee",
-                "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                "comments": []
-            }
-        },
-        {
-            "@id": "time",
-            "@type": ["ProtocolParameter","ArcProtocolParameter"],
-            "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                "ProtocolParameter": "sdo:Thing",
-                "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                "parameterName": "arc:ARC#ARC_00000100"
-            },
-            "parameterName": {
-                "@id": "time",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "time",
-                "termSource": "EFO",
-                "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                "comments": []
-            }
-        }
-    ],
     "components": [
         {
             "@id": "#Component_digestion_stopper",
-            "@type": ["Component","ArcComponent"],
+            "@type": ["Component"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-                
-                "Component": "sdo:Thing",
-                "ArcComponent": "arc:ARC#ARC_00000065",
+    
+                "Component": "sdo:PropertyValue",
 
-                "componentName": "arc:ARC#ARC_00000019",
-                "componentType": "arc:ARC#ARC_00000102"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "componentName": "digestion_stopper",
-            "componentType": {
-                "@id": "formic_acid",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "Formic Acid",
-                "termSource": "NCIT",
-                "termAccession": "http://purl.obolibrary.org/obo/NCIT_C83719",
-                "comments": []
-            }
+            "value": "digestion_stopper",
+            "category": "Formic Acid",
+            "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C83719"
         },
         {
             "@id": "#Component_heater",
-            "@type": ["Component","ArcComponent"],
+            "@type": ["Component"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-                
-                "Component": "sdo:Thing",
-                "ArcComponent": "arc:ARC#ARC_00000065",
+    
+                "Component": "sdo:PropertyValue",
 
-                "componentName": "arc:ARC#ARC_00000019",
-                "componentType": "arc:ARC#ARC_00000102"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "componentName": "heater",
-            "componentType": {
-                "@id": "heater",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "Heater Device",
-                "termSource": "NCIT",
-                "termAccession": "http://purl.obolibrary.org/obo/NCIT_C49986",
-                "comments": []
-            }
-        }
-        
+            "value": "heater",
+            "category": "Heater Device",
+            "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C49986"
+        } 
     ],
     "comments": []
 }
@@ -367,22 +235,20 @@ let protocolWithDefaultLD =
     """
     {
     "@id": "http://madeUpProtocolWebsize.org/protein_digestion",
-    "@type": ["Protocol","ArcProtocol"],
+    "@type": ["Protocol"],
     "@context": {
         "sdo": "http://schema.org/",
-        "arc": "http://purl.org/nfdi4plants/ontology/",
+        "bio": "https://bioschemas.org/",
 
-        "Protocol": "sdo:Thing",
-        "ArcProtocol": "arc:ARC#ARC_00000040",
+        "Protocol": "bio:LabProtocol",
 
-        "name": "arc:ARC#ARC_00000019",
-        "protocolType": "arc:ARC#ARC_00000060",
-        "description": "arc:ARC#ARC_00000004",
-        "version": "arc:ARC#ARC_00000020",
-        "components": "arc:ARC#ARC_00000064",
-        "parameters": "arc:ARC#ARC_00000062",
-        "uri": "arc:ARC#ARC_00000061",
-        "comments": "arc:ARC#ARC_00000016"
+        "name": "sdo:name",
+        "protocolType": "bio:intendedUse",
+        "description": "sdo:description",
+        "version": "sdo:version",
+        "components": "bio:labEquipment",
+        "uri": "sdo:url",
+        "comments": "sdo:comment"
     },
     "name": "peptide_digestion",
     "protocolType": {
@@ -390,7 +256,6 @@ let protocolWithDefaultLD =
         "@type": "OntologyAnnotation",
         "@context": {
             "sdo": "http://schema.org/",
-            "arc": "http://purl.org/nfdi4plants/ontology/",
 
             "OntologyAnnotation": "sdo:DefinedTerm",
             
@@ -407,174 +272,45 @@ let protocolWithDefaultLD =
     "description": "The isolated proteins get solubilized. Given protease is added and the solution is heated to a given temperature. After a given amount of time, the digestion is stopped by adding a denaturation agent.",
     "uri": "http://madeUpProtocolWebsize.org/protein_digestion",
     "version": "1.0.0",
-    "parameters": [
-        {
-            "@id": "#Param_http://purl.obolibrary.org/obo/NCIT_C16965",
-            "@type": ["ProtocolParameter","ArcProtocolParameter"],
-            "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                "ProtocolParameter": "sdo:Thing",
-                "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                "parameterName": "arc:ARC#ARC_00000100"
-            },
-            "parameterName": {
-                "@id": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "Peptidase",
-                "termSource": "MS",
-                "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965",
-                "comments": []
-            }
-        },
-        {
-            "@id": "#EmptyProtocolParameter",
-            "@type": ["ProtocolParameter","ArcProtocolParameter"],
-            "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                "ProtocolParameter": "sdo:Thing",
-                "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                "parameterName": "arc:ARC#ARC_00000100"
-            },
-            "parameterName": {
-                "@id": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "temperature",
-                "termSource": "Ontobee",
-                "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029",
-                "comments": []
-            }
-        },
-        {
-            "@id": "#EmptyProtocolParameter",
-            "@type": ["ProtocolParameter","ArcProtocolParameter"],
-            "@context": {
-                "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                "ProtocolParameter": "sdo:Thing",
-                "ArcProtocolParameter": "arc:ARC#ARC_00000063",
-
-                "parameterName": "arc:ARC#ARC_00000100"
-            },
-            "parameterName": {
-                "@id": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "time",
-                "termSource": "EFO",
-                "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721",
-                "comments": []
-            }
-        }
-    ],
     "components": [
         {
             "@id": "#Component_digestion_stopper",
-            "@type": ["Component","ArcComponent"],
+            "@type": ["Component"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-                
-                "Component": "sdo:Thing",
-                "ArcComponent": "arc:ARC#ARC_00000065",
+    
+                "Component": "sdo:PropertyValue",
 
-                "componentName": "arc:ARC#ARC_00000019",
-                "componentType": "arc:ARC#ARC_00000102"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "componentName": "digestion_stopper",
-            "componentType": {
-                "@id": "http://purl.obolibrary.org/obo/NCIT_C83719",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "Formic Acid",
-                "termSource": "NCIT",
-                "termAccession": "http://purl.obolibrary.org/obo/NCIT_C83719",
-                "comments": []
-            }
+            "value": "digestion_stopper",
+            "category": "Formic Acid",
+            "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C83719"
         },
         {
             "@id": "#Component_heater",
-            "@type": ["Component","ArcComponent"],
+            "@type": ["Component"],
             "@context": {
                 "sdo": "http://schema.org/",
-                "arc": "http://purl.org/nfdi4plants/ontology/",
-                
-                "Component": "sdo:Thing",
-                "ArcComponent": "arc:ARC#ARC_00000065",
+    
+                "Component": "sdo:PropertyValue",
 
-                "componentName": "arc:ARC#ARC_00000019",
-                "componentType": "arc:ARC#ARC_00000102"
+                "category": "sdo:name",
+                "categoryCode": "sdo:propertyID",
+                "value": "sdo:value",
+                "valueCode": "sdo:valueReference",
+                "unit": "sdo:unitText",
+                "unitCode": "sdo:unitCode"
             },
-            "componentName": "heater",
-            "componentType": {
-                "@id": "http://purl.obolibrary.org/obo/NCIT_C49986",
-                "@type": "OntologyAnnotation",
-                "@context": {
-                    "sdo": "http://schema.org/",
-                    "arc": "http://purl.org/nfdi4plants/ontology/",
-
-                    "OntologyAnnotation": "sdo:DefinedTerm",
-                    
-                    "annotationValue": "sdo:name",
-                    "termSource": "sdo:inDefinedTermSet",
-                    "termAccession": "sdo:termCode",
-                    "comments": "sdo:disambiguatingDescription"
-                },
-                "annotationValue": "Heater Device",
-                "termSource": "NCIT",
-                "termAccession": "http://purl.obolibrary.org/obo/NCIT_C49986",
-                "comments": []
-            }
-        }
-        
+            "value": "heater",
+            "category": "Heater Device",
+            "categoryCode": "http://purl.obolibrary.org/obo/NCIT_C49986"
+        } 
     ],
     "comments": []
 }

--- a/tests/TestingUtils/TestObjects.Json/Publication.fs
+++ b/tests/TestingUtils/TestObjects.Json/Publication.fs
@@ -22,7 +22,6 @@ let publicationLD =
   "@type": "Publication",
   "@context": {
     "sdo": "http://schema.org/",
-    "arc": "http://purl.org/nfdi4plants/ontology/",
 
     "Publication": "sdo:ScholarlyArticle",
     
@@ -40,7 +39,6 @@ let publicationLD =
     "@type": "OntologyAnnotation",
     "@context": {
       "sdo": "http://schema.org/",
-      "arc": "http://purl.org/nfdi4plants/ontology/",
 
       "OntologyAnnotation": "sdo:DefinedTerm",
       


### PR DESCRIPTION
This PR updates the jsonld/ro-crate export such that the output and contexts now use the new bioschemas types LabProcess and LabProtocol. Also, some structural changes were made to the jsonld output. The json decoders were changed accordingly, so that they can now read typical ISA-JSON or the new RO-Crate format. Each data type therefore has a `fromJsonString` and a `fromJsonldString` function.

The tests were adapted accordingly. However, they are not yet finished. The `InvestigationLD` tests need to be updated, since the current expected json strings are still using the old structure and terms. Furthermore, a new `OutputMatchesInputLDtoLD` test was added in the `ProcessLD` test list that reads the new jsonld string, writes it again and then checks for equality. Such tests should be added for all types (the existing ones read normal ISA-JSON and then write jsonld). @HLWeil pleas add/update these tests before merging.

Another part that needs revision are the readers for Material/Sample/Source. Currently, the type is not determined correctly when reading jsonld. The test `ProcessInputLD - Sample - ReaderSuccessSimple` is deactivated therefore.