### PR TITLE
Rework Ontoly Term Uri generation

### DIFF
--- a/src/Core/ARCtrl.Core.fsproj
+++ b/src/Core/ARCtrl.Core.fsproj
@@ -5,10 +5,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Helper\Url.fs" />
     <Compile Include="Helper\Regex.fs" />
     <Compile Include="Helper\Identifier.fs" />
     <Compile Include="Helper\Collections.fs" />
+    <Compile Include="Helper\Url.fs" />
     <Compile Include="Helper\HashCodes.fs" />
     <Compile Include="Helper\Printer.fs" />
     <Compile Include="Helper\SemVer.fs" />

--- a/src/Core/ARCtrl.Core.fsproj
+++ b/src/Core/ARCtrl.Core.fsproj
@@ -5,10 +5,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Helper\Regex.fs" />
-    <Compile Include="Helper\Identifier.fs" />
     <Compile Include="Helper\Collections.fs" />
     <Compile Include="Helper\Url.fs" />
+    <Compile Include="Helper\Regex.fs" />
+    <Compile Include="Helper\Identifier.fs" />
     <Compile Include="Helper\HashCodes.fs" />
     <Compile Include="Helper\Printer.fs" />
     <Compile Include="Helper\SemVer.fs" />

--- a/src/Core/Helper/Regex.fs
+++ b/src/Core/Helper/Regex.fs
@@ -89,6 +89,11 @@ module Pattern =
     /// Watch this closely, this could hit some edge cases we do not want to cover.
     let TermAnnotationURIPattern_lessRestrictive = $@".*\/(?<{MatchGroups.idspace}>\w+?)[:_](?<{MatchGroups.localID}>\w+)"
 
+    /// Watch this closely, this could hit some edge cases we do not want to cover.
+    let TermAnnotationURIPattern_MS_RO_PO = $@".*252F(?<{MatchGroups.idspace}>\w+?)_(?<{MatchGroups.localID}>\w+)"
+
+
+
     /// This pattern is used to match both Input and Output columns and capture the IOType as `iotype` group.
     let IOTypePattern = $@"(Input|Output)\s\[(?<{MatchGroups.iotype}>.+)\]"
 
@@ -215,7 +220,8 @@ module ActivePatterns =
         match input with
         | Regex Pattern.TermAnnotationShortPattern value 
         | Regex Pattern.TermAnnotationURIPattern value 
-        | Regex Pattern.TermAnnotationURIPattern_lessRestrictive value ->
+        | Regex Pattern.TermAnnotationURIPattern_lessRestrictive value 
+        | Regex Pattern.TermAnnotationURIPattern_MS_RO_PO value ->
             let idspace = value.Groups.[Pattern.MatchGroups.idspace].Value
             let localID = value.Groups.[Pattern.MatchGroups.localID].Value
             {|IDSpace = idspace; LocalID = localID|}
@@ -307,7 +313,8 @@ let tryParseTermAnnotation (str:string) =
     match str.Trim() with
     | Regex TermAnnotationShortPattern value 
     | Regex TermAnnotationURIPattern value 
-    | Regex TermAnnotationURIPattern_lessRestrictive value ->
+    | Regex TermAnnotationURIPattern_lessRestrictive value 
+    | Regex TermAnnotationURIPattern_MS_RO_PO value ->
         let idspace = value.Groups.[Pattern.MatchGroups.idspace].Value
         let localid = value.Groups.[Pattern.MatchGroups.localID].Value
         {|IDSpace = idspace; LocalID = localid|}

--- a/src/Core/Helper/Url.fs
+++ b/src/Core/Helper/Url.fs
@@ -62,6 +62,7 @@ let uriParserCollection =
 
 
 let createOAUri (tsr : string) (localTan : string) =
-    match uriParserCollection.TryGetValue tsr with
-    | true, parser -> parser tsr localTan
-    | false, _ -> OntobeeParser tsr localTan
+    
+    match Dictionary.tryFind tsr uriParserCollection with
+    | Some parser -> parser tsr localTan
+    | None -> OntobeeParser tsr localTan

--- a/src/Core/Helper/Url.fs
+++ b/src/Core/Helper/Url.fs
@@ -1,4 +1,67 @@
 ﻿module ARCtrl.Helper.Url
 
+open System.Collections.Generic
+
 [<LiteralAttribute>]
 let OntobeeOboPurl = @"http://purl.obolibrary.org/obo/"
