### PR TITLE
Make use of @id referencing in isa json writing

### DIFF
--- a/src/ARCtrl/Json.fs
+++ b/src/ARCtrl/Json.fs
@@ -23,7 +23,7 @@ module JsonHelper =
         member _.fromROCrateJsonString (s: string) = ArcAssay.fromROCrateJsonString s
         member _.toJsonString (assay: ArcAssay, ?spaces) = ArcAssay.toJsonString(?spaces=spaces) assay
         member _.toCompressedJsonString (assay: ArcAssay,?spaces) = ArcAssay.toCompressedJsonString(?spaces=spaces) assay
-        member _.toISAJsonString (assay: ArcAssay, ?spaces) = ArcAssay.toISAJsonString(?spaces=spaces) assay
+        member _.toISAJsonString (assay: ArcAssay, ?spaces, ?useIDReferencing) = ArcAssay.toISAJsonString(?spaces=spaces, ?useIDReferencing = useIDReferencing) assay
         member _.toROCrateJsonString(assay: ArcAssay, studyName, ?spaces) = ArcAssay.toROCrateJsonString(studyName, ?spaces=spaces) assay
 
     [<AttachMembers>]
@@ -34,7 +34,7 @@ module JsonHelper =
         member _.fromROCrateJsonString (s: string) = ArcStudy.fromROCrateJsonString s
         member _.toJsonString (study: ArcStudy, ?spaces) = ArcStudy.toJsonString(?spaces=spaces) study
         member _.toCompressedJsonString (study: ArcStudy, ?spaces) = ArcStudy.toCompressedJsonString(?spaces=spaces) study
-        member _.toISAJsonString (study: ArcStudy, ?assays,?spaces) = ArcStudy.toISAJsonString(?assays=assays,?spaces=spaces) study
+        member _.toISAJsonString (study: ArcStudy, ?assays,?spaces, ?useIDReferencing) = ArcStudy.toISAJsonString(?assays=assays,?spaces=spaces, ?useIDReferencing = useIDReferencing) study
         member _.toROCrateJsonString(study: ArcStudy, ?assays,?spaces) = ArcStudy.toROCrateJsonString(?assays=assays,?spaces=spaces) study
 
     [<AttachMembers>]
@@ -45,7 +45,7 @@ module JsonHelper =
         member _.fromROCrateJsonString (s: string) = ArcInvestigation.fromROCrateJsonString s
         member _.toJsonString (investigation: ArcInvestigation, ?spaces) = ArcInvestigation.toJsonString(?spaces=spaces) investigation
         member _.toCompressedJsonString (investigation: ArcInvestigation, ?spaces) = ArcInvestigation.toCompressedJsonString(?spaces=spaces) investigation
-        member _.toISAJsonString (investigation: ArcInvestigation, ?spaces) = ArcInvestigation.toISAJsonString(?spaces=spaces) investigation
+        member _.toISAJsonString (investigation: ArcInvestigation, ?spaces, ?useIDReferencing) = ArcInvestigation.toISAJsonString(?spaces=spaces, ?useIDReferencing = useIDReferencing) investigation
         member _.toROCrateJsonString(investigation: ArcInvestigation, ?spaces) = ArcInvestigation.toROCrateJsonString(?spaces=spaces) investigation
 
     [<AttachMembers>]

--- a/src/Json/ARCtrl.Json.fsproj
+++ b/src/Json/ARCtrl.Json.fsproj
@@ -32,6 +32,7 @@
     <Compile Include="ConverterOptions.fs" />
     <Compile Include="Decode.fs" />
     <Compile Include="Encode.fs" />
+    <Compile Include="IDTable.fs" />
     <Compile Include="StringTable.fs" />
     <Compile Include="Comment.fs" />
     <Compile Include="OntologyAnnotation.fs" />
@@ -84,7 +85,6 @@
     <ProjectReference Include="..\Core\ARCtrl.Core.fsproj" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
     <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Json/Comment.fs
+++ b/src/Json/Comment.fs
@@ -58,8 +58,20 @@ module Comment =
 
     module ISAJson =
 
-        let encoder = encoder
-        
+        let encoder (idMap : IDTable.IDTableWrite option) (comment : Comment) = 
+            let f (comment : Comment) =
+                [
+                    Encode.tryInclude "@id" Encode.string (ROCrate.genID comment |> Some)
+                    Encode.tryInclude "name" Encode.string (comment.Name)
+                    Encode.tryInclude "value" Encode.string (comment.Value)
+                ]
+                |> Encode.choose
+                |> Encode.object
+            match idMap with
+            | Some idMap -> IDTable.encode ROCrate.genID f comment idMap
+            | None -> f comment
+
+
         let decoder = decoder
 
 [<AutoOpen>]
@@ -94,7 +106,7 @@ module CommentExtensions =
 
         static member toISAJsonString(?spaces) =
             fun (c:Comment) ->
-                Comment.ISAJson.encoder c
+                Comment.ISAJson.encoder None c
                 |> Encode.toJsonString (Encode.defaultSpaces spaces)
 
         member this.toISAJsonString(?spaces) =

--- a/src/Json/IDTable.fs
+++ b/src/Json/IDTable.fs
@@ -12,10 +12,15 @@ module IDTable =
 
     type IDTableRead = Dictionary<URI,obj>
 
