### PR TITLE
Add RO-Crate contexts to docs

### DIFF
--- a/docs/RO-Crate_contexts/GetContexts.fsx
+++ b/docs/RO-Crate_contexts/GetContexts.fsx
@@ -1,0 +1,58 @@
+#r "nuget: ARCtrl, 2.0.0-beta.1"
+#r "nuget: Thoth.Json.Newtonsoft, 0.1.0"
+
+open ARCtrl.Json.ROCrateContext
+
+ARCtrl.Json.ROCrateContext.Assay.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Comment.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Component.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Factor.context_jsonvalue
+ARCtrl.Json.ROCrateContext.FactorValue.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Investigation.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Material.context_jsonvalue
+ARCtrl.Json.ROCrateContext.MaterialAttribute.context_jsonvalue
+ARCtrl.Json.ROCrateContext.OntologyAnnotation.context_jsonvalue
+ARCtrl.Json.ROCrateContext.MaterialAttributeValue.context_jsonvalue
+ARCtrl.Json.ROCrateContext.OntologySourceReference.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Person.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Organization.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Study.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Process.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Protocol.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Source.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Sample.context_jsonvalue
+ARCtrl.Json.ROCrateContext.Publication.context_jsonvalue
+ARCtrl.Json.ROCrateContext.PropertyValue.context_jsonvalue
+ARCtrl.Json.ROCrateContext.ProtocolParameter.context_jsonvalue
+ARCtrl.Json.ROCrateContext.ProcessParameterValue.context_jsonvalue
+
+let writeContextToFile name contextJson =
+    let contextString = Thoth.Json.Newtonsoft.Encode.toString 2 contextJson
+    let path = System.IO.Path.Combine(__SOURCE_DIRECTORY__, $"{name}_context.json")
+    System.IO.File.WriteAllText(path, contextString)
+
+
+writeContextToFile "data" Data.context_jsonvalue
+writeContextToFile "assay" Assay.context_jsonvalue
+writeContextToFile "comment" Comment.context_jsonvalue
+writeContextToFile "component" Component.context_jsonvalue
+writeContextToFile "factor" Factor.context_jsonvalue
+writeContextToFile "factorValue" FactorValue.context_jsonvalue
+writeContextToFile "investigation" Investigation.context_jsonvalue
+writeContextToFile "material" Material.context_jsonvalue
+writeContextToFile "materialAttribute" MaterialAttribute.context_jsonvalue
+writeContextToFile "ontologyAnnotation" OntologyAnnotation.context_jsonvalue
+writeContextToFile "materialAttributeValue" MaterialAttributeValue.context_jsonvalue
+writeContextToFile "ontologySourceReference" OntologySourceReference.context_jsonvalue
+writeContextToFile "person" Person.context_jsonvalue
+writeContextToFile "organization" Organization.context_jsonvalue
+writeContextToFile "study" Study.context_jsonvalue
+writeContextToFile "process" Process.context_jsonvalue
+writeContextToFile "protocol" Protocol.context_jsonvalue
+writeContextToFile "source" Source.context_jsonvalue
+writeContextToFile "sample" Sample.context_jsonvalue
+writeContextToFile "publication" Publication.context_jsonvalue
+writeContextToFile "propertyValue" PropertyValue.context_jsonvalue
+writeContextToFile "protocolParameter" ProtocolParameter.context_jsonvalue
+writeContextToFile "processParameterValue" ProcessParameterValue.context_jsonvalue
+    

--- a/docs/RO-Crate_contexts/assay_context.json
+++ b/docs/RO-Crate_contexts/assay_context.json
@@ -1,0 +1,14 @@
+{
+  "sdo": "http://schema.org/",
+  "Assay": "sdo:Dataset",
+  "identifier": "sdo:identifier",
+  "additionalType": "sdo:additionalType",
+  "measurementType": "sdo:variableMeasured",
+  "technologyType": "sdo:measurementTechnique",
+  "technologyPlatform": "sdo:measurementMethod",
+  "dataFiles": "sdo:hasPart",
+  "performers": "sdo:creator",
+  "processSequences": "sdo:about",
+  "comments": "sdo:comment",
+  "filename": "sdo:url"
+}