+
+let OntobeeParser (tsr : string) (localTan : string) =
+    $"{OntobeeOboPurl}{tsr}_{localTan}"
+
+[<LiteralAttribute>]
+let BioregistryUrl = @"https://bioregistry.io/"
+
+let BioregistryParser (tsr : string) (localTan : string) =
+    $"{BioregistryUrl}{tsr}:{localTan}"
+
+[<LiteralAttribute>]
+let OntobeeDPBOUrl = @"http://purl.org/nfdi4plants/ontology/dpbo/"
+
+let OntobeeDPBOParser (tsr : string) (localTan : string) =
+    $"{OntobeeDPBOUrl}{tsr}_{localTan}"
+
+[<LiteralAttribute>]
+let MSUrl = @"https://www.ebi.ac.uk/ols4/ontologies/ms/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252F"
+
+let MSParser (tsr : string) (localTan : string) =
+    $"{MSUrl}{tsr}_{localTan}"
+
+[<LiteralAttribute>]
+let POUrl = @"https://www.ebi.ac.uk/ols4/ontologies/po/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252F"
+
+let POParser (tsr : string) (localTan : string) =
+    $"{POUrl}{tsr}_{localTan}"
+
+[<LiteralAttribute>]
+let ROUrl = @"https://www.ebi.ac.uk/ols4/ontologies/ro/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252F"
+
+let ROParser (tsr : string) (localTan : string) =
+    $"{ROUrl}{tsr}_{localTan}"
+
+
+/// ENVO, PSI-MS (Prefix MS), CHEBI, GO, OBI, PATO, PECO, PO (purls broken), RO (purls broken), TO, UO, PSI-MOD (prefix MOD), EFO, NCIT, OMP should match to bioregistry parser
+let uriParserCollection = 
+    [
+        "DPBO", OntobeeDPBOParser
+        "MS", MSParser
+        "PO", POParser
+        "RO", ROParser
+        "ENVO", BioregistryParser
+        "CHEBI", BioregistryParser
+        "GO", BioregistryParser
+        "OBI", BioregistryParser
+        "PATO", BioregistryParser
+        "PECO", BioregistryParser
+        "TO", BioregistryParser
+        "UO", BioregistryParser
+        "EFO", BioregistryParser
+        "NCIT", BioregistryParser
+        "OMP", BioregistryParser
+    ]
+    |> Dictionary.ofSeq
+
+
+let createOAUri (tsr : string) (localTan : string) =
+    match uriParserCollection.TryGetValue tsr with
+    | true, parser -> parser tsr localTan
+    | false, _ -> OntobeeParser tsr localTan

--- a/src/Core/OntologyAnnotation.fs
+++ b/src/Core/OntologyAnnotation.fs
@@ -52,7 +52,7 @@ type OntologyAnnotation(?name,?tsr,?tan, ?comments) =
 
     /// Create a path in form of `http://purl.obolibrary.org/obo/MS_1000121` from it's Term Accession Source `MS` and Local Term Accession Number `1000121`. 
     static member createUriAnnotation (termSourceRef : string) (localTAN : string) =
-        $"{Url.OntobeeOboPurl}{termSourceRef}_{localTAN}"
+        Helper.Url.createOAUri termSourceRef localTAN
 
     static member fromTermAnnotation (tan : string, ?name) =
         match Regex.tryParseTermAnnotation tan with

--- a/tests/Core/ARCtrl.Core.Tests.fsproj
+++ b/tests/Core/ARCtrl.Core.Tests.fsproj
@@ -6,6 +6,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="UriHelper.Tests.fs" />
     <Compile Include="Regex.Tests.fs" />
     <Compile Include="Person.Tests.fs" />
     <Compile Include="OntologyAnnotation.Tests.fs" />

