### PR TITLE
Increase robustness against OntologyAnnotation mutability issues

### DIFF
--- a/src/Core/Table/ArcTableAux.fs
+++ b/src/Core/Table/ArcTableAux.fs
@@ -310,12 +310,12 @@ module Unchecked =
                 let rowKeys = Array.map snd col |> Set.ofArray
                 for rowIndex = 0 to rowCount - 1 do
                     if not <| rowKeys.Contains rowIndex then
-                        addCellAt (columnIndex,rowIndex,defaultCell) values
+                        addCellAt (columnIndex,rowIndex,defaultCell.Copy()) values
             // No values existed in this column. Fill with default cells
             | None ->
                 let defaultCell = getEmptyCellForHeader header None
                 for rowIndex = 0 to rowCount - 1 do
-                    addCellAt (columnIndex,rowIndex,defaultCell) values
+                    addCellAt (columnIndex,rowIndex,defaultCell.Copy()) values
 
 
     /// Increases the table size to the given new row count and fills the new rows with the last value of the column

--- a/src/Core/Table/CompositeCell.fs
+++ b/src/Core/Table/CompositeCell.fs
@@ -153,6 +153,13 @@ type CompositeCell =
         | Unitized (v,oa) -> $"{v} {oa.NameText}"
         | Data d -> $"{d.NameText}"
 
+    member this.Copy() =
+        match this with
+        | Term oa -> Term (oa.Copy())
+        | FreeText s -> FreeText s
+        | Unitized (v,oa) -> Unitized (v, oa.Copy())
+        | Data d -> Data (d.Copy())
+
 #if FABLE_COMPILER
     //[<CompiledName("Term")>]
     static member term (oa:OntologyAnnotation) = CompositeCell.Term(oa)

--- a/src/Json/Table/CellTable.fs
+++ b/src/Json/Table/CellTable.fs
@@ -42,5 +42,5 @@ module CellTable =
     let decodeCell (ot : CellTableArray) : Decoder<CompositeCell> = 
         Decode.object (fun get ->
             let i = get.Required.Raw Decode.int
-            ot.[i]
+            ot.[i].Copy()
         )

--- a/tests/Core/ArcTable.Tests.fs
+++ b/tests/Core/ArcTable.Tests.fs
@@ -2337,9 +2337,26 @@ let private tests_equality = testList "equality" [
 ]
 
 
-//let private tests_fillMissing = testList "fillMissing" [
+let private tests_fillMissing = testList "fillMissing" [
+        testCase "OntologyAnnotationCopied" <| fun _ ->
+            let table = ArcTable.init "My Table"
 
-//    ]
+            table.AddColumn(CompositeHeader.Input IOType.Source, [|for i in 0 .. 4 do CompositeCell.FreeText $"Source {i}"|])
+
+            table.AddColumn(CompositeHeader.Component (OntologyAnnotation.create("instrument model", "MS", "MS:424242")))
+
+            let cell = table.Values.[(1,0)]
+
+            match cell with
+            | CompositeCell.Term oa -> 
+              oa.Name <- Some "New Name"
+            | _ -> failwith "Expected a term"
+
+            let otherCell = table.Values.[(1,1)]
+
+            Expect.equal (table.Values.[(1,1)]) (table.Values.[(1,2)]) "Should be the same cell"
+            Expect.notEqual cell otherCell "Should not be the same cell"        
+    ]
 
 let main = 
     testList "ArcTable" [
@@ -2365,5 +2382,5 @@ let main =
         tests_IterColumns
         tests_GetHashCode
         tests_equality
-        //tests_fillMissing
+        tests_fillMissing
     ]


### PR DESCRIPTION
ArcTable.FillMissingCells and Json CompositeCell compressed decoder now Copy CompositeCell to avoid OntologyAnnotation mutability issues.

closes #378 