### PR TITLE
#401: add support for `validation_packages.yml`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+ 
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false
+ 
+[*.fs]
+fsharp_multiline_bracket_style = stroustrup
+fsharp_newline_before_multiline_computation_expression = false
+ 
+[*.fsproj]
+indent_style = space
+indent_size = 2

--- a/ARCtrl.sln
+++ b/ARCtrl.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{326188FB-2CC0-4610-A082-708885BF47AA}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		.github\workflows\build-test.yml = .github\workflows\build-test.yml
 		build.cmd = build.cmd

--- a/ARCtrl.sln
+++ b/ARCtrl.sln
@@ -71,6 +71,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Python", "Python", "{501F6D
 		tests\Python\test_XlsxController.py = tests\Python\test_XlsxController.py
 	EndProjectSection
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ARCtrl.ValidationPackages", "src\ValidationPackages\ARCtrl.ValidationPackages.fsproj", "{0C35D768-BF55-4BD9-B915-35125CED65A0}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ARCtrl.Yaml", "src\Yaml\ARCtrl.Yaml.fsproj", "{4CC3AAC2-030B-4B2E-A386-9C1F68E42238}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -137,6 +141,14 @@ Global
 		{704935A5-68F2-4070-8A55-AFF8F66ACAD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{704935A5-68F2-4070-8A55-AFF8F66ACAD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{704935A5-68F2-4070-8A55-AFF8F66ACAD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C35D768-BF55-4BD9-B915-35125CED65A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C35D768-BF55-4BD9-B915-35125CED65A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C35D768-BF55-4BD9-B915-35125CED65A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C35D768-BF55-4BD9-B915-35125CED65A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CC3AAC2-030B-4B2E-A386-9C1F68E42238}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CC3AAC2-030B-4B2E-A386-9C1F68E42238}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CC3AAC2-030B-4B2E-A386-9C1F68E42238}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CC3AAC2-030B-4B2E-A386-9C1F68E42238}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -158,6 +170,8 @@ Global
 		{03F4E6D0-CFE7-44A6-994B-778B3DF6532C} = {64B34A6E-318D-4E6E-9262-CE52C9B85A38}
 		{704935A5-68F2-4070-8A55-AFF8F66ACAD6} = {64B34A6E-318D-4E6E-9262-CE52C9B85A38}
 		{501F6D1E-6300-4CA4-8E61-3523BCF4D533} = {64B34A6E-318D-4E6E-9262-CE52C9B85A38}
+		{0C35D768-BF55-4BD9-B915-35125CED65A0} = {6DA2330B-D407-4FB1-AF05-B0184034EC44}
+		{4CC3AAC2-030B-4B2E-A386-9C1F68E42238} = {6DA2330B-D407-4FB1-AF05-B0184034EC44}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1E354DE6-99BA-421E-9EF8-E808B855A85F}

--- a/build/BasicTasks.fs
+++ b/build/BasicTasks.fs
@@ -1,4 +1,4 @@
-﻿module BasicTasks
+module BasicTasks
 
 open BlackFox.Fake
 open Fake.IO
