### PR TITLE
Rename fix

### DIFF
--- a/src/ARCtrl/Xlsx.fs
+++ b/src/ARCtrl/Xlsx.fs
@@ -25,9 +25,7 @@ module XlsxHelper =
     [<AttachMembers>]
     type InvestigationXlsx() =
         member _.fromFsWorkbook (fswb: FsWorkbook) = ArcInvestigation.fromFsWorkbook fswb
-        member _.toFsWorkbook (investigation: ArcInvestigation) = ArcInvestigation.toFsWorkbook(investigation)
-        member _.toLightFsWorkbook (investigation: ArcInvestigation) = ArcInvestigation.toLightFsWorkbook(investigation)
-        
+        member _.toFsWorkbook (investigation: ArcInvestigation) = ArcInvestigation.toFsWorkbook(investigation)        
 
 open XlsxHelper
 

--- a/src/Contract/ArcAssay.fs
+++ b/src/Contract/ArcAssay.fs
@@ -28,7 +28,7 @@ module AssayContractExtensions =
                 if withFolder then 
                     let folderFS =  FileSystemTree.createAssaysFolder([|FileSystemTree.createAssayFolder this.Identifier|])
                     for p in folderFS.ToFilePaths(false) do
-                        if p <> path then Contract.createCreate(p, DTOType.PlainText)
+                        if p <> path && p <> "assays/.gitkeep" then Contract.createCreate(p, DTOType.PlainText)
                 c
             |]
 

--- a/src/Contract/ArcAssay.fs
+++ b/src/Contract/ArcAssay.fs
@@ -26,7 +26,7 @@ module AssayContractExtensions =
             let c = Contract.createCreate(path, DTOType.ISA_Assay, DTO.Spreadsheet (this |> ArcAssay.toFsWorkbook))
             [|
                 if withFolder then 
-                    let folderFS = FileSystemTree.createAssayFolder this.Identifier
+                    let folderFS =  FileSystemTree.createAssaysFolder([|FileSystemTree.createAssayFolder this.Identifier|])
                     for p in folderFS.ToFilePaths(false) do
                         if p <> path then Contract.createCreate(p, DTOType.PlainText)
                 c

--- a/src/Contract/ArcInvestigation.fs
+++ b/src/Contract/ArcInvestigation.fs
@@ -20,16 +20,14 @@ module InvestigationContractExtensions =
 
     type ArcInvestigation with
 
-        member this.ToCreateContract (?isLight: bool) =
-            let isLight = defaultArg isLight true
-            let converter = if isLight then ArcInvestigation.toLightFsWorkbook else ArcInvestigation.toFsWorkbook
+        member this.ToCreateContract () =
+            let converter = ArcInvestigation.toFsWorkbook
             let path = InvestigationFileName
             let c = Contract.createCreate(path, DTOType.ISA_Investigation, DTO.Spreadsheet (this |> converter))
             c
 
-        member this.ToUpdateContract (?isLight: bool) =
-            let isLight = defaultArg isLight true
-            let converter = if isLight then ArcInvestigation.toLightFsWorkbook else ArcInvestigation.toFsWorkbook
+        member this.ToUpdateContract () =
+            let converter = ArcInvestigation.toFsWorkbook
             let path = InvestigationFileName
             let c = Contract.createUpdate(path, DTOType.ISA_Investigation, DTO.Spreadsheet (this |> converter))
             c
@@ -44,11 +42,11 @@ module InvestigationContractExtensions =
         //    let c = Contract.createDelete(path)
         //    c
 
-        static member toCreateContract (inv: ArcInvestigation, ?isLight: bool) : Contract =
-            inv.ToCreateContract(?isLight=isLight)
+        static member toCreateContract (inv: ArcInvestigation) : Contract =
+            inv.ToCreateContract()
 
-        static member toUpdateContract (inv: ArcInvestigation, ?isLight: bool) : Contract =
-            inv.ToUpdateContract(?isLight=isLight)
+        static member toUpdateContract (inv: ArcInvestigation) : Contract =
+            inv.ToUpdateContract()
 
         static member tryFromReadContract (c:Contract) =
             match c with

--- a/src/Contract/ArcStudy.fs
+++ b/src/Contract/ArcStudy.fs
@@ -29,7 +29,7 @@ module StudyContractExtensions =
                 if withFolder then 
                     let folderFS = FileSystemTree.createStudiesFolder ([|FileSystemTree.createStudyFolder this.Identifier|])
                     for p in folderFS.ToFilePaths(false) do
-                        if p <> path then Contract.createCreate(p, DTOType.PlainText)
+                        if p <> path && p <> "studies/.gitkeep" then Contract.createCreate(p, DTOType.PlainText)
                 c
             |]
 

