### PR TITLE
Update templates json parsing

### DIFF
--- a/src/ARCtrl/Template.Web.fs
+++ b/src/ARCtrl/Template.Web.fs
@@ -5,7 +5,8 @@ open Fable.Core
 
 
 let getTemplates(url: string option) =
-    let defaultURL = @"https://github.com/nfdi4plants/Swate-templates/releases/download/latest/templates.json"
+    let defaultURL = @"https://github.com/nfdi4plants/Swate-templates/releases/download/latest/templates_v2.0.0.json"
+
     let url = defaultArg url defaultURL
     async {
         let! jsonString = ARCtrl.WebRequest.downloadFile url

--- a/src/Json/Table/Templates.fs
+++ b/src/Json/Table/Templates.fs
@@ -92,7 +92,7 @@ module Templates =
         |> Encode.array
 
     let decoder =
-        Decode.dict Template.decoder
+        Decode.array Template.decoder
         
     let fromJsonString (jsonString: string) =
         try Decode.fromJsonString decoder jsonString with

--- a/tests/ARCtrl/Template.Tests.fs
+++ b/tests/ARCtrl/Template.Tests.fs
@@ -11,7 +11,7 @@ open TestingUtils
 let private tests_Web = testList "Web" [
     testCaseAsync "getTemplates" <| async {
         let! templatesMap = ARCtrl.Template.Web.getTemplates(None)
-        Expect.isTrue (templatesMap.Count > 0) "Count > 0"
+        Expect.isTrue (templatesMap.Length > 0) "Count > 0"
     }
 ]
 

--- a/tests/Json/Template.Tests.fs
+++ b/tests/Json/Template.Tests.fs
@@ -84,8 +84,36 @@ let tests_Template =
             Expect.equal actual expected "template"
     ]
 
+let tests_Templates =
+    testList "templates" [
+        testCase "roundabout" <| fun _ ->
+            let table1 = ArcTable.init("My Table")
+            table1.AddColumn(CompositeHeader.Input IOType.Source, [|for i in 0 .. 9 do yield CompositeCell.createFreeText($"Source1 {i}")|])
+            table1.AddColumn(CompositeHeader.Output IOType.Data, [|for i in 0 .. 9 do yield CompositeCell.createFreeText($"Output1 {i}")|])
+            let template1 = Template.init("MyTemplate")
+            template1.Table <- table1
+            template1.Authors <- ResizeArray [|ARCtrl.Person.create(firstName="John", lastName="Doe"); ARCtrl.Person.create(firstName="Jane", lastName="Doe");|]
+            template1.EndpointRepositories <- ResizeArray [|ARCtrl.OntologyAnnotation("Test"); ARCtrl.OntologyAnnotation("Testing second")|]
+
+            let table2 = ArcTable.init("My Table 2")
+            table2.AddColumn(CompositeHeader.Input IOType.Source, [|for i in 0 .. 9 do yield CompositeCell.createFreeText($"Source2 {i}")|])
+            table2.AddColumn(CompositeHeader.Output IOType.Data, [|for i in 0 .. 9 do yield CompositeCell.createFreeText($"Output2 {i}")|])
+            let template2 = Template.init("MyTemplate 2")
+            template2.Table <- table2
+            template2.Authors <- ResizeArray [|ARCtrl.Person.create(firstName="John", lastName="Millter"); ARCtrl.Person.create(firstName="Jane", lastName="Miller");|]
+            template2.EndpointRepositories <- ResizeArray [|ARCtrl.OntologyAnnotation("Test2"); ARCtrl.OntologyAnnotation("Testing second2")|]
+
+            let templates = [|template1; template2|]
+
+            let json = Templates.toJsonString(4) templates
+            let actual = Templates.fromJsonString json
+
+            Expect.equal actual.Length templates.Length "Count"
+            Expect.equal actual.[0].Id templates.[0].Id "id"
+    ]
 
 let main = testList "Template" [
     tests_Organisation
     tests_Template
+    tests_Templates
 ]


### PR DESCRIPTION
Both json encoder and json decoder now expect a Template Array.

closes #375

Updated the default URI to new Swate-templates release v2.0.0

closes #374