@@ -159,5 +159,15 @@ let clean = BuildTask.create "Clean" [] {
 
 let build = BuildTask.create "Build" [clean] {
     solutionFile
-    |> DotNet.build id
+    |> DotNet.build (fun p ->
+        let msBuildParams =
+            {p.MSBuildParams with 
+                DisableInternalBinLog = true
+            }
+        {
+            p with 
+                MSBuildParams = msBuildParams
+        }
+        |> DotNet.Options.withCustomParams (Some "-tl")
+    )
 }

--- a/build/Build.fsproj
+++ b/build/Build.fsproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
@@ -21,15 +21,15 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BlackFox.Fake.BuildTask" Version="0.1.3" />
-    <PackageReference Include="Fake.Api.Github" Version="5.23.0-alpha002" />
-    <PackageReference Include="Fake.Core.Process" Version="5.23.0-alpha002" />
-    <PackageReference Include="Fake.Core.ReleaseNotes" Version="5.23.0-alpha002" />
-    <PackageReference Include="Fake.Core.Target" Version="5.23.0-alpha002" />
-    <PackageReference Include="Fake.DotNet.Cli" Version="5.23.0-alpha002" />
-    <PackageReference Include="Fake.DotNet.MSBuild" Version="5.23.0-alpha002" />
-    <PackageReference Include="Fake.IO.FileSystem" Version="5.23.0-alpha002" />
-    <PackageReference Include="Fake.JavaScript.Npm" Version="5.23.0-alpha002" />
-    <PackageReference Include="Fake.Tools.Git" Version="5.23.0-alpha002" />
+    <PackageReference Include="Fake.Api.Github" Version="6.0.0" />
+    <PackageReference Include="Fake.Core.Process" Version="6.0.0" />
+    <PackageReference Include="Fake.Core.ReleaseNotes" Version="6.0.0" />
+    <PackageReference Include="Fake.Core.Target" Version="6.0.0" />
+    <PackageReference Include="Fake.DotNet.Cli" Version="6.0.0" />
+    <PackageReference Include="Fake.DotNet.MSBuild" Version="6.0.0" />
+    <PackageReference Include="Fake.IO.FileSystem" Version="6.0.0" />
+    <PackageReference Include="Fake.JavaScript.Npm" Version="6.0.0" />
+    <PackageReference Include="Fake.Tools.Git" Version="6.0.0" />
     <PackageReference Include="Fake.Extensions.Release" Version="0.3.0" />
   </ItemGroup>
 </Project>

--- a/build/PackageTasks.fs
+++ b/build/PackageTasks.fs
@@ -1,4 +1,4 @@
-﻿module PackageTasks
+module PackageTasks
 
 open MessagePrompts
 open BasicTasks
@@ -29,6 +29,7 @@ module BundleDotNet =
                         "Version",versionTag
                         "PackageReleaseNotes",  (ProjectInfo.release.Notes |> List.map replaceCommitLink |> String.toLines )
                     ] @ p.MSBuildParams.Properties)
+                    DisableInternalBinLog = true
                 }
             {
                 p with 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMinor"
   }	
 } 

--- a/src/ARCtrl/ARCtrl.fsproj
+++ b/src/ARCtrl/ARCtrl.fsproj
@@ -47,7 +47,4 @@
       <Package Name="requests" Version="&gt;= 2.28.1 &lt; 3.0.0" ResolutionStrategy="Max" />
     </PythonDependencies>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
-  </ItemGroup>
 </Project>

--- a/src/CWL/ARCtrl.CWL.fsproj
+++ b/src/CWL/ARCtrl.CWL.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Contract/ARCtrl.Contract.fsproj
+++ b/src/Contract/ARCtrl.Contract.fsproj
@@ -8,6 +8,7 @@
     <None Include="README.md" />
     <Compile Include="Contract.fs" />
     <Compile Include="Datamap.fs" />
+    <Compile Include="ValidationPackagesConfig.fs" />
     <Compile Include="ArcAssay.fs" />
     <Compile Include="ArcStudy.fs" />
     <Compile Include="ArcInvestigation.fs" />
@@ -17,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Core\ARCtrl.Core.fsproj" />
     <ProjectReference Include="..\Json\ARCtrl.Json.fsproj" />
+    <ProjectReference Include="..\Yaml\ARCtrl.Yaml.fsproj" />
     <ProjectReference Include="..\Spreadsheet\ARCtrl.Spreadsheet.fsproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Contract/ARCtrl.Contract.fsproj
+++ b/src/Contract/ARCtrl.Contract.fsproj
@@ -25,9 +25,6 @@
     <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
     <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
-  </ItemGroup>
   <PropertyGroup>
     <Authors>nfdi4plants, Kevin Frey, Lukas Weil, Kevin Schneider, Oliver Maus</Authors>
     <Description>ARC helper functions for contracts management.</Description>

--- a/src/Contract/Contract.fs
+++ b/src/Contract/Contract.fs
@@ -15,6 +15,7 @@ type DTOType =
     | [<CompiledName("JSON")>] JSON // arc.json
     | [<CompiledName("Markdown")>] Markdown // README.md
     | [<CompiledName("CWL")>] CWL // workflow.cwl, might be a new DTO once we 