--- a/docs/RO-Crate_contexts/comment_context.json
+++ b/docs/RO-Crate_contexts/comment_context.json
@@ -1,0 +1,6 @@
+{
+  "sdo": "http://schema.org/",
+  "Comment": "sdo:Comment",
+  "name": "sdo:name",
+  "value": "sdo:text"
+}

--- a/docs/RO-Crate_contexts/component_context.json
+++ b/docs/RO-Crate_contexts/component_context.json
@@ -1,0 +1,10 @@
+{
+  "sdo": "http://schema.org/",
+  "Component": "sdo:PropertyValue",
+  "category": "sdo:name",
+  "categoryCode": "sdo:propertyID",
+  "value": "sdo:value",
+  "valueCode": "sdo:valueReference",
+  "unit": "sdo:unitText",
+  "unitCode": "sdo:unitCode"
+}

--- a/docs/RO-Crate_contexts/data_context.json
+++ b/docs/RO-Crate_contexts/data_context.json
@@ -1,0 +1,7 @@
+{
+  "sdo": "http://schema.org/",
+  "Data": "sdo:MediaObject",
+  "type": "sdo:disambiguatingDescription",
+  "name": "sdo:name",
+  "comments": "sdo:comment"
+}

--- a/docs/RO-Crate_contexts/factorValue_context.json
+++ b/docs/RO-Crate_contexts/factorValue_context.json
@@ -1,0 +1,12 @@
+{
+  "sdo": "http://schema.org/",
+  "FactorValue": "sdo:PropertyValue",
+  "additionalType": "sdo:additionalType",
+  "category": "sdo:name",
+  "categoryName": "sdo:alternateName",
+  "categoryCode": "sdo:propertyID",
+  "value": "sdo:value",
+  "valueCode": "sdo:valueReference",
+  "unit": "sdo:unitText",
+  "unitCode": "sdo:unitCode"
+}

--- a/docs/RO-Crate_contexts/factor_context.json
+++ b/docs/RO-Crate_contexts/factor_context.json
@@ -1,0 +1,9 @@
+{
+  "sdo": "http://schema.org/",
+  "Factor": "sdo:DefinedTerm",
+  "factorName": "sdo:name",
+  "annotationValue": "sdo:name",
+  "termSource": "sdo:inDefinedTermSet",
+  "termAccession": "sdo:termCode",
+  "comments": "sdo:disambiguatingDescription"
+}

--- a/docs/RO-Crate_contexts/investigation_context.json
+++ b/docs/RO-Crate_contexts/investigation_context.json
@@ -1,0 +1,16 @@
+{
+  "sdo": "http://schema.org/",
+  "Investigation": "sdo:Dataset",
+  "identifier": "sdo:identifier",
+  "title": "sdo:headline",
+  "additionalType": "sdo:additionalType",
+  "description": "sdo:description",
+  "submissionDate": "sdo:dateCreated",
+  "publicReleaseDate": "sdo:datePublished",
+  "publications": "sdo:citation",
+  "people": "sdo:creator",
+  "studies": "sdo:hasPart",
+  "ontologySourceReferences": "sdo:mentions",
+  "comments": "sdo:comment",
+  "filename": "sdo:alternateName"
+}

--- a/docs/RO-Crate_contexts/materialAttributeValue_context.json
+++ b/docs/RO-Crate_contexts/materialAttributeValue_context.json
@@ -1,0 +1,11 @@
+{
+  "sdo": "http://schema.org/",
+  "MaterialAttributeValue": "sdo:PropertyValue",
+  "additionalType": "sdo:additionalType",
+  "category": "sdo:name",
+  "categoryCode": "sdo:propertyID",
+  "value": "sdo:value",
+  "valueCode": "sdo:valueReference",
+  "unit": "sdo:unitText",
+  "unitCode": "sdo:unitCode"
+}