+    let encodeID id =
+        ["@id",Encode.string id]
+        |> Encode.object
+
     let encode (genID: 'Value -> URI) (encoder : 'Value -> Json) (value : 'Value) (table:IDTableWrite) =
-        match table.TryGetValue(genID value) with
-        | true, v -> v
-        | false, _ -> 
+        let id = genID value
+        if table.ContainsKey id then 
+           encodeID id
+        else
             let v = encoder value
             table.Add(genID value, v)
-            v
+            v            

--- a/src/Json/IDTable.fs
+++ b/src/Json/IDTable.fs
@@ -1,0 +1,21 @@
+﻿namespace ARCtrl.Json
+
+open System.Collections.Generic
+open Thoth.Json.Core
+open ARCtrl
+
+open ARCtrl.Helper
+
+module IDTable =
+
+    type IDTableWrite = Dictionary<URI,Json>
+
+    type IDTableRead = Dictionary<URI,obj>
+
+    let encode (genID: 'Value -> URI) (encoder : 'Value -> Json) (value : 'Value) (table:IDTableWrite) =
+        match table.TryGetValue(genID value) with
+        | true, v -> v
+        | false, _ -> 
+            let v = encoder value
+            table.Add(genID value, v)
+            v

--- a/src/Json/OntologyAnnotation.fs
+++ b/src/Json/OntologyAnnotation.fs
@@ -22,7 +22,7 @@ module AnnotationValue =
 
 module OntologyAnnotation =  
 
-    let encoder (oa : OntologyAnnotation) = 
+    let encoder (oa : OntologyAnnotation) =         
         [
             Encode.tryInclude "annotationValue" Encode.string (oa.Name)
             Encode.tryInclude "termSource" Encode.string (oa.TermSourceREF)
@@ -127,12 +127,18 @@ module OntologyAnnotation =
         
         let encoder (idMap : IDTable.IDTableWrite option) (oa : OntologyAnnotation) = 
             let f = fun (oa : OntologyAnnotation) ->
+                let comments = 
+                    oa.Comments
+                    |> Seq.filter (fun c -> 
+                        match c.Name with
+                        | Some n when n = Process.ColumnIndex.orderName -> false
+                        | _ -> true)
                 [
                     Encode.tryInclude "@id" Encode.string (ROCrate.genID oa |> Some)
                     Encode.tryInclude "annotationValue" Encode.string (oa.Name)
                     Encode.tryInclude "termSource" Encode.string (oa.TermSourceREF)
                     Encode.tryInclude "termAccession" Encode.string (oa.TermAccessionNumber)
-                    Encode.tryIncludeSeq "comments" Comment.encoder (oa.Comments)
+                    Encode.tryIncludeSeq "comments" Comment.encoder comments
                 ]
                 |> Encode.choose
                 |> Encode.object

--- a/src/Json/OntologySourceReference.fs
+++ b/src/Json/OntologySourceReference.fs
@@ -66,21 +66,17 @@ module OntologySourceReference =
             )
 
     module ISAJson =
-        let encoder (idMap : IDTable.IDTableWrite option) (osr : OntologySourceReference) = 
-            let f = fun (osr : OntologySourceReference) ->
-                [
-                    Encode.tryInclude "@id" Encode.string (ROCrate.genID osr |> Some)
-                    Encode.tryInclude "description" Encode.string (osr.Description)
-                    Encode.tryInclude "file" Encode.string (osr.File)
-                    Encode.tryInclude "name" Encode.string (osr.Name)
-                    Encode.tryInclude "version" Encode.string (osr.Version)
-                    Encode.tryIncludeSeq "comments" (Comment.ISAJson.encoder idMap) (osr.Comments)
-                ]
-                |> Encode.choose
-                |> Encode.object
-            match idMap with
-            | Some idMap -> IDTable.encode (fun x -> ROCrate.genID x) f osr idMap
-            | None -> f osr
+        let encoder (idMap : IDTable.IDTableWrite option) (osr : OntologySourceReference) =         
+            [
+                Encode.tryInclude "description" Encode.string (osr.Description)
+                Encode.tryInclude "file" Encode.string (osr.File)
+                Encode.tryInclude "name" Encode.string (osr.Name)
+                Encode.tryInclude "version" Encode.string (osr.Version)
+                Encode.tryIncludeSeq "comments" (Comment.ISAJson.encoder idMap) (osr.Comments)
+            ]
+            |> Encode.choose
+            |> Encode.object
+            
 
         let decoder = decoder
 

--- a/src/Json/Process/AssayMaterials.fs
+++ b/src/Json/Process/AssayMaterials.fs
@@ -10,12 +10,12 @@ module AssayMaterials =
 
     module ISAJson = 
 
-        let encoder (ps : Process list) = 
+        let encoder idMap (ps : Process list) = 
             let samples = ProcessSequence.getSamples ps
             let materials = ProcessSequence.getMaterials ps
             [
-                Encode.tryIncludeList "samples" Sample.ISAJson.encoder samples
-                Encode.tryIncludeList "otherMaterials" Material.ISAJson.encoder materials
+                Encode.tryIncludeList "samples" (Sample.ISAJson.encoder idMap) samples
+                Encode.tryIncludeList "otherMaterials" (Material.ISAJson.encoder idMap) materials
             ]
            
             |> Encode.choose

--- a/src/Json/Process/Component.fs
+++ b/src/Json/Process/Component.fs
@@ -22,17 +22,12 @@ module Component =
             PropertyValue.ROCrate.genID c
 
         let encoder (idMap : IDTable.IDTableWrite option) (c : Component) = 
-            let f (c : Component) =
-                [
-                    Encode.tryInclude "@id" Encode.string (c |> genID |> Some)
-                    Encode.tryInclude "componentName" Encode.string c.ComponentName
-                    Encode.tryInclude "componentType" (OntologyAnnotation.ISAJson.encoder idMap) c.ComponentType
-                ]
-                |> Encode.choose
-                |> Encode.object
-            match idMap with
-            | None -> f c
-            | Some idMap -> IDTable.encode genID f c idMap
+            [
+                Encode.tryInclude "componentName" Encode.string c.ComponentName
+                Encode.tryInclude "componentType" (OntologyAnnotation.ISAJson.encoder idMap) c.ComponentType
+            ]
+            |> Encode.choose
+            |> Encode.object
 
         let decoder: Decoder<Component> =
             Decode.object (fun get ->

--- a/src/Json/Process/Component.fs
+++ b/src/Json/Process/Component.fs
@@ -18,13 +18,21 @@ module Component =
     
     module ISAJson =
 
-        let encoder (c : Component) = 
-            [
-                Encode.tryInclude "componentName" Encode.string c.ComponentName
-                Encode.tryInclude "componentType" OntologyAnnotation.ISAJson.encoder c.ComponentType
-            ]
-            |> Encode.choose
-            |> Encode.object
+        let genID (c : Component) = 
+            PropertyValue.ROCrate.genID c
+
+        let encoder (idMap : IDTable.IDTableWrite option) (c : Component) = 
+            let f (c : Component) =
+                [
+                    Encode.tryInclude "@id" Encode.string (c |> genID |> Some)
+                    Encode.tryInclude "componentName" Encode.string c.ComponentName
+                    Encode.tryInclude "componentType" (OntologyAnnotation.ISAJson.encoder idMap) c.ComponentType
+                ]
+                |> Encode.choose
+                |> Encode.object
+            match idMap with
+            | None -> f c
+            | Some idMap -> IDTable.encode genID f c idMap
 
         let decoder: Decoder<Component> =
             Decode.object (fun get ->
@@ -50,9 +58,11 @@ module ComponentExtensions =
         static member fromISAJsonString (s:string) = 
             Decode.fromJsonString Component.ISAJson.decoder s   
 
-        static member toISAJsonString(?spaces) =
+        static member toISAJsonString(?spaces, ?useIDReferencing) =
+            let useIDReferencing = Option.defaultValue false useIDReferencing
+            let idMap = if useIDReferencing then Some (System.Collections.Generic.Dictionary()) else None
             fun (f:Component) ->
-                Component.ISAJson.encoder f
+                Component.ISAJson.encoder idMap f
                 |> Encode.toJsonString (Encode.defaultSpaces spaces)
 
         member this.toISAJsonString(?spaces) =

--- a/src/Json/Process/ProcessInput.fs
+++ b/src/Json/Process/ProcessInput.fs
@@ -30,16 +30,16 @@ module ProcessInput =
 
     module ISAJson =
 
-        let encoder (value : ProcessInput) = 
+        let encoder idMap (value : ProcessInput) = 
             match value with
             | ProcessInput.Source s-> 
-                Source.ISAJson.encoder s
+                Source.ISAJson.encoder idMap s
             | ProcessInput.Sample s -> 
-                Sample.ISAJson.encoder s
+                Sample.ISAJson.encoder idMap s
             | ProcessInput.Data d -> 
-                Data.ISAJson.encoder d
+                Data.ISAJson.encoder idMap d
             | ProcessInput.Material m -> 
-                Material.ISAJson.encoder m
+                Material.ISAJson.encoder idMap m
 
         let decoder: Decoder<ProcessInput> =
             Decode.oneOf [
@@ -57,10 +57,12 @@ module ProcessInputExtensions =
         static member fromISAJsonString (s:string) = 
             Decode.fromJsonString ProcessInput.ISAJson.decoder s   
 
-        static member toISAJsonString(?spaces) =
+        static member toISAJsonString(?spaces, ?useIDReferencing) =
+            let useIDReferencing = Option.defaultValue false useIDReferencing
+            let idMap = if useIDReferencing then Some (System.Collections.Generic.Dictionary()) else None           
             fun (f:ProcessInput) ->
-                ProcessInput.ISAJson.encoder f
+                ProcessInput.ISAJson.encoder idMap f
                 |> Encode.toJsonString (Encode.defaultSpaces spaces)
 
-        member this.ToISAJsonString(?spaces) =
-            ProcessInput.toISAJsonString(?spaces=spaces) this
+        member this.ToISAJsonString(?spaces, ?useIDReferencing) =
+            ProcessInput.toISAJsonString(?spaces=spaces, ?useIDReferencing = useIDReferencing) this

--- a/src/Json/Process/ProcessOutput.fs
+++ b/src/Json/Process/ProcessOutput.fs
@@ -27,14 +27,14 @@ module ProcessOutput =
 
     module ISAJson =
 
-        let encoder (value : ProcessOutput) = 
+        let encoder idMap (value : ProcessOutput) = 
             match value with
             | ProcessOutput.Sample s -> 
-                Sample.ISAJson.encoder s
+                Sample.ISAJson.encoder idMap s
             | ProcessOutput.Data d -> 
-                Data.ISAJson.encoder d
+                Data.ISAJson.encoder idMap d
             | ProcessOutput.Material m -> 
-                Material.ISAJson.encoder m
+                Material.ISAJson.encoder idMap m
 
         let decoder: Decoder<ProcessOutput> =
             Decode.oneOf [
@@ -52,13 +52,15 @@ module ProcessOutputExtensions =
         static member fromISAJsonString (s:string) = 
             Decode.fromJsonString ProcessOutput.ISAJson.decoder s   
 
-        static member toISAJsonString(?spaces) =
+        static member toISAJsonString(?spaces, ?useIDReferencing) =
+            let useIDReferencing = defaultArg useIDReferencing false
+            let idMap = if useIDReferencing then Some (System.Collections.Generic.Dictionary()) else None
             fun (f:ProcessOutput) ->
-                ProcessOutput.ISAJson.encoder f
+                ProcessOutput.ISAJson.encoder idMap f
                 |> Encode.toJsonString (Encode.defaultSpaces spaces)
 
-        member this.toISAJsonString(?spaces) = 
-            ProcessOutput.toISAJsonString(?spaces=spaces) this
+        member this.toISAJsonString(?spaces, ?useIDReferencing) = 
+            ProcessOutput.toISAJsonString(?spaces=spaces, ?useIDReferencing = useIDReferencing) this
 
         static member fromROCrateJsonString (s:string) =
             Decode.fromJsonString ProcessOutput.ROCrate.decoder s

--- a/src/Json/Process/ProcessParameterValue.fs
+++ b/src/Json/Process/ProcessParameterValue.fs
@@ -21,17 +21,14 @@ module ProcessParameterValue =
             failwith "Not implemented"
 
         let encoder (idMap : IDTable.IDTableWrite option) (oa : ProcessParameterValue) = 
-            let f (oa : ProcessParameterValue) =
-                [
-                    Encode.tryInclude "category" (ProtocolParameter.ISAJson.encoder idMap) oa.Category
-                    Encode.tryInclude "value" (Value.ISAJson.encoder idMap) oa.Value
-                    Encode.tryInclude "unit" (OntologyAnnotation.ISAJson.encoder idMap) oa.Unit
-                ]
-                |> Encode.choose
-                |> Encode.object
-            match idMap with
-            | None -> f oa
-            | Some idMap -> IDTable.encode genID f oa idMap
+            [
+                Encode.tryInclude "category" (ProtocolParameter.ISAJson.encoder idMap) oa.Category
+                Encode.tryInclude "value" (Value.ISAJson.encoder idMap) oa.Value
+                Encode.tryInclude "unit" (OntologyAnnotation.ISAJson.encoder idMap) oa.Unit
+            ]
+            |> Encode.choose
+            |> Encode.object
+            
 
         let decoder : Decoder<ProcessParameterValue> =
             Decode.object (fun get ->

--- a/src/Json/Process/ProcessSequence.fs
+++ b/src/Json/Process/ProcessSequence.fs
@@ -10,10 +10,12 @@ type ProcessSequence =
     static member fromISAJsonString (s:string) = 
         Decode.fromJsonString (Decode.list Process.ISAJson.decoder) s  
 
-    static member toISAJsonString (spaces) =
+    static member toISAJsonString(?spaces, ?useIDReferencing) =
+        let useIDReferencing = Option.defaultValue false useIDReferencing
+        let idMap = if useIDReferencing then Some (System.Collections.Generic.Dictionary()) else None
         fun (f:Process list) ->
             f
-            |> List.map Process.ISAJson.encoder
+            |> List.map (Process.ISAJson.encoder None None idMap)
             |> Encode.list
             |> Encode.toJsonString (Encode.defaultSpaces spaces)
 

--- a/src/Json/Process/PropertyValue.fs
+++ b/src/Json/Process/PropertyValue.fs
@@ -13,7 +13,7 @@ module PropertyValue =
         
         let genID (p : IPropertyValue<'T>) = 
             match p.GetCategory() with
-            | Some t -> $"{p.GetAdditionalType()}/{t}{p.GetValue()}{p.GetUnit()}"
+            | Some t -> $"{p.GetAdditionalType()}/{OntologyAnnotation.ROCrate.genID t}{p.GetValue()}{p.GetUnit()}"
             | None -> $"#Empty{p.GetAdditionalType()}"
 
         let encoder<'T> (pv : IPropertyValue<'T>) = 

--- a/src/Json/Process/PropertyValue.fs
+++ b/src/Json/Process/PropertyValue.fs
@@ -12,9 +12,10 @@ module PropertyValue =
     module ROCrate =
         
         let genID (p : IPropertyValue<'T>) = 
-            match p.GetCategory() with
-            | Some t -> $"{p.GetAdditionalType()}/{OntologyAnnotation.ROCrate.genID t}{p.GetValue()}{p.GetUnit()}"
-            | None -> $"#Empty{p.GetAdditionalType()}"
+            match p.GetCategory(),p.GetValue(),p.GetUnit() with
+            | Some t, Some v, Some u -> $"#{p.GetAdditionalType()}/{t.NameText}={v.Text}{u.NameText}"
+            | Some t, Some v, None-> $"#{p.GetAdditionalType()}/{t.NameText}={v.Text}"
+            | _ -> $"#Empty{p.GetAdditionalType()}"
 
         let encoder<'T> (pv : IPropertyValue<'T>) = 
             let categoryName, categoryURL = 

--- a/src/Json/Process/Protocol.fs
+++ b/src/Json/Process/Protocol.fs
@@ -10,17 +10,20 @@ module Protocol =
     module ROCrate =
 
         let genID (studyName:string Option) (assayName:string Option) (processName:string Option) (p:Protocol): string = 
-            match p.Uri with
-            | Some u -> u
-            | None -> 
-                match p.Name with
-                | Some n -> "#Protocol_" + n.Replace(" ","_")
+            match p.ID with
+            | Some id when id <> "" -> id
+            | _ ->
+                match p.Uri with
+                | Some u -> u
                 | None -> 
-                    match (studyName,assayName,processName) with
-                    | (Some sn, Some an, Some pn) -> "#Protocol_" + sn.Replace(" ","_") + "_" + an.Replace(" ","_") + "_" + pn.Replace(" ","_")
-                    | (Some sn, None, Some pn) -> "#Protocol_" + sn.Replace(" ","_") + "_" + pn.Replace(" ","_")
-                    | (None, None, Some pn) -> "#Protocol_" + pn.Replace(" ","_")
-                    | _ -> "#EmptyProtocol" 
+                    match p.Name with
+                    | Some n -> "#Protocol_" + n.Replace(" ","_")
+                    | None -> 
+                        match (studyName,assayName,processName) with
+                        | (Some sn, Some an, Some pn) -> "#Protocol_" + sn.Replace(" ","_") + "_" + an.Replace(" ","_") + "_" + pn.Replace(" ","_")
+                        | (Some sn, None, Some pn) -> "#Protocol_" + sn.Replace(" ","_") + "_" + pn.Replace(" ","_")
+                        | (None, None, Some pn) -> "#Protocol_" + pn.Replace(" ","_")
+                        | _ -> "#EmptyProtocol" 
 
         let encoder (studyName:string Option) (assayName:string Option) (processName:string Option) (oa : Protocol) = 
             [

--- a/src/Json/Process/ProtocolParameter.fs
+++ b/src/Json/Process/ProtocolParameter.fs
@@ -13,7 +13,7 @@ module ProtocolParameter =
 
         let genID (p : ProtocolParameter) = 
             match p.ParameterName with
-            | Some name -> $"#ProtocolParameter/{name}"
+            | Some name -> $"#ProtocolParameter/{OntologyAnnotation.ROCrate.genID name}"
             | None -> "#EmptyProtocolParameter"
 
         let encoder (idMap : IDTable.IDTableWrite option) (value : ProtocolParameter) = 

--- a/src/Json/Process/ProtocolParameter.fs
+++ b/src/Json/Process/ProtocolParameter.fs
@@ -11,12 +11,22 @@ module ProtocolParameter =
     
     module ISAJson = 
 
-        let encoder (value : ProtocolParameter) = 
-            [
-                Encode.tryInclude "parameterName" OntologyAnnotation.ISAJson.encoder value.ParameterName
-            ]
-            |> Encode.choose
-            |> Encode.object
+        let genID (p : ProtocolParameter) = 
+            match p.ParameterName with
+            | Some name -> $"#ProtocolParameter/{name}"
+            | None -> "#EmptyProtocolParameter"
+
+        let encoder (idMap : IDTable.IDTableWrite option) (value : ProtocolParameter) = 
+            let f (value : ProtocolParameter) =
+                [
+                    Encode.tryInclude "@id" Encode.string (value |> genID |> Some)
+                    Encode.tryInclude "parameterName" (OntologyAnnotation.ISAJson.encoder idMap) value.ParameterName
+                ]
+                |> Encode.choose
+                |> Encode.object
+            match idMap with
+            | None -> f value
+            | Some idMap -> IDTable.encode genID f value idMap 
 
         let decoder : Decoder<ProtocolParameter> =
             Decode.object (fun get ->
@@ -36,7 +46,7 @@ module ProtocolParameterExtensions =
     
         static member toISAJsonString(?spaces) =
             fun (v:ProtocolParameter) ->
-                ProtocolParameter.ISAJson.encoder v
+                ProtocolParameter.ISAJson.encoder None v
                 |> Encode.toJsonString (Encode.defaultSpaces spaces)
                 
         member this.ToISAJsonString(?spaces) =

--- a/src/Json/Process/StudyMaterials.fs
+++ b/src/Json/Process/StudyMaterials.fs
@@ -9,14 +9,14 @@ open System.IO
 module StudyMaterials = 
 
     module ISAJson = 
-        let encoder (ps : Process list) = 
+        let encoder idMap (ps : Process list) = 
             let source = ProcessSequence.getSources ps
             let samples = ProcessSequence.getSamples ps
             let materials = ProcessSequence.getMaterials ps
             [
-                Encode.tryIncludeList "sources" (Source.ISAJson.encoder) source
-                Encode.tryIncludeList "samples" (Sample.ISAJson.encoder) samples
-                Encode.tryIncludeList "otherMaterials" (Material.ISAJson.encoder) materials
+                Encode.tryIncludeList "sources" (Source.ISAJson.encoder idMap) source
+                Encode.tryIncludeList "samples" (Sample.ISAJson.encoder idMap) samples
+                Encode.tryIncludeList "otherMaterials" (Material.ISAJson.encoder idMap) materials
             ]  
             |> Encode.choose
             |> Encode.object 

--- a/src/Json/Process/Value.fs
+++ b/src/Json/Process/Value.fs
@@ -11,7 +11,7 @@ module Value =
 
     module ISAJson = 
 
-        let encoder (value : Value) = 
+        let encoder (idMap : IDTable.IDTableWrite option) (value : Value) = 
             match value with
             | Value.Float f -> 
                 Encode.float f
@@ -20,7 +20,7 @@ module Value =
             | Value.Name s -> 
                 Encode.string s
             | Value.Ontology s -> 
-                OntologyAnnotation.ISAJson.encoder s
+                OntologyAnnotation.ISAJson.encoder idMap s
 
         let decoder : Decoder<Value> =
             Decode.oneOf [
@@ -41,7 +41,7 @@ module ValueExtensions =
 
         static member toISAJsonString(?spaces) =
             fun (v:Value) ->
-                Value.ISAJson.encoder v
+                Value.ISAJson.encoder None v
                 |> Encode.toJsonString (Encode.defaultSpaces spaces)
             
 

--- a/src/Json/Publication.fs
+++ b/src/Json/Publication.fs
@@ -74,22 +74,16 @@ module Publication =
     module ISAJson =
         
         let encoder (idMap : IDTable.IDTableWrite option) (oa : Publication) = 
-            let f (oa : Publication) =
-                [
-                    Encode.tryInclude "@id" Encode.string (ROCrate.genID oa |> Some)
-                    Encode.tryInclude "pubMedID" Encode.string oa.PubMedID
-                    Encode.tryInclude "doi" Encode.string (oa.DOI)
-                    Encode.tryInclude "authorList" Encode.string oa.Authors
-                    Encode.tryInclude "title" Encode.string (oa.Title)
-                    Encode.tryInclude "status" OntologyAnnotation.encoder oa.Status
-                    Encode.tryIncludeSeq "comments" (Comment.ISAJson.encoder idMap) oa.Comments
-                ]
-                |> Encode.choose
-                |> Encode.object
-            match idMap with
-            | None -> f oa
-            | Some idMap -> IDTable.encode ROCrate.genID f oa idMap
-
+            [
+                Encode.tryInclude "pubMedID" Encode.string oa.PubMedID
+                Encode.tryInclude "doi" Encode.string (oa.DOI)
+                Encode.tryInclude "authorList" Encode.string oa.Authors
+                Encode.tryInclude "title" Encode.string (oa.Title)
+                Encode.tryInclude "status" OntologyAnnotation.encoder oa.Status
+                Encode.tryIncludeSeq "comments" (Comment.ISAJson.encoder idMap) oa.Comments
+            ]
+            |> Encode.choose
+            |> Encode.object
 
         let allowedFields = ["pubMedID";"doi";"authorList";"title";"status";"comments";]
 

--- a/src/Json/Study.fs
+++ b/src/Json/Study.fs
@@ -168,48 +168,53 @@ module Study =
         /// </summary>
         /// <param name="s"></param>
         /// <param name="assays"></param>
-        let encoder (assays: ArcAssay list option) (s : ArcStudy) = 
-            let study = s.Copy(true)
-            let fileName = Identifier.Study.fileNameFromIdentifier study.Identifier
-            let assaysRaw = Helper.getAssayInformation assays study
-            let assays = 
-                let n = ResizeArray()
-                for a in assaysRaw do 
-                    let assay = a.Copy()
-                    // Move persons to study
-                    for person in assay.Performers do
-                        // set source assay identifier as comment
-                        let person = Process.Conversion.Person.setSourceAssayComment person assay.Identifier
-                        study.Contacts.Add(person)
-                    assay.Performers <- ResizeArray()
-                    n.Add(assay)
-                n
-            let processes = study.GetProcesses()
-            let protocols = ProcessSequence.getProtocols processes
-            let factors = ProcessSequence.getFactors processes
-            let characteristics = ProcessSequence.getCharacteristics processes
-            let units = ProcessSequence.getUnits processes
-            [
-                "filename", Encode.string fileName
-                "identifier", Encode.string study.Identifier
-                Encode.tryInclude "title" Encode.string study.Title
-                Encode.tryInclude "description" Encode.string study.Description
-                Encode.tryInclude "submissionDate" Encode.string study.SubmissionDate
-                Encode.tryInclude "publicReleaseDate" Encode.string study.PublicReleaseDate
-                Encode.tryIncludeSeq "publications" Publication.ISAJson.encoder study.Publications
-                Encode.tryIncludeSeq "people" Person.ISAJson.encoder study.Contacts
-                Encode.tryIncludeSeq "studyDesignDescriptors" OntologyAnnotation.ISAJson.encoder study.StudyDesignDescriptors
-                Encode.tryIncludeList "protocols" Protocol.ISAJson.encoder protocols
-                Encode.tryInclude "materials" StudyMaterials.ISAJson.encoder (Option.fromValueWithDefault [] processes)
-                Encode.tryIncludeList "factors" Factor.ISAJson.encoder factors
-                Encode.tryIncludeList "characteristicCategories" MaterialAttribute.ISAJson.encoder characteristics     
-                Encode.tryIncludeList "unitCategories" OntologyAnnotation.ISAJson.encoder units
-                Encode.tryIncludeList "processSequence" Process.ISAJson.encoder processes
-                Encode.tryIncludeSeq "assays" Assay.ISAJson.encoder assays
-                Encode.tryIncludeSeq "comments" Comment.ISAJson.encoder study.Comments
-            ]
-            |> Encode.choose
-            |> Encode.object
+        let encoder idMap (assays: ArcAssay list option) (s : ArcStudy) = 
+            let f (s : ArcStudy) =
+                let study = s.Copy(true)
+                let fileName = Identifier.Study.fileNameFromIdentifier study.Identifier
+                let assaysRaw = Helper.getAssayInformation assays study
+                let assays = 
+                    let n = ResizeArray()
+                    for a in assaysRaw do 
+                        let assay = a.Copy()
+                        // Move persons to study
+                        for person in assay.Performers do
+                            // set source assay identifier as comment
+                            let person = Process.Conversion.Person.setSourceAssayComment person assay.Identifier
+                            study.Contacts.Add(person)
+                        assay.Performers <- ResizeArray()
+                        n.Add(assay)
+                    n
+                let processes = study.GetProcesses()
+                let protocols = ProcessSequence.getProtocols processes
+                let factors = ProcessSequence.getFactors processes
+                let characteristics = ProcessSequence.getCharacteristics processes
+                let units = ProcessSequence.getUnits processes
+                [
+                    "@id", Encode.string (study |> ROCrate.genID)
+                    "filename", Encode.string fileName
+                    "identifier", Encode.string study.Identifier
+                    Encode.tryInclude "title" Encode.string study.Title
+                    Encode.tryInclude "description" Encode.string study.Description
+                    Encode.tryInclude "submissionDate" Encode.string study.SubmissionDate
+                    Encode.tryInclude "publicReleaseDate" Encode.string study.PublicReleaseDate
+                    Encode.tryIncludeSeq "publications" (Publication.ISAJson.encoder idMap) study.Publications
+                    Encode.tryIncludeSeq "people" (Person.ISAJson.encoder idMap) study.Contacts
+                    Encode.tryIncludeSeq "studyDesignDescriptors" (OntologyAnnotation.ISAJson.encoder idMap) study.StudyDesignDescriptors
+                    Encode.tryIncludeList "protocols" (Protocol.ISAJson.encoder (Some s.Identifier) None None idMap) protocols
+                    Encode.tryInclude "materials" (StudyMaterials.ISAJson.encoder idMap) (Option.fromValueWithDefault [] processes)
+                    Encode.tryIncludeList "factors" (Factor.ISAJson.encoder idMap) factors
+                    Encode.tryIncludeList "characteristicCategories" (MaterialAttribute.ISAJson.encoder idMap) characteristics     
+                    Encode.tryIncludeList "unitCategories" (OntologyAnnotation.ISAJson.encoder idMap) units
+                    Encode.tryIncludeList "processSequence" (Process.ISAJson.encoder (Some s.Identifier) None idMap) processes
+                    Encode.tryIncludeSeq "assays" (Assay.ISAJson.encoder (Some s.Identifier) idMap) assays
+                    Encode.tryIncludeSeq "comments" (Comment.ISAJson.encoder idMap) study.Comments
+                ]
+                |> Encode.choose
+                |> Encode.object
+            match idMap with
+            | None -> f s
+            | Some idMap -> IDTable.encode (fun s -> ROCrate.genID s) f s idMap
 
         let allowedFields = ["@id";"filename";"identifier";"title";"description";"submissionDate";"publicReleaseDate";"publications";"people";"studyDesignDescriptors";"protocols";"materials";"assays";"factors";"characteristicCategories";"unitCategories";"processSequence";"comments";"@type"; "@context"]
         
@@ -308,10 +313,12 @@ module StudyExtensions =
         static member fromISAJsonString (s:string) = 
             Decode.fromJsonString Study.ISAJson.decoder s
 
-        static member toISAJsonString(?assays: ArcAssay list, ?spaces) =
+        static member toISAJsonString(?assays: ArcAssay list, ?spaces, ?useIDReferencing) =
+            let useIDReferencing = Option.defaultValue false useIDReferencing
+            let idMap = if useIDReferencing then Some (System.Collections.Generic.Dictionary()) else None
             fun (obj:ArcStudy) ->
-                Study.ISAJson.encoder assays obj
+                Study.ISAJson.encoder idMap assays obj
                 |> Encode.toJsonString (Encode.defaultSpaces spaces)
 
-        member this.ToISAJsonString(?assays,?spaces) = 
-            ArcStudy.toISAJsonString(?assays=assays,?spaces=spaces) this
+        member this.ToISAJsonString(?assays,?spaces, ?useIDReferencing) = 
+            ArcStudy.toISAJsonString(?assays=assays,?spaces=spaces, ?useIDReferencing = useIDReferencing) this

--- a/tests/Json/Data.Tests.fs
+++ b/tests/Json/Data.Tests.fs
@@ -15,18 +15,18 @@ let basic_tests = testList "BasicJson" [
 let isa_tests = testList "ISAJson" [
     testCase "NativeISAFieldsIO" <| fun _ ->
         let d = Data("MyID","MyName",DataFile.RawDataFile,comments = ResizeArray [Comment.create("MyKey","MyValue")])
-        let json = Data.ISAJson.encoder d |> Encode.toJsonString 2
+        let json = Data.ISAJson.encoder None d |> Encode.toJsonString 2
         let d2 = Decode.fromJsonString Data.ISAJson.decoder json
         Expect.equal d2 d "Different after write and read"
     ptestCase "AllFieldsLossless" <| fun _ ->
         let d = Data("MyID","MyName",DataFile.RawDataFile,"text/csv","MySelector",ResizeArray [Comment.create("MyKey","MyValue")])
-        let json = Data.ISAJson.encoder d |> Encode.toJsonString 2
+        let json = Data.ISAJson.encoder None d |> Encode.toJsonString 2
         let d2 = Decode.fromJsonString Data.ISAJson.decoder json
         Expect.equal d2 d "Different after write and read"
     #if !FABLE_COMPILER_PYTHON
     testAsync "WriterSchemaCorrectness" {
         let d = Data("MyID","MyName",DataFile.RawDataFile, "text/csv", "MySelector", ResizeArray [Comment.create("MyKey","MyValue")])
-        let json = Data.ISAJson.encoder d |> Encode.toJsonString 2
+        let json = Data.ISAJson.encoder None d |> Encode.toJsonString 2
         let! validation = Validation.validateData json
         Expect.isTrue validation.Success $"Data did not match schema: {validation.GetErrors()}"
     }

--- a/tests/Json/Study.Tests.fs
+++ b/tests/Json/Study.Tests.fs
@@ -103,9 +103,9 @@ let private test_compressed =
         None
         compareFields
 
-let private test_isa =
+let private test_isa = testList "ISA" [
     createBaseJsonTests
-        "isa"
+        "base"
         create_filled
         ArcStudy.toISAJsonString
         (ArcStudy.fromISAJsonString >> fun (s,_) -> s)
@@ -115,6 +115,10 @@ let private test_isa =
         None
         #endif
         compareFields
+    testCase "UseIDTable" <| fun _ ->
+        let table = ArcTable.init ("Process1")
+        table.create
+     ]
 
 let private test_roCrate =
     createBaseJsonTests

--- a/tests/Json/Study.Tests.fs
+++ b/tests/Json/Study.Tests.fs
@@ -155,15 +155,15 @@ let private test_isa = testList "ISA" [
         let protocolVersionCells = [|for i = 0 to 1 do CompositeCell.FreeText protocolVersion|]
         let protocolVersionColumn = CompositeColumn.create(protocolVersionHeader, protocolVersionCells)
 
-        let peptidase = OntologyAnnotation.create("Peptidase", "MS", "http://purl.obolibrary.org/obo/NCIT_C16965")
+        let peptidase = OntologyAnnotation.create("Peptidase", "NCIT", "http://purl.obolibrary.org/obo/NCIT_C16965")
         let peptidaseHeader = CompositeHeader.Parameter peptidase
-        let trypsin = OntologyAnnotation.create("Trypsin/P", "MS", "http://purl.obolibrary.org/obo/NCIT_C16965")
+        let trypsin = OntologyAnnotation.create("Trypsin/P", "MS", "http://purl.obolibrary.org/obo/MS_1001313")
         let peptidaseCells = [|for i = 0 to 1 do CompositeCell.Term trypsin|]
         let peptidaseColumn = CompositeColumn.create(peptidaseHeader, peptidaseCells)
 
         let temperature = OntologyAnnotation.create("temperature", "Ontobee", "http://purl.obolibrary.org/obo/NCRO_0000029")
         let temperatureHeader = CompositeHeader.Parameter temperature
-        let degrees = OntologyAnnotation.create("degrees Celsius", "OM2", "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius")
+        let degrees = OntologyAnnotation.create("degree Celsius", "OM2", "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius")
         let temperatureCells = [|for i = 0 to 1 do CompositeCell.Unitized ("23",degrees)|]
         let temperatureColumn = CompositeColumn.create(temperatureHeader, temperatureCells)
 

--- a/tests/Json/Study.Tests.fs
+++ b/tests/Json/Study.Tests.fs
@@ -115,9 +115,90 @@ let private test_isa = testList "ISA" [
         None
         #endif
         compareFields
+
     testCase "UseIDTable" <| fun _ ->
         let table = ArcTable.init ("Process1")
-        table.create
+
+        let inputHeader = CompositeHeader.Input (IOType.Source)
+        let inputCells = [|for i = 0 to 1 do CompositeCell.FreeText $"Source{i+1}"|]
+        let inputColumn = CompositeColumn.create(inputHeader, inputCells)
+
+        let organism = OntologyAnnotation.create("organism", "OBI", "http://purl.obolibrary.org/obo/OBI_0100026")
+        let organismHeader = CompositeHeader.Characteristic organism
+        let arabidopsis = OntologyAnnotation.create("Arabidopsis thaliana", "NCBITaxon", "http://purl.obolibrary.org/obo/NCBITaxon_3702")
+        let organismCells = [|for i = 0 to 1 do CompositeCell.Term arabidopsis|]
+        let organismColumn = CompositeColumn.create(organismHeader, organismCells)
+
+
+        let protocolName = "peptide_digestion"
+        let protocolREFHeader = CompositeHeader.ProtocolREF
+        let protocolREFCells = [|for i = 0 to 1 do CompositeCell.FreeText protocolName|]
+        let protocolREFColumn = CompositeColumn.create(protocolREFHeader, protocolREFCells)
+
+        let protocolType = OntologyAnnotation.create("Protein Digestion", "NCIT", "http://purl.obolibrary.org/obo/NCIT_C70845")
+        let protocolTypeHeader = CompositeHeader.ProtocolType
+        let protocolTypeCells = [|for i = 0 to 1 do CompositeCell.Term protocolType|]
+        let protocolTypeColumn = CompositeColumn.create(protocolTypeHeader, protocolTypeCells)
+
+        let protocolDescription = "The isolated proteins get solubilized. Given protease is added and the solution is heated to a given temperature. After a given amount of time, the digestion is stopped by adding a denaturation agent."
+        let protocolDescriptionHeader = CompositeHeader.ProtocolDescription
+        let protocolDescriptionCells = [|for i = 0 to 1 do CompositeCell.FreeText protocolDescription|]
+        let protocolDescriptionColumn = CompositeColumn.create(protocolDescriptionHeader, protocolDescriptionCells)
+
+        let protocolURI = "http://madeUpProtocolWebsize.org/protein_digestion"
+        let protocolURIHeader = CompositeHeader.ProtocolUri
+        let protocolURICells = [|for i = 0 to 1 do CompositeCell.FreeText protocolURI|]
+        let protocolURIColumn = CompositeColumn.create(protocolURIHeader, protocolURICells)
+
+        let protocolVersion = "1.0.0"
+        let protocolVersionHeader = CompositeHeader.ProtocolVersion
+        let protocolVersionCells = [|for i = 0 to 1 do CompositeCell.FreeText protocolVersion|]
+        let protocolVersionColumn = CompositeColumn.create(protocolVersionHeader, protocolVersionCells)
+
+        let peptidase = OntologyAnnotation.create("Peptidase", "MS", "http://purl.obolibrary.org/obo/NCIT_C16965")
+        let peptidaseHeader = CompositeHeader.Parameter peptidase
+        let trypsin = OntologyAnnotation.create("Trypsin/P", "MS", "http://purl.obolibrary.org/obo/NCIT_C16965")
+        let peptidaseCells = [|for i = 0 to 1 do CompositeCell.Term trypsin|]
+        let peptidaseColumn = CompositeColumn.create(peptidaseHeader, peptidaseCells)
+
+        let temperature = OntologyAnnotation.create("temperature", "Ontobee", "http://purl.obolibrary.org/obo/NCRO_0000029")
+        let temperatureHeader = CompositeHeader.Parameter temperature
+        let degrees = OntologyAnnotation.create("degrees Celsius", "OM2", "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius")
+        let temperatureCells = [|for i = 0 to 1 do CompositeCell.Unitized ("23",degrees)|]
+        let temperatureColumn = CompositeColumn.create(temperatureHeader, temperatureCells)
+
+        let time = OntologyAnnotation.create("time", "EFO", "http://www.ebi.ac.uk/efo/EFO_0000721")
+        let timeHeader = CompositeHeader.Parameter time
+        let hours = OntologyAnnotation.create("hour", "UO", "http://purl.obolibrary.org/obo/UO_0000032")
+        let timeCells = [|for i = 0 to 1 do CompositeCell.Unitized ("10",hours)|]
+        let timeColumn = CompositeColumn.create(timeHeader, timeCells)
+
+        let outputHeader = CompositeHeader.Output (IOType.Sample)
+        let outputCells = [|for i = 0 to 1 do CompositeCell.FreeText $"Sample{i+1}"|]
+        let outputColumn = CompositeColumn.create(outputHeader, outputCells)
+
+        table.AddColumns [|
+            inputColumn;
+            organismColumn;
+            protocolREFColumn;
+            protocolTypeColumn;
+            protocolDescriptionColumn;
+            protocolURIColumn;
+            protocolVersionColumn;
+            peptidaseColumn;
+            temperatureColumn;
+            timeColumn;
+            outputColumn        
+        |]
+
+        let study = ArcStudy.init("Study1")
+        study.AddTable table
+
+        let json = ArcStudy.toISAJsonString(useIDReferencing = true) study
+
+        //let expectedString = TestObjects.Json.Study.studyWithIDTable.Replace("\s","")
+
+        Expect.stringEqual json TestObjects.Json.Study.studyWithIDTable "json"
      ]
 
 let private test_roCrate =

--- a/tests/TestingUtils/TestObjects.Json/Person.fs
+++ b/tests/TestingUtils/TestObjects.Json/Person.fs
@@ -28,6 +28,7 @@ let person =
 let personWithORCID = 
     """
 {
+  "@id":"0000-0002-1825-0097",
   "firstName": "Juan",
   "lastName": "Castrillo",
   "comments": [

--- a/tests/TestingUtils/TestObjects.Json/Process.fs
+++ b/tests/TestingUtils/TestObjects.Json/Process.fs
@@ -10,6 +10,7 @@ let process' =
         "@id": "#protocols/peptide_digestion",
         "name": "peptide_digestion",
         "protocolType": {
+            "@id": "http://purl.obolibrary.org/obo/NCIT_C70845",
             "annotationValue": "Protein Digestion",
             "termSource": "NCIT",
             "termAccession": "http://purl.obolibrary.org/obo/NCIT_C70845"
@@ -19,21 +20,27 @@ let process' =
         "version": "1.0.0",
         "parameters": [
             {
+                "@id" : "#ProtocolParameter/http://purl.obolibrary.org/obo/NCIT_C16965",
                 "parameterName": {
+                    "@id": "http://purl.obolibrary.org/obo/NCIT_C16965",
                     "annotationValue": "Peptidase",
                     "termSource": "MS",
                     "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965"
                 }
             },
             {
+                "@id" : "#ProtocolParameter/http://purl.obolibrary.org/obo/NCRO_0000029",
                 "parameterName": {
+                    "@id": "http://purl.obolibrary.org/obo/NCRO_0000029",
                     "annotationValue": "temperature",
                     "termSource": "Ontobee",
                     "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029"
                 }
             },
             {
+                "@id" : "#ProtocolParameter/http://www.ebi.ac.uk/efo/EFO_0000721",
                 "parameterName": {
+                    "@id": "http://www.ebi.ac.uk/efo/EFO_0000721",
                     "annotationValue": "time",
                     "termSource": "EFO",
                     "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721"
@@ -44,6 +51,7 @@ let process' =
             {
                 "componentName": "digestion_stopper",
                 "componentType": {
+                    "@id": "http://purl.obolibrary.org/obo/NCIT_C83719",
                     "annotationValue": "Formic Acid",
                     "termSource": "NCIT",
                     "termAccession": "http://purl.obolibrary.org/obo/NCIT_C83719"
@@ -52,6 +60,7 @@ let process' =
             {
                 "componentName": "heater",
                 "componentType": {
+                    "@id": "http://purl.obolibrary.org/obo/NCIT_C49986",
                     "annotationValue": "Heater Device",
                     "termSource": "NCIT",
                     "termAccession": "http://purl.obolibrary.org/obo/NCIT_C49986"
@@ -63,13 +72,16 @@ let process' =
     "parameterValues": [
         {
             "category": {
+                "@id" : "#ProtocolParameter/http://purl.obolibrary.org/obo/NCIT_C16965",
                 "parameterName": {
+                    "@id": "http://purl.obolibrary.org/obo/NCIT_C16965",
                     "annotationValue": "Peptidase",
                     "termSource": "MS",
                     "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965"
                 }
             },
             "value": {
+                "@id": "http://purl.obolibrary.org/obo/MS_1001313",
                 "annotationValue": "Trypsin/P",
                 "termSource": "NCI",
                 "termAccession": "http://purl.obolibrary.org/obo/MS_1001313"
@@ -77,7 +89,9 @@ let process' =
         },
         {
             "category": {
+                "@id" : "#ProtocolParameter/http://purl.obolibrary.org/obo/NCRO_0000029",
                 "parameterName": {
+                    "@id": "http://purl.obolibrary.org/obo/NCRO_0000029",
                     "annotationValue": "temperature",
                     "termSource": "Ontobee",
                     "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029"
@@ -85,6 +99,7 @@ let process' =
             },
             "value": 37,
             "unit": {
+                "@id": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius",
                 "annotationValue": "degree Celsius",
                 "termSource": "OM2",
                 "termAccession": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius"
@@ -92,7 +107,9 @@ let process' =
         },
         {
             "category": {
+                "@id" : "#ProtocolParameter/http://www.ebi.ac.uk/efo/EFO_0000721",
                 "parameterName": {
+                    "@id": "http://www.ebi.ac.uk/efo/EFO_0000721",
                     "annotationValue": "time",
                     "termSource": "EFO",
                     "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721"
@@ -100,6 +117,7 @@ let process' =
             },
             "value": 1,
             "unit": {
+                "@id": "http://purl.obolibrary.org/obo/UO_0000032",
                 "annotationValue": "hour",
                 "termSource": "UO",
                 "termAccession": "http://purl.obolibrary.org/obo/UO_0000032"

--- a/tests/TestingUtils/TestObjects.Json/Protocol.fs
+++ b/tests/TestingUtils/TestObjects.Json/Protocol.fs
@@ -7,6 +7,7 @@ let protocol =
     "@id": "#protocols/peptide_digestion",
     "name": "peptide_digestion",
     "protocolType": {
+        "@id":"http://purl.obolibrary.org/obo/NCIT_C70845",
         "annotationValue": "Protein Digestion",
         "termSource": "NCIT",
         "termAccession": "http://purl.obolibrary.org/obo/NCIT_C70845"
@@ -16,21 +17,27 @@ let protocol =
     "version": "1.0.0",
     "parameters": [
         {
+            "@id": "#ProtocolParameter/http://purl.obolibrary.org/obo/NCIT_C16965",
             "parameterName": {
+                "@id": "http://purl.obolibrary.org/obo/NCIT_C16965",
                 "annotationValue": "Peptidase",
                 "termSource": "MS",
                 "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965"
             }
         },
         {
+            "@id": "#ProtocolParameter/http://purl.obolibrary.org/obo/NCRO_0000029",
             "parameterName": {
+                "@id": "http://purl.obolibrary.org/obo/NCRO_0000029",
                 "annotationValue": "temperature",
                 "termSource": "Ontobee",
                 "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029"
             }
         },
         {
+            "@id": "#ProtocolParameter/http://www.ebi.ac.uk/efo/EFO_0000721",
             "parameterName": {
+                "@id": "http://www.ebi.ac.uk/efo/EFO_0000721",
                 "annotationValue": "time",
                 "termSource": "EFO",
                 "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721"
@@ -41,6 +48,7 @@ let protocol =
         {
             "componentName": "digestion_stopper",
             "componentType": {
+                "@id": "http://purl.obolibrary.org/obo/NCIT_C83719",
                 "annotationValue": "Formic Acid",
                 "termSource": "NCIT",
                 "termAccession": "http://purl.obolibrary.org/obo/NCIT_C83719"
@@ -49,6 +57,7 @@ let protocol =
         {
             "componentName": "heater",
             "componentType": {
+                "@id": "http://purl.obolibrary.org/obo/NCIT_C49986",
                 "annotationValue": "Heater Device",
                 "termSource": "NCIT",
                 "termAccession": "http://purl.obolibrary.org/obo/NCIT_C49986"

--- a/tests/TestingUtils/TestObjects.Json/Study.fs
+++ b/tests/TestingUtils/TestObjects.Json/Study.fs
@@ -25,7 +25,7 @@ let studyWithIDTable =
                         "parameterName": {
                             "@id": "http://purl.obolibrary.org/obo/NCIT_C16965",
                             "annotationValue": "Peptidase",
-                            "termSource": "MS",
+                            "termSource": "NCIT",
                             "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965"
                         }
                     },
@@ -92,19 +92,11 @@ let studyWithIDTable =
         },
         "processSequence" : [
             {
-                "@id": "#Process/Process1",
-                "processName": "Process1",
+                "@id": "#Process_Process1",
+                "name": "Process1",
                 "executesProtocol": {
-                    "@id" : "#protocols/peptide_digestion"
+                    "@id" : "http://madeUpProtocolWebsize.org/protein_digestion"
                 },
-                "inputs" : [
-                    {"@id" : "#Source_Source1"},
-                    {"@id" : "#Source_Source2"}
-                ],
-                "outputs" : [
-                    {"@id" : "#Sample_Sample1"},
-                    {"@id" : "#Sample_Sample1"}
-                ],
                 "parameterValues" : [
                     {
                         "category" : {"@id" : "#ProtocolParameter/http://purl.obolibrary.org/obo/NCIT_C16965"},
@@ -125,6 +117,14 @@ let studyWithIDTable =
                         "value": 10,
                         "unit" : {"@id" : "http://purl.obolibrary.org/obo/UO_0000032"}
                     }
+                ],
+                "inputs" : [
+                    {"@id" : "#Source_Source1"},
+                    {"@id" : "#Source_Source2"}
+                ],
+                "outputs" : [
+                    {"@id" : "#Sample_Sample1"},
+                    {"@id" : "#Sample_Sample2"}
                 ]
             }
 

--- a/tests/TestingUtils/TestObjects.Json/Study.fs
+++ b/tests/TestingUtils/TestObjects.Json/Study.fs
@@ -1,0 +1,155 @@
+﻿module TestObjects.Json.Study
+
+let studyWithIDTable =
+    """
+    {
+        "@id": "#study/Study1",
+        "filename" : "studies/Study1/isa.study.xlsx",
+        "protocols" : [
+            {
+                "@id" : "#protocols/peptide_digestion",
+                "name": "peptide_digestion",
+                "protocolType": {
+                    "@id":"http://purl.obolibrary.org/obo/NCIT_C70845",
+                    "annotationValue": "Protein Digestion",
+                    "termSource": "NCIT",
+                    "termAccession": "http://purl.obolibrary.org/obo/NCIT_C70845"
+                },
+                "description": "The isolated proteins get solubilized. Given protease is added and the solution is heated to a given temperature. After a given amount of time, the digestion is stopped by adding a denaturation agent.",
+                "uri": "http://madeUpProtocolWebsize.org/protein_digestion",
+                "version": "1.0.0",
+                "parameters": [
+                    {
+                        "@id": "#ProtocolParameter/http://purl.obolibrary.org/obo/NCIT_C16965",
+                        "parameterName": {
+                            "@id": "http://purl.obolibrary.org/obo/NCIT_C16965",
+                            "annotationValue": "Peptidase",
+                            "termSource": "MS",
+                            "termAccession": "http://purl.obolibrary.org/obo/NCIT_C16965"
+                        }
+                    },
+                    {
+                        "@id": "#ProtocolParameter/http://purl.obolibrary.org/obo/NCRO_0000029",
+                        "parameterName": {
+                            "@id": "http://purl.obolibrary.org/obo/NCRO_0000029",
+                            "annotationValue": "temperature",
+                            "termSource": "Ontobee",
+                            "termAccession": "http://purl.obolibrary.org/obo/NCRO_0000029"
+                        }
+                    },
+                    {
+                        "@id": "#ProtocolParameter/http://www.ebi.ac.uk/efo/EFO_0000721",
+                        "parameterName": {
+                            "@id": "http://www.ebi.ac.uk/efo/EFO_0000721",
+                            "annotationValue": "time",
+                            "termSource": "EFO",
+                            "termAccession": "http://www.ebi.ac.uk/efo/EFO_0000721"
+                        }
+                    }
+                ]
+            }
+        ],
+        "materials" : [
+            {
+                "@id": "#Source/Source1",
+                "name": "Source1",
+                "characteristics" : [
+                    {
+                        "@id" : "#CharacteristicValue/",
+                        "category" : {
+                            "@id" : "#CharacteristicCategory/http://purl.obolibrary.org/obo/OBI_0100026"
+                        },
+                        "value" : {
+                            "@id": "http://purl.obolibrary.org/obo/NCBITaxon_3702",
+                            "annotationValue": "Arabidopsis thaliana",
+                            "termSource": "NCBITaxon",
+                            "termAccession": "http://purl.obolibrary.org/obo/NCBITaxon_3702"
+                        }
+                    }
+                ]
+            
+            },
+            {
+                "@id": "#Source/Source2",
+                "name": "Source2",
+                "characteristics" : [{"@id" : "#CharacteristicValue/"}
+                ]
+            
+            },
+            {
+                "@id": "#Sample/Sample1",
+                "name": "Sample1"           
+            },
+            {
+                "@id": "#Sample/Sample2",
+                "name": "Sample2"           
+            }
+
+        ],
+        "processes" : [
+            {
+                "@id": "#Process/Process1",
+                "processName": "Process1",
+                "executesProtocol": {
+                    "@id" : "#protocols/peptide_digestion"
+                },
+                "inputs" : [
+                    {"@id" : "#Source/Source1"},
+                    {"@id" : "#Source/Source2"}
+                ],
+                "outputs" : [
+                    {"@id" : "#Sample/Sample1"},
+                    {"@id" : "#Sample/Sample1"}
+                ],
+                "parameterValues" : [
+                    {
+                        "category" : {"@id" : "#ProtocolParameter/http://purl.obolibrary.org/obo/NCIT_C16965"},
+                        "value": {
+                            "@id": "http://purl.obolibrary.org/obo/MS_1001313",
+                            "annotationValue": "Trypsin/P",
+                            "termSource": "NCI",
+                            "termAccession": "http://purl.obolibrary.org/obo/MS_1001313"
+                        }
+                    },
+                    {
+                        "category" : {"@id" : "#ProtocolParameter/http://purl.obolibrary.org/obo/NCRO_0000029"},
+                        "value": 23,
+                        "unit" : {"@id" : "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius"}
+                    },
+                    {
+                        "category" : {"@id" : "#ProtocolParameter/http://www.ebi.ac.uk/efo/EFO_0000721"},
+                        "value": 10,
+                        "unit" : {"@id" : "http://purl.obolibrary.org/obo/UO_0000032"}
+                    }
+                ]
+            }
+
+        ],
+        "characteristicCategories": [
+            {
+                "@id" : "#CharacteristicCategory/http://purl.obolibrary.org/obo/OBI_0100026",
+                "characteristicType" : {
+                    "@id": "http://purl.obolibrary.org/obo/OBI_0100026",
+                    "annotationValue": "organism",
+                    "termSource": "OBI",
+                    "termAccession": "http://purl.obolibrary.org/obo/OBI_0100026"
+                }
+            }
+        ],
+        "unitCategories" : [
+            {
+                "@id": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius",
+                "annotationValue": "degree Celsius",
+                "termSource": "OM2",
+                "termAccession": "http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius"
+            },
+            {
+                "@id": "http://purl.obolibrary.org/obo/UO_0000032",
+                "annotationValue": "hour",
+                "termSource": "UO",
+                "termAccession": "http://purl.obolibrary.org/obo/UO_0000032"
+            }
+        ]
+
+    }
+    """

--- a/tests/TestingUtils/TestObjects.Json/Study.fs
+++ b/tests/TestingUtils/TestObjects.Json/Study.fs
@@ -5,9 +5,10 @@ let studyWithIDTable =
     {
         "@id": "#study/Study1",
         "filename" : "studies/Study1/isa.study.xlsx",
+        "identifier" : "Study1",
         "protocols" : [
             {
-                "@id" : "#protocols/peptide_digestion",
+                "@id" : "http://madeUpProtocolWebsize.org/protein_digestion",
                 "name": "peptide_digestion",
                 "protocolType": {
                     "@id":"http://purl.obolibrary.org/obo/NCIT_C70845",
@@ -49,44 +50,47 @@ let studyWithIDTable =
                 ]
             }
         ],
-        "materials" : [
-            {
-                "@id": "#Source/Source1",
-                "name": "Source1",
-                "characteristics" : [
-                    {
-                        "@id" : "#CharacteristicValue/",
-                        "category" : {
-                            "@id" : "#CharacteristicCategory/http://purl.obolibrary.org/obo/OBI_0100026"
-                        },
-                        "value" : {
-                            "@id": "http://purl.obolibrary.org/obo/NCBITaxon_3702",
-                            "annotationValue": "Arabidopsis thaliana",
-                            "termSource": "NCBITaxon",
-                            "termAccession": "http://purl.obolibrary.org/obo/NCBITaxon_3702"
+        "materials" : {           
+            "sources" : [
+                {
+                    "@id": "#Source_Source1",
+                    "name": "Source1",
+                    "characteristics" : [
+                        {
+                            "@id" : "#MaterialAttributeValue/organism=Arabidopsis thaliana",
+                            "category" : {
+                                "@id" : "#MaterialAttribute/http://purl.obolibrary.org/obo/OBI_0100026"
+                            },
+                            "value" : {
+                                "@id": "http://purl.obolibrary.org/obo/NCBITaxon_3702",
+                                "annotationValue": "Arabidopsis thaliana",
+                                "termSource": "NCBITaxon",
+                                "termAccession": "http://purl.obolibrary.org/obo/NCBITaxon_3702"
+                            }
                         }
-                    }
-                ]
+                    ]            
+                },
+                {
+                    "@id": "#Source_Source2",
+                    "name": "Source2",
+                    "characteristics" : [{"@id" : "#MaterialAttributeValue/organism=Arabidopsis thaliana"}
+                    ]
             
-            },
-            {
-                "@id": "#Source/Source2",
-                "name": "Source2",
-                "characteristics" : [{"@id" : "#CharacteristicValue/"}
-                ]
+                }
+            ],
+            "samples" : [
             
-            },
-            {
-                "@id": "#Sample/Sample1",
-                "name": "Sample1"           
-            },
-            {
-                "@id": "#Sample/Sample2",
-                "name": "Sample2"           
-            }
-
-        ],
-        "processes" : [
+                {
+                    "@id": "#Sample_Sample1",
+                    "name": "Sample1"           
+                },
+                {
+                    "@id": "#Sample_Sample2",
+                    "name": "Sample2"           
+                }
+            ]
+        },
+        "processSequence" : [
             {
                 "@id": "#Process/Process1",
                 "processName": "Process1",
@@ -94,12 +98,12 @@ let studyWithIDTable =
                     "@id" : "#protocols/peptide_digestion"
                 },
                 "inputs" : [
-                    {"@id" : "#Source/Source1"},
-                    {"@id" : "#Source/Source2"}
+                    {"@id" : "#Source_Source1"},
+                    {"@id" : "#Source_Source2"}
                 ],
                 "outputs" : [
-                    {"@id" : "#Sample/Sample1"},
-                    {"@id" : "#Sample/Sample1"}
+                    {"@id" : "#Sample_Sample1"},
+                    {"@id" : "#Sample_Sample1"}
                 ],
                 "parameterValues" : [
                     {
@@ -107,7 +111,7 @@ let studyWithIDTable =
                         "value": {
                             "@id": "http://purl.obolibrary.org/obo/MS_1001313",
                             "annotationValue": "Trypsin/P",
-                            "termSource": "NCI",
+                            "termSource": "MS",
                             "termAccession": "http://purl.obolibrary.org/obo/MS_1001313"
                         }
                     },
@@ -127,7 +131,7 @@ let studyWithIDTable =
         ],
         "characteristicCategories": [
             {
-                "@id" : "#CharacteristicCategory/http://purl.obolibrary.org/obo/OBI_0100026",
+                "@id" : "#MaterialAttribute/http://purl.obolibrary.org/obo/OBI_0100026",
                 "characteristicType" : {
                     "@id": "http://purl.obolibrary.org/obo/OBI_0100026",
                     "annotationValue": "organism",

--- a/tests/TestingUtils/TestingUtils.fsproj
+++ b/tests/TestingUtils/TestingUtils.fsproj
@@ -5,6 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="TestObjects.Json\Study.fs" />
     <Compile Include="TestObjects.Json\ROCrate.fs" />
     <Content Include="TestObjects.Json\MinimalJson.json" />
     <Compile Include="TestObjects.Json\Assay.fs" />


### PR DESCRIPTION
### Description

ISA-json writer functions now contain `useIDReferencing` flag, which will lead to every object in the json file being written only once. For every other appearance of the same object, an object just containing its `@id` will be written in its stead.

### Usage:

#### fsharp
```fsharp
open ARCtrl
open ARCtrl.Json

ArcStudy.toISAJsonString(useIDReferencing = true) study
```

#### javascript
```javascript
import { JsonController } from "./src/ARCtrl/Json.js";

JsonController.Study.toISAJsonString(study, void 0, void 0, true)
```

#### python
```python
from src.ARCtrl.json import JsonController

JsonController.Study().to_isajson_string(study, None, None, True)
```

@Freymaurer @xiaoranzhou 

#324