+    | [<CompiledName("YAML")>] YAML // .arc/validation_packages.yml
     | [<CompiledName("PlainText")>] PlainText // any other
     | [<CompiledName("Cli")>] CLI
     //| [<CompiledName("EmptyFile")>] EmptyFile // .gitkeep

--- a/src/Contract/ValidationPackagesConfig.fs
+++ b/src/Contract/ValidationPackagesConfig.fs
@@ -1,0 +1,48 @@
+﻿namespace ARCtrl.Contract
+
+open ARCtrl.FileSystem
+open ARCtrl.Path
+open ARCtrl
+open ARCtrl.Yaml
+open ARCtrl.Helper
+open ARCtrl.ValidationPackages
+
+[<AutoOpen>]
+module ValidationPackagesConfigExtensions = 
+
+    let (|ValidationPackagesYamlPath|_|) (input) =
+        match input with
+        | [|ARCConfigFolderName; ValidationPackagesYamlFileName|] -> 
+            let path = ARCtrl.Path.combineMany input
+            Some path
+        | _ -> None
+
+    let internal config_file_path = [|ARCConfigFolderName; ValidationPackagesYamlFileName|] |> ARCtrl.Path.combineMany
+
+    type ValidationPackagesConfig with
+    
+        member this.ToCreateContract () =
+            Contract.createCreate(config_file_path, DTOType.YAML, DTO.Text (this |> ValidationPackagesConfig.toYamlString()))
+
+        member this.ToUpdateContract () =
+            Contract.createUpdate(config_file_path, DTOType.YAML, DTO.Text (this |> ValidationPackagesConfig.toYamlString()))
+
+        member this.ToDeleteContract () =
+            Contract.createDelete(config_file_path)
+
+        static member toDeleteContract (config: ValidationPackagesConfig) : Contract =
+            config.ToDeleteContract()
+
+        static member toCreateContract (config: ValidationPackagesConfig) : Contract =
+            config.ToCreateContract()
+
+        static member toUpdateContract (config: ValidationPackagesConfig) : Contract =
+            config.ToUpdateContract()
+
+        static member tryFromReadContract (c:Contract) =
+            match c with
+            | {Operation = READ; DTOType = Some DTOType.YAML; DTO = Some (DTO.Text yaml)} ->
+                yaml
+                |> ValidationPackagesConfig.fromYamlString
+                |> Some 
+            | _ -> None

--- a/src/Core/ARCtrl.Core.fsproj
+++ b/src/Core/ARCtrl.Core.fsproj
@@ -62,9 +62,6 @@
     <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
     <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
-  </ItemGroup>
   <PropertyGroup>
     <Authors>nfdi4plants, Lukas Weil, Kevin Frey, Kevin Schneider, Oliver Maus</Authors>
     <Description>ARC and ISA compliant experimental metadata toolkit in F#. This project is meant as an easy means to open, manipulate and save ISA (Investigation,Study,Assay) metadata files in the dotnet environment.</Description>

--- a/src/FileSystem/Path.fs
+++ b/src/FileSystem/Path.fs
@@ -15,8 +15,10 @@ let [<Literal>] StudyFileName = "isa.study.xlsx"
 let [<Literal>] InvestigationFileName = "isa.investigation.xlsx"
 let [<Literal>] GitKeepFileName = ".gitkeep" 
 let [<Literal>] READMEFileName = "README.md"
+let [<Literal>] ValidationPackagesYamlFileName = "validation_packages.yml"
 
 // Folder
+let [<Literal>] ARCConfigFolderName = ".arc"
 let [<Literal>] AssaysFolderName = "assays"
 let [<Literal>] StudiesFolderName = "studies"
 let [<Literal>] WorkflowsFolderName = "workflows"

--- a/src/Json/ARCtrl.Json.fsproj
+++ b/src/Json/ARCtrl.Json.fsproj
@@ -88,9 +88,6 @@
     <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
     <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