--- a/src/Core/ArcTypes.fs
+++ b/src/Core/ArcTypes.fs
@@ -1090,6 +1090,7 @@ type ArcStudy(identifier : string, ?title, ?description, ?submissionDate, ?publi
             HashCodes.boxHashSeq this.Contacts
             HashCodes.boxHashSeq this.StudyDesignDescriptors
             HashCodes.boxHashSeq this.Tables
+            HashCodes.boxHashSeq this.RegisteredAssayIdentifiers
             HashCodes.boxHashSeq this.Comments
         |]
         |> HashCodes.boxHashArray 
@@ -1292,11 +1293,13 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
         )
         this.Studies
         |> Seq.iter (fun s ->
-            s.RegisteredAssayIdentifiers
-            |> Seq.iteri (fun i ai -> 
-                if ai = oldIdentifier then
-                    s.RegisteredAssayIdentifiers[i] <- newIdentifier
-            )       
+            let index = 
+                s.RegisteredAssayIdentifiers 
+                |> Seq.tryFindIndex (fun ai -> ai = oldIdentifier)
+            match index with
+            | None -> ()
+            | Some index -> 
+                s.RegisteredAssayIdentifiers.[index] <- newIdentifier
         )
 
     static member renameAssay(oldIdentifier: string, newIdentifier: string) =       
@@ -1543,11 +1546,12 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             if s.Identifier = oldIdentifier then 
                 s.Identifier <- newIdentifier
         )
-        this.RegisteredStudyIdentifiers
-        |> Seq.iteri (fun i si -> 
-            if si = oldIdentifier then
-                this.RegisteredStudyIdentifiers.[i] <- newIdentifier
-        )
+        let index =
+            this.RegisteredStudyIdentifiers
+            |> Seq.tryFindIndex (fun si -> si = oldIdentifier)
+        match index with
+        | None -> ()
+        | Some index -> this.RegisteredStudyIdentifiers.[index] <- newIdentifier
 
     /// <summary>
     /// Renames a study in the whole investigation
@@ -1925,6 +1929,7 @@ type ArcInvestigation(identifier : string, ?title : string, ?description : strin
             HashCodes.boxHashSeq this.Publications
             HashCodes.boxHashSeq this.Contacts
             HashCodes.boxHashSeq this.OntologySourceReferences
+            HashCodes.boxHashSeq this.RegisteredStudyIdentifiers
             HashCodes.boxHashSeq this.Comments
             HashCodes.boxHashSeq this.Remarks
         |]

--- a/src/FileSystem/FileSystemTree.fs
+++ b/src/FileSystem/FileSystemTree.fs
@@ -225,13 +225,13 @@ type FileSystemTree =
     static member createAssaysFolder(assays : FileSystemTree array) =
         FileSystemTree.createFolder(
             ARCtrl.Path.AssaysFolderName, 
-            Array.append [|FileSystemTree.createGitKeepFile()|] assays
+            Array.append [|if assays.Length = 0 then FileSystemTree.createGitKeepFile()|] assays
         )
 
     static member createStudiesFolder(studies : FileSystemTree array) =
         FileSystemTree.createFolder(
             ARCtrl.Path.StudiesFolderName,
-            Array.append [|FileSystemTree.createGitKeepFile()|] studies
+            Array.append [|if studies.Length = 0 then FileSystemTree.createGitKeepFile()|] studies
         )
 
     static member createWorkflowsFolder(workflows : FileSystemTree array) =

--- a/src/FileSystem/FileSystemTree.fs
+++ b/src/FileSystem/FileSystemTree.fs
@@ -225,13 +225,13 @@ type FileSystemTree =
     static member createAssaysFolder(assays : FileSystemTree array) =
         FileSystemTree.createFolder(
             ARCtrl.Path.AssaysFolderName, 
-            Array.append [|if assays.Length = 0 then FileSystemTree.createGitKeepFile()|] assays
+            Array.append [|FileSystemTree.createGitKeepFile()|] assays
         )
 
     static member createStudiesFolder(studies : FileSystemTree array) =
         FileSystemTree.createFolder(
             ARCtrl.Path.StudiesFolderName,
-            Array.append [|if studies.Length = 0 then FileSystemTree.createGitKeepFile()|] studies
+            Array.append [|FileSystemTree.createGitKeepFile()|] studies
         )
 
     static member createWorkflowsFolder(workflows : FileSystemTree array) =