--- a/tests/Core/Main.fs
+++ b/tests/Core/Main.fs
@@ -3,6 +3,7 @@
 open Fable.Pyxpecto
 
 let all = testSequenced <| testList "Core" [
+    UriHelper.Tests.main
     DataModel.Tests.main
     OntologyAnnotation.Tests.main
     Regex.Tests.main

--- a/tests/Core/OntologyAnnotation.Tests.fs
+++ b/tests/Core/OntologyAnnotation.Tests.fs
@@ -5,7 +5,7 @@ open ARCtrl
 
 module private Helper = 
     let short = "EFO:0000721"
-    let uri = "http://purl.obolibrary.org/obo/EFO_0000721" 
+    let uri = "https://bioregistry.io/EFO:0000721" 
     let otherParseable = "http://www.ebi.ac.uk/efo/EFO_0000721"
     let other = "Unparseable"
 
@@ -84,19 +84,19 @@ let private tests_constructor = testList "constructor" [
         let oa = OntologyAnnotation(tan = short)
         Expect.equal oa.TermAccessionNumber.Value short "TAN incorrect"
         Expect.equal oa.TermAccessionShort short "short TAN incorrect"
-        Expect.equal oa.TermAccessionOntobeeUrl uri "short TAN incorrect"
+        Expect.equal oa.TermAccessionOntobeeUrl uri "uri TAN incorrect"
     )
     testCase "FromUri" (fun () ->          
         let oa = OntologyAnnotation(tan = uri)
         Expect.equal oa.TermAccessionNumber.Value uri "TAN incorrect"
         Expect.equal oa.TermAccessionShort short "short TAN incorrect"
-        Expect.equal oa.TermAccessionOntobeeUrl uri "short TAN incorrect"
+        Expect.equal oa.TermAccessionOntobeeUrl uri "uri TAN incorrect"
     )
     testCase "FromOtherParseable" (fun () ->          
         let oa = OntologyAnnotation(tan = otherParseable)
         Expect.equal oa.TermAccessionNumber.Value otherParseable "TAN incorrect"
         Expect.equal oa.TermAccessionShort short "short TAN incorrect"
-        Expect.equal oa.TermAccessionOntobeeUrl uri "short TAN incorrect"
+        Expect.equal oa.TermAccessionOntobeeUrl uri "uri TAN incorrect"
     )
     testCase "FromOther" (fun () ->          
         let oa = OntologyAnnotation(tan = other)

--- a/tests/Core/UriHelper.Tests.fs
+++ b/tests/Core/UriHelper.Tests.fs
@@ -1,0 +1,70 @@
+﻿module UriHelper.Tests
+
+open TestingUtils
+open ARCtrl
+
+let private tests_createUri =
+    testList "CreateUri" [
+        testCase "DPBO" (fun () ->
+            let tsr = "DPBO"
+            let localTan = "0002006"
+
+            let uri = Helper.Url.createOAUri tsr localTan
+            let expectedUri = @"http://purl.org/nfdi4plants/ontology/dpbo/DPBO_0002006"
+            Expect.equal uri expectedUri ""
+        )
+        testCase "MS" (fun () ->
+            let tsr = "MS"
+            let localTan = "1000121"
+
+            let uri = Helper.Url.createOAUri tsr localTan
+            let expectedUri = @"https://www.ebi.ac.uk/ols4/ontologies/ms/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FMS_1000121"
+            Expect.equal uri expectedUri ""
+        )
+        testCase "PO" (fun () ->
+            let tsr = "PO"
+            let localTan = "0007033"
+
+            let uri = Helper.Url.createOAUri tsr localTan
+            let expectedUri = @"https://www.ebi.ac.uk/ols4/ontologies/po/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPO_0007033"
+            Expect.equal uri expectedUri ""
+        )
+        testCase "RO" (fun () ->
+            let tsr = "RO"
+            let localTan = "0002533"
+
+            let uri = Helper.Url.createOAUri tsr localTan
+            let expectedUri = @"https://www.ebi.ac.uk/ols4/ontologies/ro/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FRO_0002533"
+            Expect.equal uri expectedUri ""
+        )
+        testCase "EFO" (fun () ->
+            let tsr = "EFO"
+            let localTan = "0000001"
+
+            let uri = Helper.Url.createOAUri tsr localTan
+            let expectedUri = @"https://bioregistry.io/EFO:0000001"
+            Expect.equal uri expectedUri ""
+        )
+        testCase "NCIT" (fun () ->
+            let tsr = "NCIT"
+            let localTan = "C12345"
+
+            let uri = Helper.Url.createOAUri tsr localTan
+            let expectedUri = @"https://bioregistry.io/NCIT:C12345"
+            Expect.equal uri expectedUri ""
+        )
+        testCase "BackupPurl" (fun () ->
+            let tsr = "OGG"
+            let localTan = "3000009507"
+
+            let uri = Helper.Url.createOAUri tsr localTan
+            let expectedUri = @"http://purl.obolibrary.org/obo/OGG_3000009507"
+            Expect.equal uri expectedUri ""
+        )
+    ]
+
+let main = 
+    testList "UriHelper" [
+        tests_createUri
+    ]
+

--- a/tests/TestingUtils/TestObjects.Spreadsheet/Spreadsheet.ArcTable.fs
+++ b/tests/TestingUtils/TestObjects.Spreadsheet/Spreadsheet.ArcTable.fs
@@ -35,12 +35,12 @@ module Parameter =
     let temperatureValueV1 = "5"
     let temperatureValueV2 = "degree celsius"
     let temperatureValueV3 = "UO"
-    let temperatureValueV4 = "http://purl.obolibrary.org/obo/UO_0000027"
+    let temperatureValueV4 = Helper.Url.createOAUri "UO" "0000027"
 
     let temperatureValue2V1 = "10"
     let temperatureValue2V2 = "degree celsius"
     let temperatureValue2V3 = "UO"
-    let temperatureValue2V4 = "http://purl.obolibrary.org/obo/UO_0000027"
+    let temperatureValue2V4 = Helper.Url.createOAUri "UO" "0000027"
 
     let appendTemperatureColumn l (c : FsCellsCollection) (t : FsTable) = 
         let colCount = if t.IsEmpty(c) then 0 else t.ColumnCount()
@@ -76,7 +76,7 @@ module Parameter =
             (OntologyAnnotation("instrument model","MS","MS:1000031"))
     let instrumentValue = 
         CompositeCell.createTermFromString
-            ("Thermo Fisher Scientific instrument model","MS","http://purl.obolibrary.org/obo/MS_1000483")
+            ("Thermo Fisher Scientific instrument model","MS",Helper.Url.createOAUri "MS" "1000483")
 
 
     let instrumentHeaderV1 = "Parameter [instrument model]"
@@ -85,7 +85,7 @@ module Parameter =
 
     let instrumentValueV1 = "Thermo Fisher Scientific instrument model"
     let instrumentValueV2 = "MS"
-    let instrumentValueV3 = "http://purl.obolibrary.org/obo/MS_1000483"
+    let instrumentValueV3 = Helper.Url.createOAUri "MS" "1000483"
 
     let appendInstrumentColumn l (c : FsCellsCollection) (t : FsTable) = 
         let colCount = if t.IsEmpty(c) then 0 else t.ColumnCount()
@@ -143,7 +143,8 @@ module Factor =
     let timeValueV1 = "10"
     let timeValueV2 = "hour"
     let timeValueV3 = "UO"
-    let timeValueV4 = "http://purl.obolibrary.org/obo/UO_0000032"
+    let timeValueV4 = Helper.Url.createOAUri "UO" "0000032"
+
 
     let appendTimeColumn l (c : FsCellsCollection) (t : FsTable) = 
         let colCount = if t.IsEmpty(c) then 0 else t.ColumnCount()
@@ -345,7 +346,7 @@ module Protocol =
         
         let collectionValue =
             CompositeCell.createTermFromString
-                ("sample collection protocol","DPBO","http://purl.obolibrary.org/obo/DPBO_1000169")
+                ("sample collection protocol","DPBO",Helper.Url.createOAUri "DPBO" "1000169")
 
         let collectionHeaderV1 = "Protocol Type"
         let collectionHeaderV2 = "Term Source REF (DPBO:1000161)"
@@ -353,7 +354,7 @@ module Protocol =
 
         let collectionValueV1 = "sample collection protocol"
         let collectionValueV2 = "DPBO"
-        let collectionValueV3 = "http://purl.obolibrary.org/obo/DPBO_1000169"
+        let collectionValueV3 = Helper.Url.createOAUri "DPBO" "1000169"
 
         let appendCollectionColumn l (c : FsCellsCollection) (t : FsTable) = 
             let colCount = if t.IsEmpty(c) then 0 else t.ColumnCount()
@@ -372,7 +373,7 @@ module Protocol =
                 (OntologyAnnotation("instrument model","MS","MS:1000031"))
         let instrumentValue = 
             CompositeCell.createTermFromString
-                ("Thermo Fisher Scientific instrument model","MS","http://purl.obolibrary.org/obo/MS_1000483")
+                ("Thermo Fisher Scientific instrument model","MS",Helper.Url.createOAUri "MS" "1000483")
 
 
         let instrumentHeaderV1 = "Component [instrument model]"
@@ -381,7 +382,7 @@ module Protocol =
 
         let instrumentValueV1 = "Thermo Fisher Scientific instrument model"
         let instrumentValueV2 = "MS"
-        let instrumentValueV3 = "http://purl.obolibrary.org/obo/MS_1000483"
+        let instrumentValueV3 = Helper.Url.createOAUri "MS" "1000483"
 
         let appendInstrumentColumn l (c : FsCellsCollection) (t : FsTable) = 
             let colCount = if t.IsEmpty(c) then 0 else t.ColumnCount()

--- a/tests/TestingUtils/TestObjects.Spreadsheet/Spreadsheet.Template.fs
+++ b/tests/TestingUtils/TestObjects.Spreadsheet/Spreadsheet.Template.fs
@@ -38,11 +38,11 @@ let templateMetadata =
     row9.[6].Value <- "ENA"
     let row10 = ws.Row(10)
     row10.[1].Value <- "ER Term Accession Number"
-    row10.[2].Value <- "http://purl.obolibrary.org/obo/DPBO_1000096"
-    row10.[3].Value <- "http://purl.obolibrary.org/obo/NFDI4PSO_1000097"
-    row10.[4].Value <- "http://purl.obolibrary.org/obo/NFDI4PSO_1000098"
-    row10.[5].Value <- "http://purl.obolibrary.org/obo/NFDI4PSO_0010002"
-    row10.[6].Value <- "http://purl.obolibrary.org/obo/DPBO_0010000"
+    row10.[2].Value <- ARCtrl.Helper.Url.createOAUri "DPBO" "1000096"
+    row10.[3].Value <- ARCtrl.Helper.Url.createOAUri "NFDI4PSO" "1000097"
+    row10.[4].Value <- ARCtrl.Helper.Url.createOAUri "NFDI4PSO" "1000098"
+    row10.[5].Value <- ARCtrl.Helper.Url.createOAUri "NFDI4PSO" "0010002"
+    row10.[6].Value <- ARCtrl.Helper.Url.createOAUri "DPBO" "0010000"
     let row11 = ws.Row(11)
     row11.[1].Value <- "ER Term Source REF"
     row11.[2].Value <- "DPBO"
@@ -63,8 +63,8 @@ let templateMetadata =
     let row14 = ws.Row(14)
     row14.[1].Value <- "Tags Term Accession Number"
     row14.[2].Value <- ""
-    row14.[3].Value <- "http://purl.obolibrary.org/obo/NCIT_C71492"
-    row14.[4].Value <- "http://purl.obolibrary.org/obo/DPBO_1000164"
+    row14.[3].Value <- ARCtrl.Helper.Url.createOAUri "NCIT" "C71492"
+    row14.[4].Value <- ARCtrl.Helper.Url.createOAUri "DPBO" "1000164"
     row14.[5].Value <- ""
     row14.[6].Value <- ""
     let row15 = ws.Row(15)
@@ -195,7 +195,7 @@ let templateMetadata_deprecatedKeys =
     row8.[6].Value <- "ENA"
     let row9 = ws.Row(9)
     row9.[1].Value <- "ER Term Accession Number"
-    row9.[2].Value <- "http://purl.obolibrary.org/obo/DPBO_1000096"
+    row9.[2].Value <- ARCtrl.Helper.Url.createOAUri "DPBO" "1000096"
     row9.[3].Value <- "NFDI4PSO:1000097"
     row9.[4].Value <- "NFDI4PSO:1000098"
     row9.[5].Value <- "NFDI4PSO:0010002"
@@ -220,8 +220,8 @@ let templateMetadata_deprecatedKeys =
     let row13 = ws.Row(13)
     row13.[1].Value <- "Tags Term Accession Number"
     row13.[2].Value <- ""
-    row13.[3].Value <- "http://purl.obolibrary.org/obo/NCIT_C71492"
-    row13.[4].Value <- "http://purl.obolibrary.org/obo/DPBO_1000164"
+    row13.[3].Value <- ARCtrl.Helper.Url.createOAUri "NCIT" "C71492"
+    row13.[4].Value <- ARCtrl.Helper.Url.createOAUri "DPBO" "1000164"
     row13.[5].Value <- ""
     row13.[6].Value <- ""
     let row14 = ws.Row(14)


### PR DESCRIPTION
URL generation does now not always produce PURLs, but different URLs depending on the Ontology namespace.

```
  "DPBO", OntobeeDPBOParser
  "MS", MSParser
  "PO", POParser
  "RO", ROParser
  "ENVO", BioregistryParser
  "CHEBI", BioregistryParser
  "GO", BioregistryParser
  "OBI", BioregistryParser
  "PATO", BioregistryParser
  "PECO", BioregistryParser
  "TO", BioregistryParser
  "UO", BioregistryParser
  "EFO", BioregistryParser
  "NCIT", BioregistryParser
  "OMP", BioregistryParser
```

closes #368 