-  </ItemGroup>
   <PropertyGroup>
     <Authors>nfdi4plants, Lukas Weil, Florian Wetzels, Kevin Frey</Authors>
     <Description>ARC and ISA json compliant parser for experimental metadata toolkit in F#. This project is meant as an easy means to open, manipulate and save ISA (Investigation,Study,Assay) metadata files in isa-json format.</Description>

--- a/src/Spreadsheet/ARCtrl.Spreadsheet.fsproj
+++ b/src/Spreadsheet/ARCtrl.Spreadsheet.fsproj
@@ -43,9 +43,6 @@
     <ProjectReference Include="..\Core\ARCtrl.Core.fsproj" />
     <ProjectReference Include="..\FileSystem\ARCtrl.FileSystem.fsproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
-  </ItemGroup>
   <PropertyGroup>
     <Authors>nfdi4plants, Lukas Weil</Authors>
     <Description>ARC and ISA xlsx compliant parser for experimental metadata toolkit in F#. This project is meant as an easy means to open, manipulate and save ISA (Investigation,Study,Assay) metadata files in isa-xlsx format.</Description>

--- a/src/ValidationPackages/ARCtrl.ValidationPackages.fsproj
+++ b/src/ValidationPackages/ARCtrl.ValidationPackages.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,6 +10,7 @@
     <Compile Include="ValidationPackagesConfig.fs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
     <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ValidationPackages/ARCtrl.ValidationPackages.fsproj
+++ b/src/ValidationPackages/ARCtrl.ValidationPackages.fsproj
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup> 
+    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" /> 
+    <Compile Include="ValidationPackage.fs" />
+    <Compile Include="ValidationPackagesConfig.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\ARCtrl.Core.fsproj" />
+  </ItemGroup>
+  <PropertyGroup>
+    <Authors>nfdi4plants</Authors>
+    <Description>ARC helper functions for Common workflow language.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageTags>ARC F# FSharp dotnet .Net bioinformatics biology fable-library datascience dataplant nfdi metadata</PackageTags>
+    <PackageProjectUrl>https://github.com/nfdi4plants/ARCtrl/tree/main/src/CWL</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/nfdi4plants/ARCtrl</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+</Project>

--- a/src/ValidationPackages/ValidationPackage.fs
+++ b/src/ValidationPackages/ValidationPackage.fs
@@ -19,12 +19,6 @@ type ValidationPackage(name, ?version) =
 
     static member make name version = ValidationPackage(name=name, ?version=version)
 
-    static member create(name,?version) : ValidationPackage =
-        ValidationPackage.make name version
-    
-    static member toString (vp : ValidationPackage) =
-        vp.Name, Option.defaultValue "" vp.Version
-
     member this.Copy() =
         ValidationPackage.make this.Name this.Version
 

--- a/src/ValidationPackages/ValidationPackage.fs
+++ b/src/ValidationPackages/ValidationPackage.fs
@@ -1,0 +1,42 @@
+﻿namespace ARCtrl.ValidationPackages
+
+open ARCtrl.Helper
+open Fable.Core
+
+[<AttachMembers>]
+type ValidationPackage(name, ?version) =
+    
+    let mutable _name : string = name
+    let mutable _version : string option = version
+
+    member this.Name 
+        with get() = _name
+        and set(name) = _name <- name
+
+    member this.Version
+        with get() = _version
+        and set(version) = _version <- version
+
+    static member make name version = ValidationPackage(name=name, ?version=version)
+
+    static member create(name,?version) : ValidationPackage =
+        ValidationPackage.make name version
+    
+    static member toString (vp : ValidationPackage) =
+        vp.Name, Option.defaultValue "" vp.Version
+
+    member this.Copy() =
+        ValidationPackage.make this.Name this.Version
+
+    override this.Equals(obj) =
+        match obj with
+        | :? ValidationPackage as other_vp -> other_vp.Name = this.Name && other_vp.Version = this.Version
+        | _ -> false
+
+    override this.GetHashCode() =        
+        [|
+            this.Name.GetHashCode() |> box
+            HashCodes.boxHashOption this.Version
+        |]
+        |> HashCodes.boxHashArray
+        |> fun x -> x :?> int

