### PR TITLE
Update datamap handling in GetUpdateContracts function

### DIFF
--- a/src/ARCtrl/ARC.fs
+++ b/src/ARCtrl/ARC.fs
@@ -406,7 +406,7 @@ type ARC(?isa : ArcInvestigation, ?cwl : CWL.CWL, ?fs : FileSystem.FileSystem) =
                     let hash = s.GetLightHashCode()
                     if s.StaticHash = 0 then
                         yield! s.ToCreateContract(WithFolder = true,?datamapAsFile = datamapAsFile)
-                    elif s.StaticHash <> hash then 
+                    else
                         yield! s.ToUpdateContract(?datamapAsFile = datamapAsFile)
                     s.StaticHash <- hash
                 
@@ -415,7 +415,7 @@ type ARC(?isa : ArcInvestigation, ?cwl : CWL.CWL, ?fs : FileSystem.FileSystem) =
                     let hash = a.GetLightHashCode()
                     if a.StaticHash = 0 then 
                         yield! a.ToCreateContract(WithFolder = true,?datamapAsFile = datamapAsFile)
-                    elif a.StaticHash <> hash then 
+                    else
                         yield! a.ToUpdateContract(?datamapAsFile = datamapAsFile)
                     a.StaticHash <- hash
             |]

--- a/src/Contract/ArcAssay.fs
+++ b/src/Contract/ArcAssay.fs
@@ -20,23 +20,42 @@ module AssayContractExtensions =
 
     type ArcAssay with
 
-        member this.ToCreateContract (?WithFolder) =
+        member this.ToCreateContract (?WithFolder, ?datamapAsFile) =
             let withFolder = defaultArg WithFolder false
+            let dataMapAsFile = defaultArg datamapAsFile false
             let path = Identifier.Assay.fileNameFromIdentifier this.Identifier
-            let c = Contract.createCreate(path, DTOType.ISA_Assay, DTO.Spreadsheet (this |> ArcAssay.toFsWorkbook))
+            let dto = DTO.Spreadsheet (ArcAssay.toFsWorkbook(this, datamapSheet = not dataMapAsFile))
+            let c = Contract.createCreate(path, DTOType.ISA_Assay, dto)
             [|
                 if withFolder then 
                     let folderFS =  FileSystemTree.createAssaysFolder([|FileSystemTree.createAssayFolder this.Identifier|])
                     for p in folderFS.ToFilePaths(false) do
-                        if p <> path && p <> "assays/.gitkeep" then Contract.createCreate(p, DTOType.PlainText)
-                c
+                        if p <> path && p <> "assays/.gitkeep" then
+                            yield Contract.createCreate(p, DTOType.PlainText)              
+                match this.DataMap with
+                    | Some dm -> 
+                        dm.StaticHash <- dm.GetHashCode()
+                        if dataMapAsFile then
+                            yield dm.ToCreateContractForAssay(this.Identifier)
+                    | _ -> ()
+                yield c              
             |]
 
 
-        member this.ToUpdateContract () =
+        member this.ToUpdateContract (?datamapAsFile) =
+            let dataMapAsFile = defaultArg datamapAsFile false
             let path = Identifier.Assay.fileNameFromIdentifier this.Identifier
-            let c = Contract.createUpdate(path, DTOType.ISA_Assay, DTO.Spreadsheet (this |> ArcAssay.toFsWorkbook))
-            c
+            let dto = DTO.Spreadsheet (ArcAssay.toFsWorkbook(this, datamapSheet = not dataMapAsFile))
+            let c = Contract.createUpdate(path, DTOType.ISA_Assay, dto)
+            [|
+                match this.DataMap with
+                    | Some dm -> 
+                        dm.StaticHash <- dm.GetHashCode()
+                        if dataMapAsFile then
+                            yield dm.ToUpdateContractForAssay(this.Identifier)
+                    | _ -> ()
+                yield c
+            |]
 
         member this.ToDeleteContract () =
             let path = getAssayFolderPath(this.Identifier)
@@ -49,7 +68,7 @@ module AssayContractExtensions =
         static member toCreateContract (assay: ArcAssay,?WithFolder) : Contract [] =
             assay.ToCreateContract(?WithFolder = WithFolder)
 
-        static member toUpdateContract (assay: ArcAssay) : Contract =
+        static member toUpdateContract (assay: ArcAssay) : Contract [] =
             assay.ToUpdateContract()
 
         static member tryFromReadContract (c:Contract) =

--- a/tests/ARCtrl/ARCtrl.Tests.fs
+++ b/tests/ARCtrl/ARCtrl.Tests.fs
@@ -490,8 +490,8 @@ let private tests_updateContracts = testList "update_contracts" [
 
         let contracts = arc.GetUpdateContracts()
         Expect.equal contracts.Length 1 $"Should contain only assay datamap change contract"
-        let expectedPath = Identifier.Assay.datamapFileNameFromIdentifier SimpleISA.Assay.proteomeIdentifer
-        Expect.equal contracts.[0].Path expectedPath "Should be the assay datamap file"
+        let expectedPath = Identifier.Assay.fileNameFromIdentifier SimpleISA.Assay.proteomeIdentifer
+        Expect.equal contracts.[0].Path expectedPath "Should be the assay file, as datamap is contained in assay"
         let nextContracts = arc.GetUpdateContracts()
         Expect.equal nextContracts.Length 0 "Should contain no contracts as there are no changes"
     )


### PR DESCRIPTION
kinda related to #407 

GetUpdateContracts() and GetWriteContracts() functions now have `datamapAsFile` flag. When not set, now the datamap is written as part of the assay/study file. When set to true, it is written as its own file. 