### PR TITLE
Add gitattributes contract to gitinitcontracts

### DIFF
--- a/src/ARCtrl/ARC.fs
+++ b/src/ARCtrl/ARC.fs
@@ -346,6 +346,7 @@ type ARC(?isa : ArcInvestigation, ?cwl : CWL.CWL, ?fs : FileSystem.FileSystem) =
         let defaultGitignore = defaultArg defaultGitignore false
         [|
             Contract.Git.Init.createInitContract(?branch = branch)
+            Contract.Git.gitattributesContract
             if defaultGitignore then Contract.Git.gitignoreContract
             if repositoryAddress.IsSome then Contract.Git.Init.createAddRemoteContract repositoryAddress.Value
         |]
@@ -462,6 +463,7 @@ type ARC(?isa : ArcInvestigation, ?cwl : CWL.CWL, ?fs : FileSystem.FileSystem) =
         
     static member DefaultContracts = Map<string,Contract> [|
         ARCtrl.Contract.Git.gitignoreFileName, ARCtrl.Contract.Git.gitignoreContract
+        ARCtrl.Contract.Git.gitattributesFileName, ARCtrl.Contract.Git.gitattributesContract
     |]
 
     static member fromROCrateJsonString (s:string) = 

--- a/src/Contract/Git.fs
+++ b/src/Contract/Git.fs
@@ -15,7 +15,7 @@ let createGitContract(arguments) = Contract.createExecute(gitWithArgs(arguments)
 
 let gitignoreContract = Contract.createCreate(gitignoreFileName,DTOType.PlainText,DTO.Text ARCtrl.FileSystem.DefaultGitignore.dgi)
 
-let gitattributesContract = Contract.createCreate(gitattributesFileName,DTOType.PlainText)
+let gitattributesContract = Contract.createCreate(gitattributesFileName,DTOType.PlainText, DTO.Text ARCtrl.FileSystem.DefaultGitattributes.dga)
 
 type Init = 
 

--- a/src/Contract/Git.fs
+++ b/src/Contract/Git.fs
@@ -5,6 +5,7 @@ open ARCtrl.Contract
 let [<Literal>] git = @"git"  
 let [<Literal>] defaultBranch = @"main" 
 let [<Literal>] gitignoreFileName = @".gitignore" 
+let [<Literal>] gitattributesFileName = @".gitattributes" 
 
 let gitWithArgs(arguments : string []) = CLITool.create(git,arguments)
 
@@ -13,6 +14,8 @@ let createGitContractAt path arguments = Contract.createExecute(gitWithArgs(argu
 let createGitContract(arguments) = Contract.createExecute(gitWithArgs(arguments))
 
 let gitignoreContract = Contract.createCreate(gitignoreFileName,DTOType.PlainText,DTO.Text ARCtrl.FileSystem.DefaultGitignore.dgi)
+
+let gitattributesContract = Contract.createCreate(gitattributesFileName,DTOType.PlainText)
 
 type Init = 
 

--- a/src/FileSystem/ARCtrl.FileSystem.fsproj
+++ b/src/FileSystem/ARCtrl.FileSystem.fsproj
@@ -8,11 +8,11 @@
     <Compile Include="Path.fs" />
     <Compile Include="Commit.fs" />
     <Compile Include="DefaultGitignore.fs" />
+    <Compile Include="DefaultGitattributes.fs" />
     <Compile Include="FileSystemTree.fs" />
     <Compile Include="FileSystem.fs" />
   </ItemGroup>
 	<ItemGroup>
-		<Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
     <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
     <ItemGroup>

--- a/src/FileSystem/DefaultGitattributes.fs
+++ b/src/FileSystem/DefaultGitattributes.fs
@@ -1,0 +1,3 @@
+﻿module ARCtrl.FileSystem.DefaultGitattributes
+
+let dga= """**/dataset/**"""

--- a/tests/ARCtrl/ARCtrl.Contracts.Tests.fs
+++ b/tests/ARCtrl/ARCtrl.Contracts.Tests.fs
@@ -26,24 +26,30 @@ let tests_gitContracts = testList "gitContracts" [
     testCase "init_basic" <| fun _ ->
         let arc = ARC()
         let contracts = arc.GetGitInitContracts()
-        Expect.equal contracts.Length 1 "Should be one contract"
+        Expect.equal contracts.Length 2 "Should be two contracts"
+        /// Check init contract
         Expect.equal contracts.[0].Operation Operation.EXECUTE "Should be an execute operation"
         Expect.isSome contracts.[0].DTOType "Should have a DTO type"
         Expect.equal contracts.[0].DTOType.Value DTOType.CLI "Should be a CLI DTO"
         Expect.equal contracts.[0].Path "" "Should have an empty path"
-        Expect.isSome contracts.[0].DTO "Should have a DTO"
-        let dto = contracts.[0].DTO.Value
+        let dto = Expect.wantSome contracts.[0].DTO "Should have a DTO"
         Expect.isTrue dto.isCLITool "Should be a CLI tool"
         let cli = dto.AsCLITool()
         Expect.equal cli.Name "git" "Should be git"
         Expect.equal cli.Arguments.Length 3 "Should have two arguments"
         Expect.sequenceEqual cli.Arguments [|"init";"-b";"main"|] "Should be init"
+        /// Check gitattributes contract
+        Expect.equal contracts.[1].Operation Operation.CREATE "Should be an create operation"
+        let dtoType = Expect.wantSome contracts.[1].DTOType "Should have a DTO type"
+        Expect.equal dtoType DTOType.PlainText "Should be a plain text"
+        Expect.equal contracts.[1].Path ".gitattributes" "Should have a path"
+        Expect.isNone contracts.[1].DTO "Should not have no DTO"
 
     testCase "init_Branch" <| fun _ ->
         let arc = ARC()
         let branchName = "myBranch"
         let contracts = arc.GetGitInitContracts(branch = branchName)
-        Expect.equal contracts.Length 1 "Should be one contract"
+        Expect.equal contracts.Length 2 "Should be two contracts"
         let dto = contracts.[0].DTO.Value
         let cli = dto.AsCLITool()
         Expect.sequenceEqual cli.Arguments [|"init";"-b";branchName|] "Should have new branchname"
@@ -52,19 +58,19 @@ let tests_gitContracts = testList "gitContracts" [
         let arc = ARC()
         let remote = @"www.fantasyGit.net/MyAccount/MyRepo"
         let contracts = arc.GetGitInitContracts(repositoryAddress = remote)
-        Expect.equal contracts.Length 2 "Should be two contracts"
-        let dto = contracts.[1].DTO.Value
+        Expect.equal contracts.Length 3 "Should be three contracts"
+        let dto = contracts.[2].DTO.Value
         let cli = dto.AsCLITool()
         Expect.sequenceEqual cli.Arguments [|"remote";"add";"origin";remote|] "Should correctly set new remote"
 
     testCase "init_GitIgnore" <| fun _ ->
         let arc = ARC()
         let contracts = arc.GetGitInitContracts(defaultGitignore = true)
-        Expect.equal contracts.Length 2 "Should be two contracts"
-        Expect.equal contracts.[1].Operation Operation.CREATE "Should be an create operation"
-        let dto = contracts.[1].DTO.Value
+        Expect.equal contracts.Length 3 "Should be three contracts"
+        Expect.equal contracts.[2].Operation Operation.CREATE "Should be an create operation"
+        let dto = contracts.[2].DTO.Value
         Expect.isTrue dto.isText "Should be text"
-        Expect.equal contracts.[1].Path ".gitignore" "Should be a gitignore"
+        Expect.equal contracts.[2].Path ".gitignore" "Should be a gitignore"
     testCase "clone_AllOptions" <| fun _ ->
         let remoteURL = @"https://git.fantasyGit.net/MyAccount/MyRepo"
         let user = "Lukas"

--- a/tests/ARCtrl/ARCtrl.Contracts.Tests.fs
+++ b/tests/ARCtrl/ARCtrl.Contracts.Tests.fs
@@ -43,14 +43,17 @@ let tests_gitContracts = testList "gitContracts" [
         let dtoType = Expect.wantSome contracts.[1].DTOType "Should have a DTO type"
         Expect.equal dtoType DTOType.PlainText "Should be a plain text"
         Expect.equal contracts.[1].Path ".gitattributes" "Should have a path"
-        Expect.isNone contracts.[1].DTO "Should not have no DTO"
+        let dto = Expect.wantSome contracts.[1].DTO "Gitattributes contract should have a DTO"
+        Expect.isTrue dto.isText "Should be text"
+        let text = dto.AsText()
+        Expect.equal text "**/dataset/**" "Should have the correct text"
 
     testCase "init_Branch" <| fun _ ->
         let arc = ARC()
         let branchName = "myBranch"
         let contracts = arc.GetGitInitContracts(branch = branchName)
         Expect.equal contracts.Length 2 "Should be two contracts"
-        let dto = contracts.[0].DTO.Value
+        let dto = Expect.wantSome contracts.[0].DTO "Should have a DTO"
         let cli = dto.AsCLITool()
         Expect.sequenceEqual cli.Arguments [|"init";"-b";branchName|] "Should have new branchname"
 
@@ -59,7 +62,7 @@ let tests_gitContracts = testList "gitContracts" [
         let remote = @"www.fantasyGit.net/MyAccount/MyRepo"
         let contracts = arc.GetGitInitContracts(repositoryAddress = remote)
         Expect.equal contracts.Length 3 "Should be three contracts"
-        let dto = contracts.[2].DTO.Value
+        let dto = Expect.wantSome contracts.[2].DTO "Should have a DTO"
         let cli = dto.AsCLITool()
         Expect.sequenceEqual cli.Arguments [|"remote";"add";"origin";remote|] "Should correctly set new remote"
 
@@ -68,7 +71,7 @@ let tests_gitContracts = testList "gitContracts" [
         let contracts = arc.GetGitInitContracts(defaultGitignore = true)
         Expect.equal contracts.Length 3 "Should be three contracts"
         Expect.equal contracts.[2].Operation Operation.CREATE "Should be an create operation"
-        let dto = contracts.[2].DTO.Value
+        let dto = Expect.wantSome contracts.[2].DTO "Should have a DTO"
         Expect.isTrue dto.isText "Should be text"
         Expect.equal contracts.[2].Path ".gitignore" "Should be a gitignore"
     testCase "clone_AllOptions" <| fun _ ->


### PR DESCRIPTION
#354 

I've left the dto empty as asked for in the issue, but maybe we could add a default rule like `**/dataset/**`. Let me know what you think, @Freymaurer @JonasLukasczyk 