--- a/src/ValidationPackages/ValidationPackagesConfig.fs
+++ b/src/ValidationPackages/ValidationPackagesConfig.fs
@@ -1,0 +1,42 @@
+﻿namespace ARCtrl.ValidationPackages
+
+open ARCtrl.Helper
+open Fable.Core
+
+[<AttachMembers>]
+type ValidationPackagesConfig(validation_packages, ?arc_specification) =
+    
+    let mutable _validation_packages : ValidationPackage array = validation_packages
+    let mutable _arc_specification : string option = arc_specification
+
+    member this.ValidationPackages 
+        with get() = _validation_packages
+        and set(validation_packages) = _validation_packages <- validation_packages
+
+    member this.ARCSpecification
+        with get() = _arc_specification
+        and set(arc_specification) = _arc_specification <- arc_specification
+
+    static member make validation_packages arc_specification = ValidationPackagesConfig(validation_packages=validation_packages, ?arc_specification=arc_specification)
+
+    static member create(validation_packages,?arc_specification) : ValidationPackagesConfig =
+        ValidationPackagesConfig.make validation_packages arc_specification
+    
+    static member toString (vp : ValidationPackagesConfig) =
+        vp.ValidationPackages, Option.defaultValue "" vp.ARCSpecification
+
+    member this.Copy() =
+        ValidationPackagesConfig.make this.ValidationPackages this.ARCSpecification
+
+    override this.Equals(obj) =
+        match obj with
+        | :? ValidationPackagesConfig as other_vpc -> other_vpc.ValidationPackages = this.ValidationPackages && other_vpc.ARCSpecification = this.ARCSpecification
+        | _ -> false
+
+    override this.GetHashCode() =        
+        [|
+            this.ValidationPackages.GetHashCode() |> box
+            HashCodes.boxHashOption this.ARCSpecification
+        |]
+        |> HashCodes.boxHashArray
+        |> fun x -> x :?> int

--- a/src/ValidationPackages/ValidationPackagesConfig.fs
+++ b/src/ValidationPackages/ValidationPackagesConfig.fs
@@ -6,7 +6,7 @@ open Fable.Core
 [<AttachMembers>]
 type ValidationPackagesConfig(validation_packages, ?arc_specification) =
     
-    let mutable _validation_packages : ValidationPackage array = validation_packages
+    let mutable _validation_packages : ResizeArray<ValidationPackage> = validation_packages
     let mutable _arc_specification : string option = arc_specification
 
     member this.ValidationPackages 
@@ -18,12 +18,6 @@ type ValidationPackagesConfig(validation_packages, ?arc_specification) =
         and set(arc_specification) = _arc_specification <- arc_specification
 
     static member make validation_packages arc_specification = ValidationPackagesConfig(validation_packages=validation_packages, ?arc_specification=arc_specification)
-
-    static member create(validation_packages,?arc_specification) : ValidationPackagesConfig =
-        ValidationPackagesConfig.make validation_packages arc_specification
-    
-    static member toString (vp : ValidationPackagesConfig) =
-        vp.ValidationPackages, Option.defaultValue "" vp.ARCSpecification
 
     member this.Copy() =
         ValidationPackagesConfig.make this.ValidationPackages this.ARCSpecification

--- a/src/Yaml/ARCtrl.Yaml.fsproj
+++ b/src/Yaml/ARCtrl.Yaml.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,6 +9,9 @@
     <Compile Include="Decode.fs" />
     <Compile Include="ValidationPackage.fs" />
     <Compile Include="ValidationPackagesConfig.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
     <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Yaml/ARCtrl.Yaml.fsproj
