### PR TITLE
add addColumnFill member function with tests

### DIFF
--- a/src/Core/Table/ArcTable.fs
+++ b/src/Core/Table/ArcTable.fs
@@ -181,12 +181,10 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
             newTable.AddColumn(header, ?cells = cells, ?index = index, ?forceReplace = forceReplace)
             newTable
 
-    // New AddColumnFill adds a new column which fills in the single given value for the length of the table.
-    member this.AddColumnFill (header: CompositeHeader, cell: CompositeCell, ?index: int ,?forceReplace : bool) =  // Member function to add a column with the same value for each cell
-        let cells = Array.init this.RowCount (fun _ -> cell.Copy())    // Create an array of cells with the same value based on the RowCount mutable object so use init instead of Array.create
-        this.AddColumn(header, cells = cells, ?index = index,  ?forceReplace = forceReplace)        // implementing existing AddColumn method
+    member this.AddColumnFill (header: CompositeHeader, cell: CompositeCell, ?index: int ,?forceReplace : bool) =  
+        let cells = Array.init this.RowCount (fun _ -> cell.Copy())    
+        this.AddColumn(header, cells = cells, ?index = index,  ?forceReplace = forceReplace)     
 
-    // Static function to add a column with the same value for each cell (returns a new ArcTable)
     static member addColumnFill (header: CompositeHeader, cell: CompositeCell, ?index: int ,?forceReplace : bool) : ArcTable -> ArcTable =
         fun (table: ArcTable) ->
             let newTable = table.Copy()

--- a/src/Core/Table/ArcTable.fs
+++ b/src/Core/Table/ArcTable.fs
@@ -181,6 +181,18 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
             newTable.AddColumn(header, ?cells = cells, ?index = index, ?forceReplace = forceReplace)
             newTable
 
+    // New AddColumnFill adds a new column which fills in the single given value for the length of the table.
+    member this.AddColumnFill (header: CompositeHeader, cell: CompositeCell, ?index: int ,?forceReplace : bool) =  // Member function to add a column with the same value for each cell
+        let cells = Array.init this.RowCount (fun _ -> cell.Copy())    // Create an array of cells with the same value based on the RowCount mutable object so use init instead of Array.create
+        this.AddColumn(header, cells = cells, ?index = index,  ?forceReplace = forceReplace)        // implementing existing AddColumn method
+
+    // Static function to add a column with the same value for each cell (returns a new ArcTable)
+    static member addColumnFill (header: CompositeHeader, cell: CompositeCell, ?index: int ,?forceReplace : bool) : ArcTable -> ArcTable =
+        fun (table: ArcTable) ->
+            let newTable = table.Copy()
+            newTable.AddColumnFill(header, cell, ?index = index,  ?forceReplace = forceReplace)
+            newTable
+
     // - Column API - //
     /// Replaces the header and cells of a column at given index.
     member this.UpdateColumn (columnIndex:int, header: CompositeHeader, ?cells: CompositeCell [], ?skipFillMissing) =

--- a/src/Core/Table/ArcTable.fs
+++ b/src/Core/Table/ArcTable.fs
@@ -181,6 +181,7 @@ type ArcTable(name: string, headers: ResizeArray<CompositeHeader>, values: Syste
             newTable.AddColumn(header, ?cells = cells, ?index = index, ?forceReplace = forceReplace)
             newTable
 
+    /// Adds a new column which fills in the single given value for the length of the table.
     member this.AddColumnFill (header: CompositeHeader, cell: CompositeCell, ?index: int ,?forceReplace : bool) =  
         let cells = Array.init this.RowCount (fun _ -> cell.Copy())    
         this.AddColumn(header, cells = cells, ?index = index,  ?forceReplace = forceReplace)     

--- a/tests/Core/ArcTable.Tests.fs
+++ b/tests/Core/ArcTable.Tests.fs
@@ -1623,6 +1623,46 @@ let private tests_AddColumns =
         ]
     ]
 