--- a/docs/RO-Crate_contexts/materialAttribute_context.json
+++ b/docs/RO-Crate_contexts/materialAttribute_context.json
@@ -1,0 +1,7 @@
+{
+  "sdo": "http://schema.org/",
+  "arc": "http://purl.org/nfdi4plants/ontology/",
+  "MaterialAttribute": "sdo:Property",
+  "ArcMaterialAttribute": "arc:ARC#ARC_00000050",
+  "characteristicType": "arc:ARC#ARC_00000098"
+}

--- a/docs/RO-Crate_contexts/material_context.json
+++ b/docs/RO-Crate_contexts/material_context.json
@@ -1,0 +1,8 @@
+{
+  "sdo": "http://schema.org/",
+  "bio": "https://bioschemas.org/",
+  "Material": "bio:Sample",
+  "type": "sdo:disambiguatingDescription",
+  "name": "sdo:name",
+  "characteristics": "bio:additionalProperty"
+}

--- a/docs/RO-Crate_contexts/ontologyAnnotation_context.json
+++ b/docs/RO-Crate_contexts/ontologyAnnotation_context.json
@@ -1,0 +1,8 @@
+{
+  "sdo": "http://schema.org/",
+  "OntologyAnnotation": "sdo:DefinedTerm",
+  "annotationValue": "sdo:name",
+  "termSource": "sdo:inDefinedTermSet",
+  "termAccession": "sdo:termCode",
+  "comments": "sdo:disambiguatingDescription"
+}

--- a/docs/RO-Crate_contexts/ontologySourceReference_context.json
+++ b/docs/RO-Crate_contexts/ontologySourceReference_context.json
@@ -1,0 +1,9 @@
+{
+  "sdo": "http://schema.org/",
+  "OntologySourceReference": "sdo:DefinedTermSet",
+  "description": "sdo:description",
+  "name": "sdo:name",
+  "file": "sdo:url",
+  "version": "sdo:version",
+  "comments": "sdo:disambiguatingDescription"
+}

--- a/docs/RO-Crate_contexts/organization_context.json
+++ b/docs/RO-Crate_contexts/organization_context.json
@@ -1,0 +1,5 @@
+{
+  "sdo": "http://schema.org/",
+  "Organization": "sdo:Organization",
+  "name": "sdo:name"
+}

--- a/docs/RO-Crate_contexts/person_context.json
+++ b/docs/RO-Crate_contexts/person_context.json
@@ -1,0 +1,15 @@
+{
+  "sdo": "http://schema.org/",
+  "Person": "sdo:Person",
+  "orcid": "sdo:identifier",
+  "firstName": "sdo:givenName",
+  "lastName": "sdo:familyName",
+  "midInitials": "sdo:additionalName",
+  "email": "sdo:email",
+  "address": "sdo:address",
+  "phone": "sdo:telephone",
+  "fax": "sdo:faxNumber",
+  "comments": "sdo:disambiguatingDescription",
+  "roles": "sdo:jobTitle",
+  "affiliation": "sdo:affiliation"
+}

--- a/docs/RO-Crate_contexts/processParameterValue_context.json
+++ b/docs/RO-Crate_contexts/processParameterValue_context.json
@@ -1,0 +1,11 @@
+{
+  "sdo": "http://schema.org/",
+  "additionalType": "sdo:additionalType",
+  "ProcessParameterValue": "sdo:PropertyValue",
+  "category": "sdo:name",
+  "categoryCode": "sdo:propertyID",
+  "value": "sdo:value",
+  "valueCode": "sdo:valueReference",
+  "unit": "sdo:unitText",
+  "unitCode": "sdo:unitCode"
+}

--- a/docs/RO-Crate_contexts/process_context.json
+++ b/docs/RO-Crate_contexts/process_context.json
@@ -1,0 +1,13 @@
+{
+  "sdo": "http://schema.org/",
+  "bio": "https://bioschemas.org/",
+  "Process": "bio:LabProcess",
+  "name": "sdo:name",
+  "executesProtocol": "bio:executesLabProtocol",
+  "parameterValues": "bio:parameterValue",
+  "performer": "sdo:agent",
+  "date": "sdo:endTime",
+  "inputs": "sdo:object",
+  "outputs": "sdo:result",
+  "comments": "sdo:disambiguatingDescription"
+}

