### PR TITLE
Nuget package fix and test time adjustment

### DIFF
--- a/ARCtrl.sln
+++ b/ARCtrl.sln
@@ -93,6 +93,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ARCtrl.ROCrate", "src\ROCra
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ARCtrl.ROCrate.Tests", "tests\ROCrate\ARCtrl.ROCrate.Tests.fsproj", "{212A1C64-02FC-465A-B0FA-F69735F37ACC}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "All.Tests", "tests\All\All.Tests.fsproj", "{243ACD5F-10AD-4BE6-9932-829667BE2053}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -187,6 +189,10 @@ Global
 		{212A1C64-02FC-465A-B0FA-F69735F37ACC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{212A1C64-02FC-465A-B0FA-F69735F37ACC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{212A1C64-02FC-465A-B0FA-F69735F37ACC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{243ACD5F-10AD-4BE6-9932-829667BE2053}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{243ACD5F-10AD-4BE6-9932-829667BE2053}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{243ACD5F-10AD-4BE6-9932-829667BE2053}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{243ACD5F-10AD-4BE6-9932-829667BE2053}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -215,6 +221,7 @@ Global
 		{D10D12C7-B877-423B-867D-161D99E673C9} = {64B34A6E-318D-4E6E-9262-CE52C9B85A38}
 		{658BF141-B4B5-4B90-891D-AC36A3FD7574} = {6DA2330B-D407-4FB1-AF05-B0184034EC44}
 		{212A1C64-02FC-465A-B0FA-F69735F37ACC} = {64B34A6E-318D-4E6E-9262-CE52C9B85A38}
+		{243ACD5F-10AD-4BE6-9932-829667BE2053} = {64B34A6E-318D-4E6E-9262-CE52C9B85A38}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1E354DE6-99BA-421E-9EF8-E808B855A85F}

--- a/build/ProjectInfo.fs
+++ b/build/ProjectInfo.fs
@@ -8,15 +8,16 @@ let project = "ARCtrl"
 /// Dotnet and JS test paths
 let testProjects = 
     [
-        "tests/Core"
-        "tests/Json"
-        "tests/Spreadsheet"
-        "tests/FileSystem"
-        "tests/ARCtrl"
-        "tests/Yaml"
-        "tests/ValidationPackages"
-        "tests/Contract"
-        "tests/ROCrate"
+        "tests/All"
+        //"tests/Core"
+        //"tests/Json"
+        //"tests/Spreadsheet"
+        //"tests/FileSystem"
+        //"tests/ARCtrl"
+        //"tests/Yaml"
+        //"tests/ValidationPackages"
+        //"tests/Contract"
+        //"tests/ROCrate"
     ]
 
 /// Native JS test paths

--- a/build/TestTasks.fs
+++ b/build/TestTasks.fs
@@ -9,6 +9,8 @@ open Fake.Core
 
 module RunTests = 
 
+    let skipTestsFlag = "--skipTests"
+
     let runTestsUI = BuildTask.create "runTestsUI" [clean; build] {
         let path = "tests/UI"
         Trace.traceImportant "Start UI tests"
@@ -18,46 +20,65 @@ module RunTests =
         run npx $"cypress run --component -P {path}" ""
     }
 
-    let runTestsJsNative = BuildTask.create "runTestsJSNative" [clean; build] {
-        Trace.traceImportant "Start native JavaScript tests"
-        for path in ProjectInfo.jsTestProjects do
-            // transpile library for native access
-            run dotnet $"fable src/ARCtrl/ARCtrl.Javascript.fsproj -o {path}/ARCtrl" ""
-            GenerateIndexJs.ARCtrl_generate($"{path}/ARCtrl")
-            run npx $"mocha {path} --timeout 20000" "" 
-    }
+    let runTestsJsNative = BuildTask.createFn "runTestsJSNative" [clean; build] (fun tp ->
+        if tp.Context.Arguments |> List.exists (fun a -> a.ToLower() = skipTestsFlag.ToLower()) |> not then
+            Trace.traceImportant "Start native JavaScript tests"
+            for path in ProjectInfo.jsTestProjects do
+                // transpile library for native access
+                run dotnet $"fable src/ARCtrl/ARCtrl.Javascript.fsproj -o {path}/ARCtrl" ""
+                GenerateIndexJs.ARCtrl_generate($"{path}/ARCtrl")
+                run npx $"mocha {path} --timeout 20000" ""
+        else
+            Trace.traceImportant "Skipping JavaScript tests"
+    )
 
-    let runTestsJs = BuildTask.create "runTestsJS" [clean; build] {
-        for path in ProjectInfo.testProjects do
-            // transpile js files from fsharp code
-            run dotnet $"fable {path} -o {path}/js" ""
-            // run mocha in target path to execute tests
-            // "--timeout 20000" is used, because json schema validation takes a bit of time.
-            run node $"{path}/js/Main.js" ""
-    }
+    let runTestsJs = BuildTask.createFn "runTestsJS" [clean; build] (fun tp ->
+        if tp.Context.Arguments |> List.exists (fun a -> a.ToLower() = skipTestsFlag.ToLower()) |> not then
+            Trace.traceImportant "Start Js tests"
+            for path in ProjectInfo.testProjects do
+                // transpile js files from fsharp code
+                run dotnet $"fable {path} -o {path}/js" ""
+                // run mocha in target path to execute tests
+                // "--timeout 20000" is used, because json schema validation takes a bit of time.
+                run node $"{path}/js/Main.js" ""
+        else
+            Trace.traceImportant "Skipping Js tests"
+    )
 
-    let runTestsPyNative = BuildTask.create "runTestsPyNative" [clean; build] {
-        Trace.traceImportant "Start native Python tests"
-        for path in ProjectInfo.pyTestProjects do
-            // transpile library for native access
-            run dotnet $"fable src/ARCtrl/ARCtrl.Python.fsproj -o {path}/ARCtrl --lang python" ""
-            GenerateIndexPy.ARCtrl_generate($"{path}/ARCtrl")
-            run python $"-m pytest {path}" "" 
-    }
+    let runTestsPyNative = BuildTask.createFn "runTestsPyNative" [clean; build] (fun tp ->
+        if tp.Context.Arguments |> List.exists (fun a -> a.ToLower() = skipTestsFlag.ToLower()) |> not then
+            Trace.traceImportant "Start native Python tests"
+            for path in ProjectInfo.pyTestProjects do
+                // transpile library for native access
+                run dotnet $"fable src/ARCtrl/ARCtrl.Python.fsproj -o {path}/ARCtrl --lang python" ""
+                GenerateIndexPy.ARCtrl_generate($"{path}/ARCtrl")
+                run python $"-m pytest {path}" ""
+        else
+            Trace.traceImportant "Skipping Python tests"
+    )
 
-    let runTestsPy = BuildTask.create "runTestsPy" [clean; build] {
-        for path in ProjectInfo.testProjects do
-            //transpile py files from fsharp code
-            run dotnet $"fable {path} -o {path}/py --lang python" ""
-            // run pyxpecto in target path to execute tests in python
-            run python $"{path}/py/main.py" ""
-    }
+    let runTestsPy = BuildTask.createFn "runTestsPy" [clean; build] (fun tp ->
+        if tp.Context.Arguments |> List.exists (fun a -> a.ToLower() = skipTestsFlag.ToLower()) |> not then
+            Trace.traceImportant "Start Python tests"
+            for path in ProjectInfo.testProjects do
+                //transpile py files from fsharp code
+                run dotnet $"fable {path} -o {path}/py --lang python" ""
+                // run pyxpecto in target path to execute tests in python
+                run python $"{path}/py/main.py" ""
+        else
+            Trace.traceImportant "Skipping Python tests"
 
-    let runTestsDotnet = BuildTask.create "runTestsDotnet" [clean; build] {
-        let dotnetRun = run dotnet "run"
-        testProjects
-        |> Seq.iter dotnetRun
-    }
+    )
+
+    let runTestsDotnet = BuildTask.createFn "runTestsDotnet" [clean; build] (fun tp ->
+        if tp.Context.Arguments |> List.exists (fun a -> a.ToLower() = skipTestsFlag.ToLower()) |> not then
+            Trace.traceImportant "Start .NET tests"
+            let dotnetRun = run dotnet "run"
+            testProjects
+            |> Seq.iter dotnetRun
+        else
+            Trace.traceImportant "Skipping .NET tests"
+    )
 
     let runTestProject = BuildTask.createFn "runTestProject" [clean; build] (fun config ->
         let dotnetRun = run dotnet "run"

--- a/build/TestTasks.fs
+++ b/build/TestTasks.fs
@@ -25,7 +25,7 @@ module RunTests =
             Trace.traceImportant "Start native JavaScript tests"
             for path in ProjectInfo.jsTestProjects do
                 // transpile library for native access
-                run dotnet $"fable src/ARCtrl/ARCtrl.Javascript.fsproj -o {path}/ARCtrl" ""
+                run dotnet $"fable src/ARCtrl/ARCtrl.Javascript.fsproj -o {path}/ARCtrl --nocache" ""
                 GenerateIndexJs.ARCtrl_generate($"{path}/ARCtrl")
                 run npx $"mocha {path} --timeout 20000" ""
         else
@@ -37,7 +37,7 @@ module RunTests =
             Trace.traceImportant "Start Js tests"
             for path in ProjectInfo.testProjects do
                 // transpile js files from fsharp code
-                run dotnet $"fable {path} -o {path}/js" ""
+                run dotnet $"fable {path} -o {path}/js --nocache" ""
                 // run mocha in target path to execute tests
                 // "--timeout 20000" is used, because json schema validation takes a bit of time.
                 run node $"{path}/js/Main.js" ""
@@ -50,7 +50,7 @@ module RunTests =
             Trace.traceImportant "Start native Python tests"
             for path in ProjectInfo.pyTestProjects do
                 // transpile library for native access
-                run dotnet $"fable src/ARCtrl/ARCtrl.Python.fsproj -o {path}/ARCtrl --lang python" ""
+                run dotnet $"fable src/ARCtrl/ARCtrl.Python.fsproj -o {path}/ARCtrl --lang python --nocache" ""
                 GenerateIndexPy.ARCtrl_generate($"{path}/ARCtrl")
                 run python $"-m pytest {path}" ""
         else
@@ -62,7 +62,7 @@ module RunTests =
             Trace.traceImportant "Start Python tests"
             for path in ProjectInfo.testProjects do
                 //transpile py files from fsharp code
-                run dotnet $"fable {path} -o {path}/py --lang python" ""
+                run dotnet $"fable {path} -o {path}/py --lang python --nocache" ""
                 // run pyxpecto in target path to execute tests in python
                 run python $"{path}/py/main.py" ""
         else

--- a/src/ARCtrl/ARCtrl.Common.props
+++ b/src/ARCtrl/ARCtrl.Common.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Library for management of Annotated Research Contexts (ARCs) using an in-memory representation and runtime agnostic contract systems.</Description>
   </PropertyGroup>
-  <ItemGroup>  
+  <!--<ItemGroup>  
     <Compile Include="JsonIO\Decode.fs" />
     <Compile Include="JsonIO\Encode.fs" />
     <Compile Include="JsonIO\Comment.fs" />
@@ -43,7 +43,7 @@
     <Compile Include="JsonIO\ROCrateObject.fs" />
     <Compile Include="JsonIO\ARC.fs" />
     <None Include="README.md" />
-  </ItemGroup>
+  </ItemGroup>-->
   <ItemGroup>
       <ProjectReference Include="..\Contract\ARCtrl.Contract.fsproj" />
       <ProjectReference Include="..\CWL\ARCtrl.CWL.fsproj" />

--- a/src/ARCtrl/ARCtrl.Javascript.fsproj
+++ b/src/ARCtrl/ARCtrl.Javascript.fsproj
@@ -8,6 +8,7 @@
   
   <Import Project="ARCtrl.Common.props" />
   <ItemGroup>
+    <Content Include="ARCtrl.Common.props" Pack="true" PackagePath="fable/"/>
     <Compile Include="WebRequest\WebRequest.Node.fs" />
     <Compile Include="WebRequest\WebRequest.fs" />
     <Compile Include="Template.Web.fs" />

--- a/src/ARCtrl/ARCtrl.Javascript.fsproj
+++ b/src/ARCtrl/ARCtrl.Javascript.fsproj
@@ -7,6 +7,50 @@
   <Import Project="../Package.Metadata.props" />
   
   <Import Project="ARCtrl.Common.props" />
+
+  <ItemGroup>
+    <Compile Include="JsonIO\Decode.fs" />
+    <Compile Include="JsonIO\Encode.fs" />
+    <Compile Include="JsonIO\Comment.fs" />
+    <Compile Include="JsonIO\OntologyAnnotation.fs" />
+    <Compile Include="JsonIO\OntologySourceReference.fs" />
+    <Compile Include="JsonIO\DataFile.fs" />
+    <Compile Include="JsonIO\Data.fs" />
+    <Compile Include="JsonIO\Person.fs" />
+    <Compile Include="JsonIO\Publication.fs" />
+    <Compile Include="JsonIO\Process\Value.fs" />
+    <Compile Include="JsonIO\Process\Factor.fs" />
+    <Compile Include="JsonIO\Process\FactorValue.fs" />
+    <Compile Include="JsonIO\Process\ProtocolParameter.fs" />
+    <Compile Include="JsonIO\Process\MaterialType.fs" />
+    <Compile Include="JsonIO\Process\MaterialAttribute.fs" />
+    <Compile Include="JsonIO\Process\Component.fs" />
+    <Compile Include="JsonIO\Process\Protocol.fs" />
+    <Compile Include="JsonIO\Process\MaterialAttributeValue.fs" />
+    <Compile Include="JsonIO\Process\Material.fs" />
+    <Compile Include="JsonIO\Process\Source.fs" />
+    <Compile Include="JsonIO\Process\Sample.fs" />
+    <Compile Include="JsonIO\Process\ProcessParameterValue.fs" />
+    <Compile Include="JsonIO\Process\ProcessInput.fs" />
+    <Compile Include="JsonIO\Process\ProcessOutput.fs" />
+    <Compile Include="JsonIO\Process\Process.fs" />
+    <Compile Include="JsonIO\Process\ProcessSequence.fs" />
+    <Compile Include="JsonIO\Process\StudyMaterials.fs" />
+    <Compile Include="JsonIO\Table\Compression.fs" />
+    <Compile Include="JsonIO\Table\CompositeCell.fs" />
+    <Compile Include="JsonIO\Table\IOType.fs" />
+    <Compile Include="JsonIO\Table\CompositeHeader.fs" />
+    <Compile Include="JsonIO\Table\ArcTable.fs" />
+    <Compile Include="JsonIO\Table\Templates.fs" />
+    <Compile Include="JsonIO\DataMap\DataMap.fs" />
+    <Compile Include="JsonIO\Assay.fs" />
+    <Compile Include="JsonIO\Study.fs" />
+    <Compile Include="JsonIO\Investigation.fs" />
+    <Compile Include="JsonIO\ROCrateObject.fs" />
+    <Compile Include="JsonIO\ARC.fs" />
+    <None Include="README.md" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Content Include="ARCtrl.Common.props" Pack="true" PackagePath="fable/"/>
     <Compile Include="WebRequest\WebRequest.Node.fs" />

--- a/src/ARCtrl/ARCtrl.Python.fsproj
+++ b/src/ARCtrl/ARCtrl.Python.fsproj
@@ -7,7 +7,8 @@
   <Import Project="../Package.Metadata.props" />
   
   <Import Project="ARCtrl.Common.props" />
-  <ItemGroup>   
+  <ItemGroup>
+    <Content Include="ARCtrl.Common.props" Pack="true" PackagePath="fable/"/>
     <Compile Include="WebRequest\WebRequest.Py.fs" />
     <Compile Include="WebRequest\WebRequest.fs" />
     <Compile Include="Template.Web.fs" />

--- a/src/ARCtrl/ARCtrl.Python.fsproj
+++ b/src/ARCtrl/ARCtrl.Python.fsproj
@@ -7,6 +7,50 @@
   <Import Project="../Package.Metadata.props" />
   
   <Import Project="ARCtrl.Common.props" />
+
+  <ItemGroup>
+    <Compile Include="JsonIO\Decode.fs" />
+    <Compile Include="JsonIO\Encode.fs" />
+    <Compile Include="JsonIO\Comment.fs" />
+    <Compile Include="JsonIO\OntologyAnnotation.fs" />
+    <Compile Include="JsonIO\OntologySourceReference.fs" />
+    <Compile Include="JsonIO\DataFile.fs" />
+    <Compile Include="JsonIO\Data.fs" />
+    <Compile Include="JsonIO\Person.fs" />
+    <Compile Include="JsonIO\Publication.fs" />
+    <Compile Include="JsonIO\Process\Value.fs" />
+    <Compile Include="JsonIO\Process\Factor.fs" />
+    <Compile Include="JsonIO\Process\FactorValue.fs" />
+    <Compile Include="JsonIO\Process\ProtocolParameter.fs" />
+    <Compile Include="JsonIO\Process\MaterialType.fs" />
+    <Compile Include="JsonIO\Process\MaterialAttribute.fs" />
+    <Compile Include="JsonIO\Process\Component.fs" />
+    <Compile Include="JsonIO\Process\Protocol.fs" />
+    <Compile Include="JsonIO\Process\MaterialAttributeValue.fs" />
+    <Compile Include="JsonIO\Process\Material.fs" />
+    <Compile Include="JsonIO\Process\Source.fs" />
+    <Compile Include="JsonIO\Process\Sample.fs" />
+    <Compile Include="JsonIO\Process\ProcessParameterValue.fs" />
+    <Compile Include="JsonIO\Process\ProcessInput.fs" />
+    <Compile Include="JsonIO\Process\ProcessOutput.fs" />
+    <Compile Include="JsonIO\Process\Process.fs" />
+    <Compile Include="JsonIO\Process\ProcessSequence.fs" />
+    <Compile Include="JsonIO\Process\StudyMaterials.fs" />
+    <Compile Include="JsonIO\Table\Compression.fs" />
+    <Compile Include="JsonIO\Table\CompositeCell.fs" />
+    <Compile Include="JsonIO\Table\IOType.fs" />
+    <Compile Include="JsonIO\Table\CompositeHeader.fs" />
+    <Compile Include="JsonIO\Table\ArcTable.fs" />
+    <Compile Include="JsonIO\Table\Templates.fs" />
+    <Compile Include="JsonIO\DataMap\DataMap.fs" />
+    <Compile Include="JsonIO\Assay.fs" />
+    <Compile Include="JsonIO\Study.fs" />
+    <Compile Include="JsonIO\Investigation.fs" />
+    <Compile Include="JsonIO\ROCrateObject.fs" />
+    <Compile Include="JsonIO\ARC.fs" />
+    <None Include="README.md" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Content Include="ARCtrl.Common.props" Pack="true" PackagePath="fable/"/>
     <Compile Include="WebRequest\WebRequest.Py.fs" />

--- a/src/ARCtrl/ARCtrl.fsproj
+++ b/src/ARCtrl/ARCtrl.fsproj
@@ -6,8 +6,8 @@
   <Import Project="../Package.Metadata.props" />
   
   <Import Project="ARCtrl.Common.props" />
-  <ItemGroup>  
-    <None Include="ARCtrl.Common.props" />
+  <ItemGroup>
+    <Content Include="ARCtrl.Common.props" Pack="true" PackagePath="fable/" />
     <Compile Include="WebRequest\WebRequest.fs" />
     <Compile Include="Template.Web.fs" />
     <Compile Include="ARC.fs" />

--- a/src/ARCtrl/ARCtrl.fsproj
+++ b/src/ARCtrl/ARCtrl.fsproj
@@ -6,6 +6,50 @@
   <Import Project="../Package.Metadata.props" />
   
   <Import Project="ARCtrl.Common.props" />
+
+  <ItemGroup>
+    <Compile Include="JsonIO\Decode.fs" />
+    <Compile Include="JsonIO\Encode.fs" />
+    <Compile Include="JsonIO\Comment.fs" />
+    <Compile Include="JsonIO\OntologyAnnotation.fs" />
+    <Compile Include="JsonIO\OntologySourceReference.fs" />
+    <Compile Include="JsonIO\DataFile.fs" />
+    <Compile Include="JsonIO\Data.fs" />
+    <Compile Include="JsonIO\Person.fs" />
+    <Compile Include="JsonIO\Publication.fs" />
+    <Compile Include="JsonIO\Process\Value.fs" />
+    <Compile Include="JsonIO\Process\Factor.fs" />
+    <Compile Include="JsonIO\Process\FactorValue.fs" />
+    <Compile Include="JsonIO\Process\ProtocolParameter.fs" />
+    <Compile Include="JsonIO\Process\MaterialType.fs" />
+    <Compile Include="JsonIO\Process\MaterialAttribute.fs" />
+    <Compile Include="JsonIO\Process\Component.fs" />
+    <Compile Include="JsonIO\Process\Protocol.fs" />
+    <Compile Include="JsonIO\Process\MaterialAttributeValue.fs" />
+    <Compile Include="JsonIO\Process\Material.fs" />
+    <Compile Include="JsonIO\Process\Source.fs" />
+    <Compile Include="JsonIO\Process\Sample.fs" />
+    <Compile Include="JsonIO\Process\ProcessParameterValue.fs" />
+    <Compile Include="JsonIO\Process\ProcessInput.fs" />
+    <Compile Include="JsonIO\Process\ProcessOutput.fs" />
+    <Compile Include="JsonIO\Process\Process.fs" />
+    <Compile Include="JsonIO\Process\ProcessSequence.fs" />
+    <Compile Include="JsonIO\Process\StudyMaterials.fs" />
+    <Compile Include="JsonIO\Table\Compression.fs" />
+    <Compile Include="JsonIO\Table\CompositeCell.fs" />
+    <Compile Include="JsonIO\Table\IOType.fs" />
+    <Compile Include="JsonIO\Table\CompositeHeader.fs" />
+    <Compile Include="JsonIO\Table\ArcTable.fs" />
+    <Compile Include="JsonIO\Table\Templates.fs" />
+    <Compile Include="JsonIO\DataMap\DataMap.fs" />
+    <Compile Include="JsonIO\Assay.fs" />
+    <Compile Include="JsonIO\Study.fs" />
+    <Compile Include="JsonIO\Investigation.fs" />
+    <Compile Include="JsonIO\ROCrateObject.fs" />
+    <Compile Include="JsonIO\ARC.fs" />
+    <None Include="README.md" />
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="ARCtrl.Common.props" Pack="true" PackagePath="fable/" />
     <Compile Include="WebRequest\WebRequest.fs" />

--- a/src/ARCtrl/packages.lock.json
+++ b/src/ARCtrl/packages.lock.json
@@ -47,17 +47,17 @@
       "arctrl.contract": {
         "type": "Project",
         "dependencies": {
-          "ARCtrl.Core": "[2.1.0, )",
-          "ARCtrl.Json": "[2.1.0, )",
-          "ARCtrl.Spreadsheet": "[2.1.0, )",
-          "ARCtrl.Yaml": "[2.1.0, )"
+          "ARCtrl.Core": "[2.1.0-alpha.3, )",
+          "ARCtrl.Json": "[2.1.0-alpha.3, )",
+          "ARCtrl.Spreadsheet": "[2.1.0-alpha.3, )",
+          "ARCtrl.Yaml": "[2.1.0-alpha.3, )"
         }
       },
       "arctrl.core": {
         "type": "Project",
         "dependencies": {
-          "ARCtrl.CWL": "[2.1.0, )",
-          "ARCtrl.FileSystem": "[2.1.0, )"
+          "ARCtrl.CWL": "[2.1.0-alpha.3, )",
+          "ARCtrl.FileSystem": "[2.1.0-alpha.3, )"
         }
       },
       "arctrl.cwl": {
@@ -72,8 +72,8 @@
       "arctrl.json": {
         "type": "Project",
         "dependencies": {
-          "ARCtrl.Core": "[2.1.0, )",
-          "ARCtrl.ROCrate": "[2.1.0, )",
+          "ARCtrl.Core": "[2.1.0-alpha.3, )",
+          "ARCtrl.ROCrate": "[2.1.0-alpha.3, )",
           "Thoth.Json.Core": "[0.4.0, )"
         }
       },
@@ -87,22 +87,22 @@
       "arctrl.spreadsheet": {
         "type": "Project",
         "dependencies": {
-          "ARCtrl.Core": "[2.1.0, )",
-          "ARCtrl.FileSystem": "[2.1.0, )",
+          "ARCtrl.Core": "[2.1.0-alpha.3, )",
+          "ARCtrl.FileSystem": "[2.1.0-alpha.3, )",
           "FsSpreadsheet": "[6.3.0-alpha.4, )"
         }
       },
       "arctrl.validationpackages": {
         "type": "Project",
         "dependencies": {
-          "ARCtrl.Core": "[2.1.0, )"
+          "ARCtrl.Core": "[2.1.0-alpha.3, )"
         }
       },
       "arctrl.yaml": {
         "type": "Project",
         "dependencies": {
-          "ARCtrl.Core": "[2.1.0, )",
-          "ARCtrl.ValidationPackages": "[2.1.0, )",
+          "ARCtrl.Core": "[2.1.0-alpha.3, )",
+          "ARCtrl.ValidationPackages": "[2.1.0-alpha.3, )",
           "YAMLicious": "[0.0.1, )"
         }
       },

--- a/tests/ARCtrl/Main.fs
+++ b/tests/ARCtrl/Main.fs
@@ -1,4 +1,4 @@
-module Main.Tests
+module ARCtrl.ARC.Tests
 
 open Fable.Pyxpecto
 
@@ -11,5 +11,7 @@ let all = testSequenced <| testList "ARCtrl" [
     ARCtrl.Tests.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all

--- a/tests/All/All.Tests.fsproj
+++ b/tests/All/All.Tests.fsproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <DefineConstants>TESTS_ALL</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ARCtrl\ARCtrl.Tests.fsproj" />
+    <ProjectReference Include="..\Contract\ARCtrl.Contract.Tests.fsproj" />
+    <ProjectReference Include="..\Core\ARCtrl.Core.Tests.fsproj" />
+    <ProjectReference Include="..\FileSystem\ARCtrl.FileSystem.Tests.fsproj" />
+    <ProjectReference Include="..\Json\ARCtrl.Json.Tests.fsproj" />
+    <ProjectReference Include="..\ROCrate\ARCtrl.ROCrate.Tests.fsproj" />
+    <ProjectReference Include="..\Spreadsheet\ARCtrl.Spreadsheet.Tests.fsproj" />
+    <ProjectReference Include="..\ValidationPackages\ARCtrl.ValidationPackages.Tests.fsproj" />
+    <ProjectReference Include="..\Yaml\ARCtrl.Yaml.Tests.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="8.0.400" />
+  </ItemGroup>
+</Project>

--- a/tests/All/Main.fs
+++ b/tests/All/Main.fs
@@ -1,0 +1,20 @@
+module Main.Tests
+
+open Fable.Pyxpecto
+
+let all = testList "All" [
+    
+    ARCtrl.Core.Tests.all
+    ARCtrl.Json.Tests.all
+    ARCtrl.Spreadsheet.Tests.all
+    ARCtrl.FileSystem.Tests.all
+    ARCtrl.ARC.Tests.all
+    ARCtrl.Yaml.Tests.all
+    ARCtrl.ValidationPackages.Tests.all
+    ARCtrl.Contract.Tests.all
+    ARCtrl.ROCrate.Tests.all
+    
+]
+
+[<EntryPoint>]
+let main argv = Pyxpecto.runTests [||] all

--- a/tests/Contract/Main.fs
+++ b/tests/Contract/Main.fs
@@ -1,4 +1,4 @@
-module ARCtrl.FileSystem.Tests
+module ARCtrl.Contract.Tests
 
 open Fable.Pyxpecto
 
@@ -6,5 +6,7 @@ let all = testSequenced <| testList "ValidationPackages" [
     Tests.ValidationPackagesConfig.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all

--- a/tests/Core/Main.fs
+++ b/tests/Core/Main.fs
@@ -1,4 +1,4 @@
-module ARCtrl.ISADotnet.Tests
+module ARCtrl.Core.Tests
 
 open Fable.Pyxpecto
 
@@ -24,5 +24,7 @@ let all = testSequenced <| testList "Core" [
     Fable.Tests.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all

--- a/tests/FileSystem/Main.fs
+++ b/tests/FileSystem/Main.fs
@@ -1,4 +1,4 @@
-﻿module ARCtrl.FileSystem.Tests
+module ARCtrl.FileSystem.Tests
 
 open Fable.Pyxpecto
 
@@ -6,5 +6,7 @@ let all = testSequenced <| testList "FileSystem" [
     ARCtrl.FileSystemTree.Tests.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all

--- a/tests/Json/Main.fs
+++ b/tests/Json/Main.fs
@@ -24,5 +24,7 @@ let all = testSequenced <| testList "Json" [
     Tests.SchemaValidation.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all

--- a/tests/ROCrate/Main.fs
+++ b/tests/ROCrate/Main.fs
@@ -1,4 +1,4 @@
-module ROCrate.Tests
+module ARCtrl.ROCrate.Tests
 
 open Fable.Pyxpecto
 
@@ -17,5 +17,7 @@ let all = testSequenced <| testList "ROCrate" [
     Tests.ScholarlyArticle.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all

--- a/tests/Spreadsheet/Main.fs
+++ b/tests/Spreadsheet/Main.fs
@@ -1,4 +1,4 @@
-﻿module Spreadsheet.Tests
+module ARCtrl.Spreadsheet.Tests
 
 open Fable.Pyxpecto
 
@@ -17,5 +17,7 @@ let all = testSequenced <| testList "ISA.Spreadsheet" [
     TemplateTests.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all

--- a/tests/ValidationPackages/Main.fs
+++ b/tests/ValidationPackages/Main.fs
@@ -1,4 +1,4 @@
-module ARCtrl.FileSystem.Tests
+module ARCtrl.ValidationPackages.Tests
 
 open Fable.Pyxpecto
 
@@ -7,5 +7,7 @@ let all = testSequenced <| testList "ValidationPackages" [
     Tests.ValidationPackagesConfig.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all

--- a/tests/Yaml/Main.fs
+++ b/tests/Yaml/Main.fs
@@ -7,5 +7,7 @@ let all = testSequenced <| testList "Yaml" [
     Tests.ValidationPackagesConfig.main
 ]
 
+#if !TESTS_ALL
 [<EntryPoint>]
+#endif
 let main argv = Pyxpecto.runTests [||] all


### PR DESCRIPTION
- Moved references to source files in `JsonIO` folder from `ARCtrl.Common.props` to each project file, as this was causing problems in downstream transpilation (see [Issue in reference project](https://github.com/MangelMaxime/fable-example-multi-targets/issues/1))
- Created an "All" Tests project which references all other tests. This should minimize duplicate transpilation and inrease build time tremendously