+++ b/src/Yaml/ARCtrl.Yaml.fsproj
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Encode.fs" />
+    <Compile Include="Decode.fs" />
+    <Compile Include="ValidationPackage.fs" />
+    <Compile Include="ValidationPackagesConfig.fs" />
+    <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="YAMLicious" Version="0.0.1-alpha" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\ARCtrl.Core.fsproj" />
+    <ProjectReference Include="..\ValidationPackages\ARCtrl.ValidationPackages.fsproj" />
+  </ItemGroup>
+  <PropertyGroup>
+    <Authors>nfdi4plants</Authors>
+    <Description>ARC helper functions for Common workflow language.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageTags>ARC F# FSharp dotnet .Net bioinformatics biology fable-library datascience dataplant nfdi metadata</PackageTags>
+    <PackageProjectUrl>https://github.com/nfdi4plants/ARCtrl/tree/main/src/CWL</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/nfdi4plants/ARCtrl</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+</Project>

--- a/src/Yaml/ARCtrl.Yaml.fsproj
+++ b/src/Yaml/ARCtrl.Yaml.fsproj
@@ -12,7 +12,7 @@
     <None Include="../../build/logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="YAMLicious" Version="0.0.1-alpha" />
+    <PackageReference Include="YAMLicious" Version="0.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\ARCtrl.Core.fsproj" />