--- a/docs/RO-Crate_contexts/propertyValue_context.json
+++ b/docs/RO-Crate_contexts/propertyValue_context.json
@@ -1,0 +1,11 @@
+{
+  "sdo": "http://schema.org/",
+  "additionalType": "sdo:additionalType",
+  "category": "sdo:name",
+  "categoryCode": "sdo:propertyID",
+  "value": "sdo:value",
+  "valueCode": "sdo:valueReference",
+  "unit": "sdo:unitText",
+  "unitCode": "sdo:unitCode",
+  "comments": "sdo:disambiguatingDescription"
+}

--- a/docs/RO-Crate_contexts/protocolParameter_context.json
+++ b/docs/RO-Crate_contexts/protocolParameter_context.json
@@ -1,0 +1,7 @@
+{
+  "sdo": "http://schema.org/",
+  "arc": "http://purl.org/nfdi4plants/ontology/",
+  "ProtocolParameter": "sdo:Thing",
+  "ArcProtocolParameter": "arc:ARC#ARC_00000063",
+  "parameterName": "arc:ARC#ARC_00000100"
+}

--- a/docs/RO-Crate_contexts/protocol_context.json
+++ b/docs/RO-Crate_contexts/protocol_context.json
@@ -1,0 +1,14 @@
+{
+  "sdo": "http://schema.org/",
+  "bio": "https://bioschemas.org/",
+  "Protocol": "bio:LabProtocol",
+  "name": "sdo:name",
+  "protocolType": "bio:intendedUse",
+  "description": "sdo:description",
+  "version": "sdo:version",
+  "components": "bio:labEquipment",
+  "reagents": "bio:reagent",
+  "computationalTools": "bio:computationalTool",
+  "uri": "sdo:url",
+  "comments": "sdo:comment"
+}

--- a/docs/RO-Crate_contexts/publication_context.json
+++ b/docs/RO-Crate_contexts/publication_context.json
@@ -1,0 +1,10 @@
+{
+  "sdo": "http://schema.org/",
+  "Publication": "sdo:ScholarlyArticle",
+  "pubMedID": "sdo:url",
+  "doi": "sdo:sameAs",
+  "title": "sdo:headline",
+  "status": "sdo:creativeWorkStatus",
+  "authorList": "sdo:author",
+  "comments": "sdo:disambiguatingDescription"
+}

--- a/docs/RO-Crate_contexts/sample_context.json
+++ b/docs/RO-Crate_contexts/sample_context.json
@@ -1,0 +1,7 @@
+{
+  "sdo": "http://schema.org/",
+  "bio": "https://bioschemas.org/",
+  "Sample": "bio:Sample",
+  "name": "sdo:name",
+  "additionalProperties": "bio:additionalProperty"
+}

--- a/docs/RO-Crate_contexts/source_context.json
+++ b/docs/RO-Crate_contexts/source_context.json
@@ -1,0 +1,7 @@
+{
+  "sdo": "http://schema.org/",
+  "bio": "https://bioschemas.org/",
+  "Source": "bio:Sample",
+  "name": "sdo:name",
+  "characteristics": "bio:additionalProperty"
+}

--- a/docs/RO-Crate_contexts/study_context.json
+++ b/docs/RO-Crate_contexts/study_context.json
@@ -1,0 +1,17 @@
+{
+  "sdo": "http://schema.org/",
+  "Study": "sdo:Dataset",
+  "identifier": "sdo:identifier",
+  "title": "sdo:headline",
+  "additionalType": "sdo:additionalType",
+  "description": "sdo:description",
+  "submissionDate": "sdo:dateCreated",
+  "publicReleaseDate": "sdo:datePublished",
+  "publications": "sdo:citation",
+  "people": "sdo:creator",
+  "assays": "sdo:hasPart",
+  "filename": "sdo:alternateName",
+  "comments": "sdo:comment",
+  "processSequence": "sdo:about",
+  "studyDesignDescriptors": "arc:ARC#ARC_00000037"
+}


### PR DESCRIPTION
These can be used for RO-Crate read in. Explanations for the read in itself should follow when the process of doing so is straightened out.