+
+//New Test for AddColumnFill
+let private tests_AddColumnFill = 
+    testList "AddColumnFill" [ 
+        testCase "addColumnFill to preexisting table with rows" (fun () ->  // AddColumnFill to Table with Rows // create ftestCase which prioritizes the testCase but only on local!!
+            let table = create_testTable()
+            let expectedValue = CompositeCell.createUnitizedFromString("1")
+            table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue) //or .createTermfromString
+            Expect.equal table.ColumnCount 6 "ColumnCount"
+            Expect.equal table.RowCount 5 "RowCount"
+            let columnIndex = table.ColumnCount - 1
+            let getactualValue rowIndex  = table.Values.[columnIndex,rowIndex]
+            for ri in 0 .. table.RowCount - 1 do 
+                let value = getactualValue ri 
+                Expect.equal value expectedValue $"RowIndex: {ri}"
+        )
+        ftestCase "addColumnFill to empty table" (fun () -> // "Empty Table" fail if empty flag at least RowCount 1 if table empty etc
+            let table = ArcTable.init(name = "EmptyTable")
+            let expectedValue = CompositeCell.createUnitizedFromString("1")
+            table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue) 
+            Expect.equal table.ColumnCount 1 "ColumnCount"
+            Expect.equal table.RowCount 0 "RowCount"            
+            let content = table.Values.Values 
+            Expect.isEmpty content "Cannot add column to empty table"
+        )
+        
+        // )
+        // testCase "mutability test" (fun () ->  // Update single cell compositeCell all exepct freeText cosnequences (mutability test)
+        //     let table = create_testTable()
+        //     Expect.equal 
+        
+        // )
+        //    testCase "CheckBoundaries" (fun () ->  // Check boundaries test if fail if out of range indices AddColumn
+        //     let table = create_testTable()
+        //     let startTooHigh() = table.AddColumnFill(table.ColumnCount, 1)
+        //     Expect.throws startTooHigh "Should fail for start Index ColumnCount"
+        // )
+    ]
+
+
 let private tests_RemoveColumn = 
     testList "RemoveColumn" [
         testCase "ensure table" (fun () ->
@@ -2369,6 +2409,7 @@ let main =
         tests_AddColumn_Mutable
         tests_addColumn_Copy
         tests_AddColumns
+        tests_AddColumnFill
         tests_RemoveColumn
         tests_RemoveColumns
         tests_MoveColumn

--- a/tests/Core/ArcTable.Tests.fs
+++ b/tests/Core/ArcTable.Tests.fs
@@ -1627,7 +1627,7 @@ let private tests_AddColumns =
 //New Test for AddColumnFill
 let private tests_AddColumnFill = 
     testList "AddColumnFill" [ 
-        testCase "addColumnFill to preexisting table with rows" (fun () ->  // AddColumnFill to Table with Rows // create ftestCase which prioritizes the testCase but only on local!!
+        testCase "addColumnFill to preexisting table with rows" (fun () ->  // AddColumnFill to Table with Rows // 
             let table = create_testTable()
             let expectedValue = CompositeCell.createUnitizedFromString("1")
             table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue) //or .createTermfromString
@@ -1639,7 +1639,7 @@ let private tests_AddColumnFill =
                 let value = getactualValue ri 
                 Expect.equal value expectedValue $"RowIndex: {ri}"
         )
-        ftestCase "addColumnFill to empty table" (fun () -> // "Empty Table" fail if empty flag at least RowCount 1 if table empty etc
+        testCase "addColumnFill to empty table" (fun () -> // "Empty Table" fail if empty flag at least RowCount 1 if table empty etc
             let table = ArcTable.init(name = "EmptyTable")
             let expectedValue = CompositeCell.createUnitizedFromString("1")
             table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue) 
@@ -1648,18 +1648,22 @@ let private tests_AddColumnFill =
             let content = table.Values.Values 
             Expect.isEmpty content "Cannot add column to empty table"
         )
-        
-        // )
-        // testCase "mutability test" (fun () ->  // Update single cell compositeCell all exepct freeText cosnequences (mutability test)
-        //     let table = create_testTable()
-        //     Expect.equal 
-        
-        // )
-        //    testCase "CheckBoundaries" (fun () ->  // Check boundaries test if fail if out of range indices AddColumn
-        //     let table = create_testTable()
-        //     let startTooHigh() = table.AddColumnFill(table.ColumnCount, 1)
-        //     Expect.throws startTooHigh "Should fail for start Index ColumnCount"
-        // )
+        testCase "mutability test" (fun () ->  // Update single cell compositeCell all exepct freeText cosnequences (mutability test)
+            let table = create_testTable()
+            let expectedValue = CompositeCell.createTermFromString("1")
+            table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue, index = 2) 
+            table.Values.[2,0].AsTerm.Name <- Some "2" 
+            let changedValue = table.Values.[(2, 0)]
+            let unaffectedValues = [ for ri in 1 .. table.RowCount - 1 -> table.Values.[(2, ri)] ]
+            for value in unaffectedValues do
+                Expect.notEqual value changedValue "Other cells should remain unchanged"
+        )
+        testCase "CheckBoundaries" (fun () ->  // Check boundaries test if fail if out of range indices AddColumn index 10 ex
+            let table = create_testTable()
+            let expectedValue = CompositeCell.createUnitizedFromString("1")
+            let newTable() = table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue, index = 10)
+            Expect.throws newTable "Should fail with index 10"
+        )
     ]
 
 