--- a/tests/ARCtrl/ARCtrl.Tests.fs
+++ b/tests/ARCtrl/ARCtrl.Tests.fs
@@ -335,6 +335,88 @@ let private tests_updateContracts = testList "update_contracts" [
         Expect.exists contracts (fun c -> c.Path = "isa.investigation.xlsx") "Contract for investigation folder missing"
         Expect.exists contracts (fun c -> c.Path = "isa.investigation.xlsx" && c.DTOType.IsSome && c.DTOType.Value = Contract.DTOType.ISA_Investigation) "Contract for investigation exisiting but has wrong DTO type"
     )
+    testCase "empty_addAssay" (fun _ ->
+        let i = ArcInvestigation("MyInvestigation")
+        let arc = ARC(isa = i)
+        arc.GetWriteContracts() |> ignore
+        i.InitAssay("MyAssay") |> ignore
+        // As the ARC is compeletely empty, GetUpdateContracts should return the same contracts as GetWriteContracts
+        let contracts = arc.GetUpdateContracts()
+        let contractPathsString = contracts |> Array.map (fun c -> c.Path) |> String.concat ", "
+        Expect.equal contracts.Length 4 $"Should contain exactly as much contracts as needed for new assay: {contractPathsString}"
+        // Assay file contract
+        let assayFilePath = "assays/MyAssay/isa.assay.xlsx"
+        let assayFileContract = Expect.wantSome (contracts |> Array.tryFind (fun c -> c.Path = assayFilePath)) $"Assay file contract for {assayFilePath} missing"
+        Expect.equal assayFileContract.Operation Operation.CREATE "Operation for assay file contract should be CREATE"
+        let assayFileDTOType = Expect.wantSome assayFileContract.DTOType "DTOType for assay file contract missing"
+        Expect.equal assayFileDTOType DTOType.ISA_Assay "DTOType for assay file contract should be ISA_Assay"
+        let assayFileDTO = Expect.wantSome assayFileContract.DTO "DTO for assay file contract missing"
+        let wb = assayFileDTO.AsSpreadsheet() :?> FsWorkbook
+        let assay = ArcAssay.fromFsWorkbook wb
+        Expect.equal assay.Identifier "MyAssay" "Assay identifier should be set"
+        // readme contract
+        let readmeFilePath = "assays/MyAssay/README.md"
+        let readmeContract = Expect.wantSome (contracts |> Array.tryFind (fun c -> c.Path = readmeFilePath)) $"Readme contract for {readmeFilePath} missing"
+        Expect.equal readmeContract.Operation Operation.CREATE "Operation for readme contract should be CREATE"
+        let readmeDTOType = Expect.wantSome readmeContract.DTOType "DTOType for readme contract missing"
+        Expect.equal readmeDTOType DTOType.PlainText "DTOType for readme contract should be ISA_Readme"
+        Expect.isNone readmeContract.DTO "DTO for readme contract should be None"
+        // protocols gitkeep contract
+        let protocolsGitkeepFilePath = "assays/MyAssay/protocols/.gitkeep"
+        let protocolsGitkeepContract = Expect.wantSome (contracts |> Array.tryFind (fun c -> c.Path = protocolsGitkeepFilePath)) $"Protocols gitkeep contract for {protocolsGitkeepFilePath} missing"
+        Expect.equal protocolsGitkeepContract.Operation Operation.CREATE "Operation for protocols gitkeep contract should be CREATE"
+        let protocolsGitkeepDTOType = Expect.wantSome protocolsGitkeepContract.DTOType "DTOType for protocols gitkeep contract missing"
+        Expect.equal protocolsGitkeepDTOType DTOType.PlainText "DTOType for protocols gitkeep contract should be GitKeep"
+        Expect.isNone protocolsGitkeepContract.DTO "DTO for protocols gitkeep contract should be None"
+        // dataset gitkeep contract
+        let datasetGitkeepFilePath = "assays/MyAssay/dataset/.gitkeep"
+        let datasetGitkeepContract = Expect.wantSome (contracts |> Array.tryFind (fun c -> c.Path = datasetGitkeepFilePath)) $"Dataset gitkeep contract for {datasetGitkeepFilePath} missing"
+        Expect.equal datasetGitkeepContract.Operation Operation.CREATE "Operation for dataset gitkeep contract should be CREATE"
+        let datasetGitkeepDTOType = Expect.wantSome datasetGitkeepContract.DTOType "DTOType for dataset gitkeep contract missing"
+        Expect.equal datasetGitkeepDTOType DTOType.PlainText "DTOType for dataset gitkeep contract should be GitKeep"
+        Expect.isNone datasetGitkeepContract.DTO "DTO for dataset gitkeep contract should be None"
+    )
+    testCase "empty_addStudy" (fun _ ->
+        let i = ArcInvestigation("MyInvestigation")
+        let arc = ARC(isa = i)
+        arc.GetWriteContracts() |> ignore
+        i.InitStudy("MyStudy") |> ignore
+        // As the ARC is compeletely empty, GetUpdateContracts should return the same contracts as GetWriteContracts
+        let contracts = arc.GetUpdateContracts()
+        let contractPathsString = contracts |> Array.map (fun c -> c.Path) |> String.concat ", "
+        Expect.equal contracts.Length 4 $"Should contain exactly as much contracts as needed for new study: {contractPathsString}"
+        // Study file contract
+        let studyFilePath = "studies/MyStudy/isa.study.xlsx"
+        let studyFileContract = Expect.wantSome (contracts |> Array.tryFind (fun c -> c.Path = studyFilePath)) $"Study file contract for {studyFilePath} missing"
+        Expect.equal studyFileContract.Operation Operation.CREATE "Operation for study file contract should be CREATE"
+        let studyFileDTOType = Expect.wantSome studyFileContract.DTOType "DTOType for study file contract missing"
+        Expect.equal studyFileDTOType DTOType.ISA_Study "DTOType for study file contract should be ISA_Study"
+        let studyFileDTO = Expect.wantSome studyFileContract.DTO "DTO for study file contract missing"
+        let wb = studyFileDTO.AsSpreadsheet() :?> FsWorkbook
+        let study,_ = ArcStudy.fromFsWorkbook wb
+        Expect.equal study.Identifier "MyStudy" "Study identifier should be set"
+        // readme contract
+        let readmeFilePath = "studies/MyStudy/README.md"
+        let readmeContract = Expect.wantSome (contracts |> Array.tryFind (fun c -> c.Path = readmeFilePath)) $"Readme contract for {readmeFilePath} missing"
+        Expect.equal readmeContract.Operation Operation.CREATE "Operation for readme contract should be CREATE"
+        let readmeDTOType = Expect.wantSome readmeContract.DTOType "DTOType for readme contract missing"
+        Expect.equal readmeDTOType DTOType.PlainText "DTOType for readme contract should be ISA_Readme"
+        Expect.isNone readmeContract.DTO "DTO for readme contract should be None"
+        // protocols gitkeep contract
+        let protocolsGitkeepFilePath = "studies/MyStudy/protocols/.gitkeep"
+        let protocolsGitkeepContract = Expect.wantSome (contracts |> Array.tryFind (fun c -> c.Path = protocolsGitkeepFilePath)) $"Protocols gitkeep contract for {protocolsGitkeepFilePath} missing"
+        Expect.equal protocolsGitkeepContract.Operation Operation.CREATE "Operation for protocols gitkeep contract should be CREATE"
+        let protocolsGitkeepDTOType = Expect.wantSome protocolsGitkeepContract.DTOType "DTOType for protocols gitkeep contract missing"
+        Expect.equal protocolsGitkeepDTOType DTOType.PlainText "DTOType for protocols gitkeep contract should be GitKeep"
+        Expect.isNone protocolsGitkeepContract.DTO "DTO for protocols gitkeep contract should be None"
+        // resources gitkeep contract
+        let resourcesGitkeepFilePath = "studies/MyStudy/resources/.gitkeep"
+        let resourcesGitkeepContract = Expect.wantSome (contracts |> Array.tryFind (fun c -> c.Path = resourcesGitkeepFilePath)) $"Resources gitkeep contract for {resourcesGitkeepFilePath} missing"
+        Expect.equal resourcesGitkeepContract.Operation Operation.CREATE "Operation for resources gitkeep contract should be CREATE"
+        let resourcesGitkeepDTOType = Expect.wantSome resourcesGitkeepContract.DTOType "DTOType for resources gitkeep contract missing"
+        Expect.equal resourcesGitkeepDTOType DTOType.PlainText "DTOType for resources gitkeep contract should be GitKeep"
+        Expect.isNone resourcesGitkeepContract.DTO "DTO for resources gitkeep contract should be None"
+    )
     testCase "init_simpleISA" (fun _ ->
         let inv = ArcInvestigation("MyInvestigation", "BestTitle")
         inv.InitStudy("MyStudy").InitRegisteredAssay("MyAssay") |> ignore

--- a/tests/Spreadsheet/InvestigationFileTests.fs
+++ b/tests/Spreadsheet/InvestigationFileTests.fs
@@ -21,7 +21,7 @@ let private testInvestigationWriterComponents =
         )
         testCase "InvestigationToRows" (fun () ->
             let i = ArcInvestigation.init("My Investigation")
-            let rows = i |> ArcInvestigation.toRows false
+            let rows = i |> ArcInvestigation.toRows
             Expect.isTrue (rows |> Seq.length |> (<) 0) "Investigation should have at least one row"
         )
         testCase "AddEmptyWorksheet" (fun () ->
@@ -32,7 +32,7 @@ let private testInvestigationWriterComponents =
         testCase "FillWorksheet" (fun () ->
             let i = ArcInvestigation.init("My Identifier")
             let sheet = FsWorksheet("Investigation")
-            let rows = i |> ArcInvestigation.toRows false
+            let rows = i |> ArcInvestigation.toRows
             rows
             |> Seq.iteri (fun rowI r -> SparseRow.writeToSheet (rowI + 1) r sheet) 
             Expect.isTrue (sheet.Rows |> Seq.length |> (<) 0) "Worksheet should have at least one row"
@@ -41,7 +41,7 @@ let private testInvestigationWriterComponents =
             let i = ArcInvestigation.init("My Identifier")
             let wb = new FsWorkbook()
             let sheet = FsWorksheet("Investigation")
-            let rows = i |> ArcInvestigation.toRows false
+            let rows = i |> ArcInvestigation.toRows
             rows
             |> Seq.iteri (fun rowI r -> SparseRow.writeToSheet (rowI + 1) r sheet)                     
             wb.AddWorksheet(sheet)
@@ -62,21 +62,21 @@ let private testInvestigationWriterComponents =
             Expect.sequenceEqual result.RegisteredStudyIdentifiers [registeredStudyIdentifier] "Only the registered study should be written and read"
         )
 
-        testCase "WriteLightInvestigationFile" <| fun _ ->
-            let isa = ArcInvestigation("MyInvestigation")
-            let registeredStudyIdentifier = "RegisteredStudy"
-            let registeredStudy = ArcStudy(registeredStudyIdentifier)
-            let unregisteredStudyIdentifier = "UnregisteredStudy"
-            let unregisteredStudy = ArcStudy(unregisteredStudyIdentifier)
-            isa.AddStudy(unregisteredStudy)
-            isa.AddRegisteredStudy(registeredStudy)
-            let assay1 = registeredStudy.InitRegisteredAssay("Assay 1")
-            let assay2 = registeredStudy.InitRegisteredAssay("Assay 2")
-            let result = ArcInvestigation.toLightFsWorkbook isa |> ArcInvestigation.fromFsWorkbook
-            Expect.hasLength result.Assays 0 "Assays hasLength"
-            Expect.equal result.AssayCount 0 "AssayCount"
-            Expect.hasLength result.Studies 0 "Studies hasLength"
-            Expect.equal result.StudyCount 0 "StudyCount"
+        //ptestCase "WriteLightInvestigationFile" <| fun _ ->
+        //    let isa = ArcInvestigation("MyInvestigation")
+        //    let registeredStudyIdentifier = "RegisteredStudy"
+        //    let registeredStudy = ArcStudy(registeredStudyIdentifier)
+        //    let unregisteredStudyIdentifier = "UnregisteredStudy"
+        //    let unregisteredStudy = ArcStudy(unregisteredStudyIdentifier)
+        //    isa.AddStudy(unregisteredStudy)
+        //    isa.AddRegisteredStudy(registeredStudy)
+        //    let assay1 = registeredStudy.InitRegisteredAssay("Assay 1")
+        //    let assay2 = registeredStudy.InitRegisteredAssay("Assay 2")
+        //    let result = ArcInvestigation.toLightFsWorkbook isa |> ArcInvestigation.fromFsWorkbook
+        //    Expect.hasLength result.Assays 0 "Assays hasLength"
+        //    Expect.equal result.AssayCount 0 "AssayCount"
+        //    Expect.hasLength result.Studies 0 "Studies hasLength"
+        //    Expect.equal result.StudyCount 0 "StudyCount"
     ]
 
 let private testInvestigationFile = 


### PR DESCRIPTION
- fix and test rename leading to update contracts when the renamed entity is registered and
- fix  getUpdateContracts for adding new assays or studies
- remove isalight:
  Whether studies are written to investigation file and assays are written to study file now solely depends on registration