--- a/src/Yaml/Decode.fs
+++ b/src/Yaml/Decode.fs
@@ -1,0 +1,36 @@
+﻿namespace Arctrl.Yaml
+
+module Decode =
+
+    // yamlicious equivalents for this?
+
+    //let helpers = 
+    //    #if FABLE_COMPILER_PYTHON
+    //    Thoth.Json.Python.Decode.helpers
+    //    #endif
+    //    #if FABLE_COMPILER_JAVASCRIPT
+    //    Thoth.Json.JavaScript.Decode.helpers
+    //    #endif
+    //    #if !FABLE_COMPILER
+    //    Thoth.Json.Newtonsoft.Decode.helpers
+    //    #endif
+
+    //let inline fromJsonString (decoder : Decoder<'a>) (s : string) : 'a = 
+    //    #if FABLE_COMPILER_PYTHON
+    //    match Thoth.Json.Python.Decode.fromString decoder s with
+    //    #endif
+    //    #if FABLE_COMPILER_JAVASCRIPT
+    //    match Thoth.Json.JavaScript.Decode.fromString decoder s with
+    //    #endif
+    //    #if !FABLE_COMPILER
+    //    match Thoth.Json.Newtonsoft.Decode.fromString decoder s with
+    //    #endif
+    //    | Ok a -> a
+    //    | Error e -> failwith (sprintf "Error decoding string: %O" e)
+
+    open YAMLicious
+    open YAMLicious.YAMLiciousTypes
+    open YAMLicious.Reader
+
+    let inline fromYamlString (decoder : YAMLElement -> 'a) (s : string) : 'a = 
+        read s |> decoder

--- a/src/Yaml/Encode.fs
+++ b/src/Yaml/Encode.fs
@@ -1,0 +1,14 @@
+﻿namespace Arctrl.Yaml
+
+module Encode =
+
+    open YAMLicious
+    open YAMLicious.YAMLiciousTypes
+    open YAMLicious.Writer
+
+    let DefaultWhitespace = 2
+
+    let defaultWhitespace spaces = defaultArg spaces DefaultWhitespace
+
+    let inline toYamlString whitespace (element : YAMLElement) = 
+        write element (Some (fun c -> {c with Whitespace = whitespace}))

--- a/src/Yaml/ValidationPackage.fs
+++ b/src/Yaml/ValidationPackage.fs
@@ -1,0 +1,47 @@
+﻿namespace ARCtrl.Yaml
+
+open ARCtrl.ValidationPackages
+open YAMLicious
+open YAMLicious.YAMLiciousTypes
+
+module ValidationPackage = 
+
+    let encoder (validationpackage : ValidationPackage) = 
+        [
+            "name", Encode.string validationpackage.Name
+            Encode.tryInclude "version" Encode.string (validationpackage.Version)
+        ]
+        |> Encode.choose
+        |> Encode.object
+
+    let decoder : (YAMLElement -> ValidationPackage) = 
+        Decode.object (fun get ->
+            ValidationPackage(
+                name = get.Required.Field "name" Decode.string,
+                ?version = get.Optional.Field "version" Decode.string
+            )
+        )
+
+[<AutoOpen>]
+module ValidationPackageExtensions =
+
+    open Arctrl.Yaml
+    type ValidationPackage with
+
+        static member fromYamlString (s:string)  = 
+            Decode.fromYamlString ValidationPackage.decoder s
+
+        static member toYamlString(?whitespace) = 
+            fun (vp:ValidationPackage) ->
+                ValidationPackage.encoder vp
+                |> Encode.toYamlString (Encode.defaultWhitespace whitespace)                  
+
+        member this.toYamlString(?whitespace) = 
+            ValidationPackage.toYamlString(?whitespace=whitespace) this
+
+    //let fromFile (path : string) = 
+    //    File.ReadAllText path 
+    //    |> fromString
+
+    //let toFile (path : string) (c:Comment) = 
+    //    File.WriteAllText(path,toString c)

--- a/src/Yaml/ValidationPackagesConfig.fs
+++ b/src/Yaml/ValidationPackagesConfig.fs
@@ -8,7 +8,7 @@ module ValidationPackagesConfig =
 
     let encoder (validationpackage : ValidationPackagesConfig) = 
         [
-            "validation_packages", Encode.array ValidationPackage.encoder validationpackage.ValidationPackages
+            "validation_packages", Encode.resizearray ValidationPackage.encoder validationpackage.ValidationPackages
             Encode.tryInclude "arc_specification" Encode.string  (validationpackage.ARCSpecification)
         ]
         |> Encode.choose
@@ -17,7 +17,7 @@ module ValidationPackagesConfig =
     let decoder : (YAMLElement -> ValidationPackagesConfig) = 
         Decode.object (fun get ->
             ValidationPackagesConfig(
-                validation_packages = get.Required.Field "validation_packages" (Decode.array ValidationPackage.decoder),
+                validation_packages = get.Required.Field "validation_packages" (Decode.resizearray ValidationPackage.decoder),
                 ?arc_specification = get.Optional.Field "arc_specification" Decode.string
             )
         )

--- a/src/Yaml/ValidationPackagesConfig.fs
+++ b/src/Yaml/ValidationPackagesConfig.fs
@@ -1,0 +1,47 @@
+﻿namespace ARCtrl.Yaml
+
+open ARCtrl.ValidationPackages
+open YAMLicious
+open YAMLicious.YAMLiciousTypes
+
+module ValidationPackagesConfig = 
+
+    let encoder (validationpackage : ValidationPackagesConfig) = 
+        [
+            "validation_packages", Encode.array ValidationPackage.encoder validationpackage.ValidationPackages
+            Encode.tryInclude "arc_specification" Encode.string  (validationpackage.ARCSpecification)
+        ]
+        |> Encode.choose
+        |> Encode.object
+
+    let decoder : (YAMLElement -> ValidationPackagesConfig) = 
+        Decode.object (fun get ->
+            ValidationPackagesConfig(
+                validation_packages = get.Required.Field "validation_packages" (Decode.array ValidationPackage.decoder),
+                ?arc_specification = get.Optional.Field "arc_specification" Decode.string
+            )
+        )
+
+[<AutoOpen>]
+module ValidationPackageConfigExtensions =
+
+    open Arctrl.Yaml
+    type ValidationPackagesConfig with
+
+        static member fromYamlString (s:string)  = 
+            Decode.fromYamlString ValidationPackagesConfig.decoder s
+
+        static member toYamlString(?whitespace) = 
+            fun (vp:ValidationPackagesConfig) ->
+                ValidationPackagesConfig.encoder vp
+                |> Encode.toYamlString (Encode.defaultWhitespace whitespace)                  
+
+        member this.toYamlString(?whitespace) = 
+            ValidationPackagesConfig.toYamlString(?whitespace=whitespace) this
+
+    //let fromFile (path : string) = 
+    //    File.ReadAllText path 
+    //    |> fromString
+
+    //let toFile (path : string) (c:Comment) = 
+    //    File.WriteAllText(path,toString c)

--- a/tests/ARCtrl/ARCtrl.Tests.fsproj
+++ b/tests/ARCtrl/ARCtrl.Tests.fsproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
@@ -16,8 +16,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\ARCtrl\ARCtrl.fsproj" />
     <ProjectReference Include="..\TestingUtils\TestingUtils.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.200" />
   </ItemGroup>
 </Project>

--- a/tests/Core/ARCtrl.Core.Tests.fsproj
+++ b/tests/Core/ARCtrl.Core.Tests.fsproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
@@ -26,11 +26,8 @@
     <Compile Include="Fable.Tests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
-	<ItemGroup>
-	  <ProjectReference Include="..\..\src\Core\ARCtrl.Core.fsproj" />
-	  <ProjectReference Include="..\TestingUtils\TestingUtils.fsproj" />
-	</ItemGroup>
-	<ItemGroup>
-	  <PackageReference Update="FSharp.Core" Version="7.0.402" />
-	</ItemGroup>
+  <ItemGroup>
+   <ProjectReference Include="..\..\src\Core\ARCtrl.Core.fsproj" />
+    <ProjectReference Include="..\TestingUtils\TestingUtils.fsproj" />
+  </ItemGroup>
 </Project>

--- a/tests/FileSystem/ARCtrl.FileSystem.Tests.fsproj
+++ b/tests/FileSystem/ARCtrl.FileSystem.Tests.fsproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
@@ -12,8 +12,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\FileSystem\ARCtrl.FileSystem.fsproj" />
     <ProjectReference Include="..\TestingUtils\TestingUtils.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
   </ItemGroup>
 </Project>

--- a/tests/Json/ARCtrl.Json.Tests.fsproj
+++ b/tests/Json/ARCtrl.Json.Tests.fsproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
@@ -43,8 +43,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Json\ARCtrl.Json.fsproj" />
     <ProjectReference Include="..\TestingUtils\TestingUtils.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.402" />
   </ItemGroup>
 </Project>

--- a/tests/Json/JsonExtensions.fs
+++ b/tests/Json/JsonExtensions.fs
@@ -1,4 +1,4 @@
-﻿module JsonExtensions 
+module JsonExtensions 
 
 let private f2 i = 
     if i < 10 then sprintf "0%i" i
@@ -22,7 +22,7 @@ module Time =
 
 module Date =
     
-    let fromInts year month day = 
+    let fromInts (year:int) (month:int) (day:int) = 
         let d = System.DateTime(year,month,day)
         d.ToJsonDateString()
       

--- a/tests/Speedtest/Speedtest.fsproj
+++ b/tests/Speedtest/Speedtest.fsproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,13 +17,7 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
 
-  <ItemGroup />
-
   <ItemGroup>
     <ProjectReference Include="..\TestingUtils\TestingUtils.fsproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
-  </ItemGroup>
-
 </Project>

--- a/tests/Spreadsheet/ARCtrl.Spreadsheet.Tests.fsproj
+++ b/tests/Spreadsheet/ARCtrl.Spreadsheet.Tests.fsproj
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
@@ -24,8 +24,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Spreadsheet\ARCtrl.Spreadsheet.fsproj" />
     <ProjectReference Include="..\TestingUtils\TestingUtils.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
   </ItemGroup>
 </Project>

--- a/tests/TestingUtils/TestingUtils.fsproj
+++ b/tests/TestingUtils/TestingUtils.fsproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
@@ -29,12 +29,8 @@
 <ItemGroup>
   <PackageReference Include="Fable.Node" Version="1.2.0" />
   <PackageReference Include="Fable.Pyxpecto" Version="1.1.0" />
-	<PackageReference Include="Fable.Core" Version="4.2.0" />
 </ItemGroup>
 <ItemGroup>
   <ProjectReference Include="..\..\src\ARCtrl\ARCtrl.fsproj" />
 </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.401" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR
- [x] Adds a type model for validation packages and the `validation_packages.yml` file [according to spec]()
- [x] Adds YAMLicious-based Encoder/Decoder logic
- [x] Adds necessary contracts
~~- [ ] Adds top-level convenience APIs~~
~~- [ ] tests~~
  ~~- [ ] type model~~
  ~~- [ ] read/write yaml~~
  ~~- [ ] contracts~~
  ~~- [ ] API~~