--- a/tests/Core/ArcTable.Tests.fs
+++ b/tests/Core/ArcTable.Tests.fs
@@ -1624,44 +1624,40 @@ let private tests_AddColumns =
     ]
 
 
-//New Test for AddColumnFill
+//Test for AddColumnFill
 let private tests_AddColumnFill = 
     testList "AddColumnFill" [ 
-        testCase "addColumnFill to preexisting table with rows" (fun () ->  // AddColumnFill to Table with Rows // 
-            let table = create_testTable()
-            let expectedValue = CompositeCell.createUnitizedFromString("1")
-            table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue) //or .createTermfromString
+        let table = create_testTable()
+        let inputHeader = CompositeHeader.Parameter (OntologyAnnotation("chlamy_r"))
+        let cellU = CompositeCell.createUnitizedFromString("1")
+        testCase "addColumnFill to preexisting table with rows" (fun () -> 
+            table.AddColumnFill(inputHeader, cellU)
             Expect.equal table.ColumnCount 6 "ColumnCount"
             Expect.equal table.RowCount 5 "RowCount"
             let columnIndex = table.ColumnCount - 1
-            let getactualValue rowIndex  = table.Values.[columnIndex,rowIndex]
-            for ri in 0 .. table.RowCount - 1 do 
-                let value = getactualValue ri 
-                Expect.equal value expectedValue $"RowIndex: {ri}"
+            for ri in 0 .. table.RowCount - 1 do
+                let value = table.Values.[(columnIndex, ri)]
+                Expect.equal value cellU $"Value at column {columnIndex}, row {ri} should be equal to the input cellU"
         )
-        testCase "addColumnFill to empty table" (fun () -> // "Empty Table" fail if empty flag at least RowCount 1 if table empty etc
-            let table = ArcTable.init(name = "EmptyTable")
-            let expectedValue = CompositeCell.createUnitizedFromString("1")
-            table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue) 
-            Expect.equal table.ColumnCount 1 "ColumnCount"
-            Expect.equal table.RowCount 0 "RowCount"            
-            let content = table.Values.Values 
+        testCase "addColumnFill to empty table" (fun () -> 
+            let emptyTable = ArcTable.init(name = "EmptyTable")
+            emptyTable.AddColumnFill(inputHeader, cellU) 
+            Expect.equal emptyTable.ColumnCount 1 "ColumnCount"
+            Expect.equal emptyTable.RowCount 0 "RowCount"            
+            let content = emptyTable.Values.Values 
             Expect.isEmpty content "Cannot add column to empty table"
         )
-        testCase "mutability test" (fun () ->  // Update single cell compositeCell all exepct freeText cosnequences (mutability test)
-            let table = create_testTable()
-            let expectedValue = CompositeCell.createTermFromString("1")
-            table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue, index = 2) 
+        testCase "mutability test" (fun () ->  
+            let cell = CompositeCell.createTermFromString("1")
+            table.AddColumnFill(inputHeader, cell, index = 2) 
             table.Values.[2,0].AsTerm.Name <- Some "2" 
-            let changedValue = table.Values.[(2, 0)]
-            let unaffectedValues = [ for ri in 1 .. table.RowCount - 1 -> table.Values.[(2, ri)] ]
-            for value in unaffectedValues do
-                Expect.notEqual value changedValue "Other cells should remain unchanged"
+            let changedCell = table.Values.[(2, 0)]
+            let unaffectedCell = [ for ri in 1 .. table.RowCount - 1 -> table.Values.[(2, ri)] ]
+            for el in unaffectedCell do
+                Expect.notEqual el changedCell "Other cells should remain unchanged"
         )
-        testCase "CheckBoundaries" (fun () ->  // Check boundaries test if fail if out of range indices AddColumn index 10 ex
-            let table = create_testTable()
-            let expectedValue = CompositeCell.createUnitizedFromString("1")
-            let newTable() = table.AddColumnFill(CompositeHeader.Parameter (OntologyAnnotation("chlamy_r")), expectedValue, index = 10)
+        testCase "checkBoundaries" (fun () ->  
+            let newTable() = table.AddColumnFill(inputHeader, cellU, index = 10)
             Expect.throws newTable "Should fail with index 10"
         )
     ]


### PR DESCRIPTION
AddColumnFill adds a new column with the given header and sets this cell for every row of this new column. The parameters are equivalent to addColumn. Two testCases have been implemented and two are still under construction. 

closes #399 