### PR TITLE
Improve LDObject, add ISA model API

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="FsSpreadsheet.Js"      Version="6.3.1" />
     <PackageVersion Include="FsSpreadsheet.Py"      Version="6.3.1" />
     <PackageVersion Include="YAMLicious"            Version="0.0.3" />
-    <PackageVersion Include="DynamicObj"            Version="4.0.3" />
+    <PackageVersion Include="DynamicObj"            Version="6.0.0" />
     <PackageVersion Include="Fable.SimpleHttp"      Version="3.5.0" />
     <PackageVersion Include="Fable.Fetch"           Version="2.6.0" />
     <PackageVersion Include="Fable.Node"            Version="1.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="FsSpreadsheet.Js"      Version="6.3.1" />
     <PackageVersion Include="FsSpreadsheet.Py"      Version="6.3.1" />
     <PackageVersion Include="YAMLicious"            Version="0.0.3" />
-    <PackageVersion Include="DynamicObj"            Version="6.0.0" />
+    <PackageVersion Include="DynamicObj"            Version="7.0.0" />
     <PackageVersion Include="Fable.SimpleHttp"      Version="3.5.0" />
     <PackageVersion Include="Fable.Fetch"           Version="2.6.0" />
     <PackageVersion Include="Fable.Node"            Version="1.2.0" />

--- a/build/ProjectInfo.fs
+++ b/build/ProjectInfo.fs
@@ -5,19 +5,22 @@ open Helpers
 
 let project = "ARCtrl"
 
+let allTestsProject = "tests/All"
+
 /// Dotnet and JS test paths
 let testProjects = 
     [
         "tests/All"
-        //"tests/Core"
-        //"tests/Json"
-        //"tests/Spreadsheet"
-        //"tests/FileSystem"
-        //"tests/ARCtrl"
-        //"tests/Yaml"
-        //"tests/ValidationPackages"
-        //"tests/Contract"
-        //"tests/ROCrate"
+        "tests/ARCtrl"
+        "tests/Contract"
+        "tests/Core"
+        "tests/CWL"
+        "tests/FileSystem"
+        "tests/Json"
+        "tests/ROCrate"
+        "tests/Spreadsheet"
+        "tests/ValidationPackages"
+        "tests/Yaml"
     ]
 
 /// Native JS test paths

--- a/build/TestTasks.fs
+++ b/build/TestTasks.fs
@@ -36,16 +36,14 @@ module RunTests =
     let runTestsJs = BuildTask.createFn "runTestsJS" [clean] (fun tp ->
         if tp.Context.Arguments |> List.exists (fun a -> a.ToLower() = skipTestsFlag.ToLower()) |> not then
             Trace.traceImportant "Start Js tests"
-            for path in ProjectInfo.testProjects do
-                // Setup test results directory after clean
-                System.IO.Directory.CreateDirectory("./tests/TestingUtils/TestResults/js") |> ignore
-                // transpile js files from fsharp code
-                run dotnet $"fable {path} -o {path}/js --nocache" ""
-
-                System.IO.File.Copy(jsHelperFilePath, $"{path}/js/{jsHelperFileName}") |> ignore
-                // run mocha in target path to execute tests
-                // "--timeout 20000" is used, because json schema validation takes a bit of time.
-                run node $"{path}/js/Main.js" ""
+            // Setup test results directory after clean
+            System.IO.Directory.CreateDirectory("./tests/TestingUtils/TestResults/js") |> ignore
+            // transpile js files from fsharp code
+            run dotnet $"fable {allTestsProject} -o {allTestsProject}/js --nocache" ""
+            System.IO.File.Copy(jsHelperFilePath, $"{allTestsProject}/js/{jsHelperFileName}") |> ignore
+            // run mocha in target path to execute tests
+            // "--timeout 20000" is used, because json schema validation takes a bit of time.
+            run node $"{allTestsProject}/js/Main.js" ""
         else
             Trace.traceImportant "Skipping Js tests"
     )
@@ -65,13 +63,12 @@ module RunTests =
     let runTestsPy = BuildTask.createFn "runTestsPy" [clean] (fun tp ->
         if tp.Context.Arguments |> List.exists (fun a -> a.ToLower() = skipTestsFlag.ToLower()) |> not then
             Trace.traceImportant "Start Python tests"
-            for path in ProjectInfo.testProjects do
-                // Setup test results directory after clean
-                System.IO.Directory.CreateDirectory("./tests/TestingUtils/TestResults/py") |> ignore
-                //transpile py files from fsharp code
-                run dotnet $"fable {path} -o {path}/py --lang python --nocache" ""
-                // run pyxpecto in target path to execute tests in python
-                run python $"{path}/py/main.py" ""
+            // Setup test results directory after clean
+            System.IO.Directory.CreateDirectory("./tests/TestingUtils/TestResults/py") |> ignore
+            //transpile py files from fsharp code
+            run dotnet $"fable {allTestsProject} -o {allTestsProject}/py --lang python --nocache" ""
+            // run pyxpecto in target path to execute tests in python
+            run python $"{allTestsProject}/py/main.py" ""
         else
             Trace.traceImportant "Skipping Python tests"
 
@@ -81,8 +78,7 @@ module RunTests =
         if tp.Context.Arguments |> List.exists (fun a -> a.ToLower() = skipTestsFlag.ToLower()) |> not then
             Trace.traceImportant "Start .NET tests"
             let dotnetRun = run dotnet "run"
-            testProjects
-            |> Seq.iter dotnetRun
+            dotnetRun allTestsProject
         else
             Trace.traceImportant "Skipping .NET tests"
     )
@@ -105,6 +101,7 @@ module RunTests =
                 run python $"{p}/py/main.py" ""
                 // transpile js files from fsharp code
                 run dotnet $"fable {p} -o {p}/js" ""
+                System.IO.Directory.CreateDirectory("./tests/TestingUtils/TestResults/js") |> ignore
                 System.IO.File.Copy(jsHelperFilePath, $"{p}/js/{jsHelperFileName}") |> ignore
                 // run mocha in target path to execute tests
                 // "--timeout 20000" is used, because json schema validation takes a bit of time.

--- a/src/Json/Decode.fs
+++ b/src/Json/Decode.fs
@@ -93,9 +93,7 @@ module Decode =
                     decoder.Decode(helpers,value)
         }
 
-
-
-    let resizeArray (decoder: Decoder<'value>) : Decoder<ResizeArray<'value>> =
+    let resizeArrayOrSingleton (decoder: Decoder<'value>) : Decoder<ResizeArray<'value>> =
         { new Decoder<ResizeArray<'value>> with
             member _.Decode(helpers, value) =
                 if helpers.isArray value then
@@ -123,7 +121,7 @@ module Decode =
                                 Ok acc
                     )
                 else
-                    ("", BadPrimitive("an array", value)) |> Error
+                    decoder.Decode(helpers, value) |> Result.map (fun x -> ResizeArray[x])
         }
 
     let datetime: Decoder<System.DateTime> =

--- a/src/Json/Encode.fs
+++ b/src/Json/Encode.fs
@@ -64,3 +64,11 @@ module Encode =
         match obj with
         | Json.Object kvs -> Json.Object (Seq.append kvs [name, value] )
         | _ -> failwith "Expected object"
+
+    let resizeArrayOrSingleton (encoder : 'T -> IEncodable) (values: ResizeArray<'T>) =
+        if values.Count = 1 then
+            values.[0] |> encoder
+        else
+            values
+            |> Seq.map encoder
+            |> Encode.seq

--- a/src/ROCrate/ArcROCrateMetadata.fs
+++ b/src/ROCrate/ArcROCrateMetadata.fs
@@ -4,7 +4,7 @@ open DynamicObj
 
 type ArcROCrateMetadata(?about : LDObject) as this =
 
-    inherit LDObject(id = "ro-crate-metadata",schemaType = "CreativeWork")
+    inherit LDObject(id = "ro-crate-metadata",schemaType = ResizeArray([|"CreativeWork"|]))
 
     do DynObj.setOptionalProperty (nameof about) about this
 

--- a/src/ROCrate/DynObjExtensions.fs
+++ b/src/ROCrate/DynObjExtensions.fs
@@ -13,3 +13,9 @@ module DynObj =
             | None -> raise (System.InvalidCastException($"Property '{propertyName}' is set on this '{className}' object but cannot be cast to '{(typeof<'TPropertyValue>).Name}'"))
         else
             raise (System.MissingMemberException($"No property '{propertyName}' set on this '{className}' object although it is mandatory. Was it created correctly?"))
+
+    let inline tryGetTypedPropertyValueAsResizeArray<'T> (name : string) (obj : DynamicObj) =
+        match obj.TryGetPropertyValue(name) with
+        | Some (:? ResizeArray<'T> as ra) -> Some ra
+        | Some (:? 'T as singleton) -> Some (ResizeArray [singleton])
+        | _ -> None

--- a/src/ROCrate/ISAProfile/Assay.fs
+++ b/src/ROCrate/ISAProfile/Assay.fs
@@ -17,7 +17,7 @@ type Assay(
     ?url,
     ?variableMeasured
 ) as this =
-    inherit Dataset(id, "Assay")
+    inherit Dataset(id = id, additionalType = ResizeArray[|"Assay"|])
     do
         DynObj.setProperty (nameof identifier) identifier this
 

--- a/src/ROCrate/ISAProfile/Data.fs
+++ b/src/ROCrate/ISAProfile/Data.fs
@@ -13,7 +13,11 @@ type Data(
     ?encodingFormat,
     ?disambiguatingDescription
 ) as this =
-    inherit LDObject(id = id, schemaType = "schema.org/MediaObject", ?additionalType = additionalType)
+    inherit LDObject(
+        id = id,
+        schemaType = ResizeArray[|"schema.org/MediaObject"|],
+        additionalType = defaultArg additionalType (ResizeArray[||])
+    )
     do
         DynObj.setProperty (nameof name) name this
 

--- a/src/ROCrate/ISAProfile/Dataset.fs
+++ b/src/ROCrate/ISAProfile/Dataset.fs
@@ -2,8 +2,12 @@ namespace ARCtrl.ROCrate
 
 open DynamicObj
 open Fable.Core
- 
+
 ///
 [<AttachMembers>]
-type Dataset (id: string, ?additionalType: string) =
-    inherit LDObject(id = id, schemaType = "schema.org/Dataset", ?additionalType = additionalType)
+type Dataset (id: string, ?additionalType: ResizeArray<string>) =
+    inherit LDObject(
+        id = id,
+        schemaType = ResizeArray[|"schema.org/Dataset"|],
+        additionalType = defaultArg additionalType (ResizeArray[||])
+    )

--- a/src/ROCrate/ISAProfile/Investigation.fs
+++ b/src/ROCrate/ISAProfile/Investigation.fs
@@ -20,7 +20,7 @@ type Investigation(
     ?url,
     ?description
 ) as this =
-    inherit Dataset(id, "Investigation")
+    inherit Dataset(id = id, additionalType = ResizeArray[|"Investigation"|])
     do 
         DynObj.setProperty (nameof identifier) identifier this
 

--- a/src/ROCrate/ISAProfile/LabProcess.fs
+++ b/src/ROCrate/ISAProfile/LabProcess.fs
@@ -17,7 +17,11 @@ type LabProcess(
     ?endTime,
     ?disambiguatingDescription
 ) as this =
-    inherit LDObject(id = id, schemaType = "bioschemas.org/LabProcess", ?additionalType = additionalType)
+    inherit LDObject(
+        id = id,
+        schemaType = ResizeArray[|"bioschemas.org/LabProcess"|],
+        additionalType = defaultArg additionalType (ResizeArray[||])
+    )
     do
         DynObj.setProperty (nameof name) name     this
         DynObj.setProperty (nameof agent) agent   this

--- a/src/ROCrate/ISAProfile/LabProtocol.fs
+++ b/src/ROCrate/ISAProfile/LabProtocol.fs
@@ -18,7 +18,11 @@ type LabProtocol(
     ?reagent,
     ?computationalTool
 ) as this =
-    inherit LDObject(id = id, schemaType = "bioschemas.org/LabProtocol", ?additionalType = additionalType)
+    inherit LDObject(
+        id = id,
+        schemaType = ResizeArray[|"bioschemas.org/LabProtocol"|],
+        additionalType = defaultArg additionalType (ResizeArray[||])
+    )
     do
         DynObj.setOptionalProperty (nameof name) name                            this
         DynObj.setOptionalProperty (nameof intendedUse) intendedUse              this

--- a/src/ROCrate/ISAProfile/Person.fs
+++ b/src/ROCrate/ISAProfile/Person.fs
@@ -20,7 +20,11 @@ type Person(
     ?faxNumber,
     ?disambiguatingDescription
 ) as this=
-    inherit LDObject(id = id, schemaType = "schema.org/Person", ?additionalType = additionalType)
+    inherit LDObject(
+        id = id,
+        schemaType = ResizeArray[|"schema.org/Person"|],
+        additionalType = defaultArg additionalType (ResizeArray[||])
+    )
     do
 
         DynObj.setProperty (nameof givenName) givenName this

--- a/src/ROCrate/ISAProfile/PropertyValue.fs
+++ b/src/ROCrate/ISAProfile/PropertyValue.fs
@@ -15,7 +15,11 @@ type PropertyValue(
     ?valueReference,
     ?additionalType
 ) as this =
-    inherit LDObject(id = id, schemaType = "schema.org/PropertyValue", ?additionalType = additionalType)
+    inherit LDObject(
+        id = id,
+        schemaType = ResizeArray[|"schema.org/PropertyValue"|],
+        additionalType = defaultArg additionalType (ResizeArray[||])
+    )
     do
 
         DynObj.setProperty (nameof name) name this

--- a/src/ROCrate/ISAProfile/Sample.fs
+++ b/src/ROCrate/ISAProfile/Sample.fs
@@ -12,7 +12,11 @@ type Sample(
     ?additionalProperty,
     ?derivesFrom
 ) as this =
-    inherit LDObject(id = id, schemaType = "bioschemas.org/Sample", ?additionalType = additionalType)
+    inherit LDObject(
+        id = id,
+        schemaType = ResizeArray[|"bioschemas.org/Sample"|], 
+        additionalType = defaultArg additionalType (ResizeArray[||])
+    )
     do
         DynObj.setProperty (nameof name) name this
 

--- a/src/ROCrate/ISAProfile/ScholarlyArticle.fs
+++ b/src/ROCrate/ISAProfile/ScholarlyArticle.fs
@@ -16,7 +16,11 @@ type ScholarlyArticle(
     ?disambiguatingDescription
 
 ) as this =
-    inherit LDObject(id = id, schemaType = "schema.org/ScholarlyArticle", ?additionalType = additionalType)
+    inherit LDObject(
+        id = id,
+        schemaType = ResizeArray[|"schema.org/ScholarlyArticle"|],
+        additionalType = defaultArg additionalType (ResizeArray[||])
+    )
     do
 
         DynObj.setProperty (nameof headline) headline     this

--- a/src/ROCrate/ISAProfile/Study.fs
+++ b/src/ROCrate/ISAProfile/Study.fs
@@ -20,7 +20,7 @@ type Study(
     ?headline,
     ?url
 ) as this = 
-    inherit Dataset(id, "Study")
+    inherit Dataset(id = id, additionalType = ResizeArray[|"Study"|])
     do
         DynObj.setProperty (nameof identifier) identifier this
         DynObj.setOptionalProperty (nameof about) about                 this 

--- a/src/ROCrate/LDObject.fs
+++ b/src/ROCrate/LDObject.fs
@@ -56,4 +56,19 @@ type LDObject(id:string, schemaType: string, ?additionalType) =
 
     member this.RemoveContext() = this.RemoveProperty("@context")
 
-    static member removeContext () = fun (roc: #LDObject) -> roc.RemoveContext() 
+    static member removeContext () = fun (roc: #LDObject) -> roc.RemoveContext()
+
+    static member tryFromDynamicObj (dynObj: DynamicObj) =
+        match
+            DynObj.tryGetTypedPropertyValue<string>("@type") dynObj,
+            DynObj.tryGetTypedPropertyValue<string>("@id") dynObj,
+            DynObj.tryGetTypedPropertyValue<string>("additionalType") dynObj
+        with
+        | (Some schemaType), (Some id), at ->
+            let roc = new LDObject(id, schemaType, ?additionalType = at)
+            match DynObj.tryGetTypedPropertyValue<LDContext>("@context") dynObj with
+            | Some context -> roc.SetContext(context)
+            | _ -> ()
+            Some roc
+        | _ -> None
+        

--- a/src/ROCrate/LDObject.fs
+++ b/src/ROCrate/LDObject.fs
@@ -75,10 +75,29 @@ type LDObject(id: string, schemaType: ResizeArray<string>, ?additionalType: Resi
             //| _ -> ()
 
             // copy dynamic properties!
-            dynObj.DeepCopyPropertiesTo(roc)
-            roc.TryGetDynamicPropertyHelper("@id").Value.RemoveValue()
-            roc.TryGetDynamicPropertyHelper("@type").Value.RemoveValue()
-            if at.IsSome then roc.TryGetDynamicPropertyHelper("additionalType").Value.RemoveValue()
+            dynObj.DeepCopyPropertiesTo(roc, includeInstanceProperties = false)
+
+
+            // ----- Commented out as implementation has not been finalized -----
+            //printfn "dynobj"
+            //dynObj.GetPropertyHelpers(true)           
+            //|> Seq.iter (fun p -> printfn "isDynamic:%b, Name: %s" p.IsDynamic p.Name)
+            //printfn "roc"
+            //roc.GetPropertyHelpers(true)           
+            //|> Seq.iter (fun p -> printfn "isDynamic:%b, Name: %s" p.IsDynamic p.Name)      
+            //roc.TryGetDynamicPropertyHelper("@id").Value.RemoveValue()
+            //roc.TryGetDynamicPropertyHelper("@type").Value.RemoveValue()
+            //if at.IsSome then roc.TryGetDynamicPropertyHelper("additionalType").Value.RemoveValue()
+
+            roc.GetPropertyHelpers(true)
+            |> Seq.iter (fun ph ->
+                if ph.IsDynamic && (ph.Name = "@id" || ph.Name = "@type" || ph.Name = "additionalType"(* || ph.Name = "id"*)) then
+                    ph.RemoveValue(roc)
+            )
+
+
+
+
             Some roc
 
         | _ -> None

--- a/tests/Json/LDObject.Tests.fs
+++ b/tests/Json/LDObject.Tests.fs
@@ -11,7 +11,7 @@ let private test_read = testList "Read" [
     testCase "onlyIDAndType" <| fun _ ->
         let json = LDObject.fromROCrateJsonString(GenericObjects.onlyIDAndType)
         Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
-        Expect.equal json.SchemaType "MyType" "type was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
     testCase "onlyID" <| fun _ ->
         let f = fun _ -> LDObject.fromROCrateJsonString(GenericObjects.onlyID) |> ignore
         Expect.throws f "Should fail if Type is missing"
@@ -21,7 +21,7 @@ let private test_read = testList "Read" [
     testCase "withStringFields" <| fun _ ->
         let json = LDObject.fromROCrateJsonString(GenericObjects.withStringFields)
         Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
-        Expect.equal json.SchemaType "MyType" "type was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
         let name = Expect.wantSome (DynObj.tryGetTypedPropertyValue<string> "name" json) "field name was not parsed"
         Expect.equal name "MyName" "field name was not parsed correctly"
         let description = Expect.wantSome (DynObj.tryGetTypedPropertyValue<string> "description" json) "field description was not parsed"
@@ -29,7 +29,7 @@ let private test_read = testList "Read" [
     testCase "withIntFields" <| fun _ ->
         let json = LDObject.fromROCrateJsonString(GenericObjects.withIntFields)
         Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
-        Expect.equal json.SchemaType "MyType" "type was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
         let number = Expect.wantSome (DynObj.tryGetTypedPropertyValue<int> "number" json) "field number was not parsed"
         Expect.equal number 42 "field number was not parsed correctly"
         let anotherNumber = Expect.wantSome (DynObj.tryGetTypedPropertyValue<int> "anotherNumber" json) "field anotherNumber was not parsed"
@@ -37,7 +37,7 @@ let private test_read = testList "Read" [
     testCase "withStringArray" <| fun _ ->
         let json = LDObject.fromROCrateJsonString(GenericObjects.withStringArray)
         Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
-        Expect.equal json.SchemaType "MyType" "type was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
         let names = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "names" json) "field names was not parsed"
         Expect.equal names.Count 2 "ResizeArray length is wrong"
         Expect.equal names.[0] "MyName" "First name was not parsed correctly"
@@ -45,75 +45,147 @@ let private test_read = testList "Read" [
     testCase "withNestedObject" <| fun _ ->
         let json = LDObject.fromROCrateJsonString(GenericObjects.withNestedObject)
         Expect.equal json.Id "OuterIdentifier" "id was not parsed correctly"
-        Expect.equal json.SchemaType "MyType" "type was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
         let nested = Expect.wantSome (DynObj.tryGetTypedPropertyValue<LDObject> "nested" json) "field nested was not parsed"
         Expect.equal nested.Id "MyIdentifier" "nested id was not parsed correctly"
-        Expect.equal nested.SchemaType "MyType" "nested type was not parsed correctly"
+        Expect.sequenceEqual nested.SchemaType ResizeArray["MyType"] "nested type was not parsed correctly"
     testCase "withObjectArray" <| fun _ ->
         let json = LDObject.fromROCrateJsonString(GenericObjects.withObjectArray)
         Expect.equal json.Id "OuterIdentifier" "id was not parsed correctly"
-        Expect.equal json.SchemaType "MyType" "type was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
         let nested = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "nested" json) "field nested was not parsed"
         Expect.equal nested.Count 2 "ResizeArray length is wrong"
         let o1 = nested.[0] :?> LDObject
         Expect.equal o1.Id "MyIdentifier" "First nested id was not parsed correctly"
-        Expect.equal o1.SchemaType "MyType" "First nested type was not parsed correctly"
+        Expect.sequenceEqual o1.SchemaType ResizeArray["MyType"] "First nested type was not parsed correctly"
         let o2 = nested.[1] :?> LDObject
         Expect.equal o2.Id "MyIdentifier" "Second nested id was not parsed correctly"
-        Expect.equal o2.SchemaType "MyType" "Second nested type was not parsed correctly"
+        Expect.sequenceEqual o2.SchemaType ResizeArray["MyType"] "Second nested type was not parsed correctly"
     testCase "withMixedArray" <| fun _ ->
         let json = LDObject.fromROCrateJsonString(GenericObjects.withMixedArray)
         Expect.equal json.Id "OuterIdentifier" "id was not parsed correctly"
-        Expect.equal json.SchemaType "MyType" "type was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
         let nested = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "nested" json) "field nested was not parsed"
         Expect.equal nested.Count 3 "ResizeArray length is wrong"
         let o1 = nested.[0] :?> LDObject
         Expect.equal o1.Id "MyIdentifier" "First nested id of object was not parsed correctly"
-        Expect.equal o1.SchemaType "MyType" "First nested type of object was not parsed correctly"
+        Expect.sequenceEqual o1.SchemaType ResizeArray["MyType"] "First nested type of object was not parsed correctly"
         let o2 = nested.[1] :?> string
         Expect.equal o2 "Value2" "Second nested string was not parsed correctly"
         let o3 = nested.[2] :?> int
         Expect.equal o3 42 "Third nested int was not parsed correctly"
+    testCase "withAdditionalTypeString" <| fun _ ->
+        let json = LDObject.fromROCrateJsonString(GenericObjects.withAdditionalTypeString)
+        Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
+        Expect.sequenceEqual json.AdditionalType ResizeArray["additionalType"] "additionalType was not parsed correctly"
+    testCase "withAdditionalTypeArray" <| fun _ ->
+        let json = LDObject.fromROCrateJsonString(GenericObjects.withAdditionalTypeArray)
+        Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
+        Expect.sequenceEqual json.AdditionalType ResizeArray["additionalType"] "additionalType was not parsed correctly"
+    testCase "withAddtionalTypeArrayMultipleEntries" <| fun _ ->
+        let json = LDObject.fromROCrateJsonString(GenericObjects.withAddtionalTypeArrayMultipleEntries)
+        Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"] "type was not parsed correctly"
+        Expect.sequenceEqual json.AdditionalType ResizeArray["additionalType1"; "additionalType2"] "additionalType was not parsed correctly"
 ]
 
 let test_write = testList "write" [
+    // The tests suffixed with 'NoTypeArray' are not real roundtrips, as we parse string OR array fields but always write arrays for the @type field.
     testCase "onlyIDAndType" <| fun _ ->
         let json = GenericObjects.onlyIDAndType
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
         Expect.stringEqual output json "Output string is not correct"
+    testCase "onlyIDAndTypeNoTypeArray" <| fun _ ->
+        let json = GenericObjects.onlyIDAndTypeNoTypeArray
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output GenericObjects.onlyIDAndType "Output string is not correct"
+
     testCase "withStringFields" <| fun _ ->
         let json = GenericObjects.withStringFields
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
         Expect.stringEqual output json "Output string is not correct"
+    testCase "withStringFieldsNoTypeArray" <| fun _ ->
+        let json = GenericObjects.withStringFieldsNoTypeArray
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output GenericObjects.withStringFields "Output string is not correct"
+
     testCase "withIntFields" <| fun _ ->
         let json = GenericObjects.withIntFields
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
         Expect.stringEqual output json "Output string is not correct"
+    testCase "withIntFieldsNoTypeArray" <| fun _ ->
+        let json = GenericObjects.withIntFieldsNoTypeArray
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output GenericObjects.withIntFields "Output string is not correct"
+
     testCase "withStringArray" <| fun _ ->
         let json = GenericObjects.withStringArray
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
         Expect.stringEqual output json "Output string is not correct"
+    testCase "withStringArrayNoTypeArray" <| fun _ ->
+        let json = GenericObjects.withStringArrayNoTypeArray
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output GenericObjects.withStringArray "Output string is not correct"
+
     testCase "withNestedObject" <| fun _ ->
         let json = GenericObjects.withNestedObject
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
         Expect.stringEqual output json "Output string is not correct"
+    testCase "withNestedObjectNoTypeArray" <| fun _ ->
+        let json = GenericObjects.withNestedObjectNoTypeArray
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output GenericObjects.withNestedObject "Output string is not correct"
+
     testCase "withObjectArray" <| fun _ ->
         let json = GenericObjects.withObjectArray
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
         Expect.stringEqual output json "Output string is not correct"
+    testCase "withObjectArrayNoTypeArray" <| fun _ ->
+        let json = GenericObjects.withObjectArrayNoTypeArray
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output GenericObjects.withObjectArray "Output string is not correct"
+
     testCase "withMixedArray" <| fun _ ->
         let json = GenericObjects.withMixedArray
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
         Expect.stringEqual output json "Output string is not correct"
-        
+    testCase "withMixedArrayNoTypeArray" <| fun _ ->
+        let json = GenericObjects.withMixedArrayNoTypeArray
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output GenericObjects.withMixedArray "Output string is not correct"
 
+    testCase "withAddtionalTypeArray" <| fun _ ->
+        let json = GenericObjects.withAdditionalTypeArray
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output json "Output string is not correct"
+    testCase "withAddtionalTypeArrayMultipleEntries" <| fun _ ->
+        let json = GenericObjects.withAddtionalTypeArrayMultipleEntries
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output json "Output string is not correct"
+
+    testCase "withAddtionalTypeString" <| fun _ ->
+        let json = GenericObjects.withAdditionalTypeString
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output GenericObjects.withAdditionalTypeArray "Output string is not correct"
 ]
 
 let main = testList "LDObject" [

--- a/tests/Json/LDObject.Tests.fs
+++ b/tests/Json/LDObject.Tests.fs
@@ -18,6 +18,10 @@ let private test_read = testList "Read" [
     testCase "onlyType" <| fun _ ->
         let f = fun _ -> LDObject.fromROCrateJsonString(GenericObjects.onlyType) |> ignore
         Expect.throws f "Should fail if ID is missing"
+    testCase "twoTypesAndID" <| fun _ ->
+        let json = LDObject.fromROCrateJsonString(GenericObjects.twoTypesAndID)
+        Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
+        Expect.sequenceEqual json.SchemaType ResizeArray["MyType"; "MySecondType"] "type was not parsed correctly"
     testCase "withStringFields" <| fun _ ->
         let json = LDObject.fromROCrateJsonString(GenericObjects.withStringFields)
         Expect.equal json.Id "MyIdentifier" "id was not parsed correctly"
@@ -104,6 +108,12 @@ let test_write = testList "write" [
         let output = LDObject.toROCrateJsonString() object
         Expect.stringEqual output GenericObjects.onlyIDAndType "Output string is not correct"
 
+    testCase "twoTypesAndID" <| fun _ ->
+        let json = GenericObjects.twoTypesAndID
+        let object = LDObject.fromROCrateJsonString(json)
+        let output = LDObject.toROCrateJsonString() object
+        Expect.stringEqual output json "Output string is not correct"
+
     testCase "withStringFields" <| fun _ ->
         let json = GenericObjects.withStringFields
         let object = LDObject.fromROCrateJsonString(json)
@@ -172,9 +182,10 @@ let test_write = testList "write" [
 
     testCase "withAddtionalTypeArray" <| fun _ ->
         let json = GenericObjects.withAdditionalTypeArray
+        let jsonOut = GenericObjects.withAdditionalTypeString
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
-        Expect.stringEqual output json "Output string is not correct"
+        Expect.stringEqual output jsonOut "Output string is not correct"
     testCase "withAddtionalTypeArrayMultipleEntries" <| fun _ ->
         let json = GenericObjects.withAddtionalTypeArrayMultipleEntries
         let object = LDObject.fromROCrateJsonString(json)
@@ -185,7 +196,7 @@ let test_write = testList "write" [
         let json = GenericObjects.withAdditionalTypeString
         let object = LDObject.fromROCrateJsonString(json)
         let output = LDObject.toROCrateJsonString() object
-        Expect.stringEqual output GenericObjects.withAdditionalTypeArray "Output string is not correct"
+        Expect.stringEqual output json "Output string is not correct"
 ]
 
 let main = testList "LDObject" [

--- a/tests/ROCrate/Common.fs
+++ b/tests/ROCrate/Common.fs
@@ -11,11 +11,28 @@ module Expect =
         Expect.equal roc.Id expectedId "object did not contain correct @id"
 
     let inline LDObjectHasType (expectedType:string) (roc:#LDObject) =
-        Expect.equal roc.SchemaType expectedType "object did not contain correct @type"
+        Expect.containsAll
+            roc.SchemaType
+            [expectedType]
+            "object did not contain correct @type"
+
+    let inline LDObjectHasTypes (expectedTypes:seq<string>) (roc:#LDObject) =
+        Expect.containsAll
+            roc.SchemaType
+            expectedTypes
+            "object did not contain correct @types"
 
     let inline LDObjectHasAdditionalType (expectedAdditionalType:string) (roc:#LDObject) =
-        Expect.isSome roc.AdditionalType "additionalType was None"
-        Expect.equal roc.AdditionalType (Some expectedAdditionalType) "object did not contain correct additionalType"
+        Expect.containsAll
+            roc.AdditionalType
+            [expectedAdditionalType]
+            "object did not contain correct additionalType"
+
+    let inline LDObjectHasAdditionalTypes (expectedAdditionalTypes:seq<string>) (roc:#LDObject) =
+        Expect.containsAll
+            roc.AdditionalType
+            expectedAdditionalTypes
+            "object did not contain correct additionalTypes"
 
     let inline LDObjectHasDynamicProperty (expectedPropertyName:string) (expectedPropertyValue:'P) (roc:#LDObject) =
         Expect.isSome (roc.TryGetDynamicPropertyHelper(expectedPropertyName)) $"object did not contain the dynamic property '{expectedPropertyName}'"
@@ -25,14 +42,14 @@ module Expect =
             $"property value of '{expectedPropertyName}' was not correct"
 
     let inline LDObjectHasStaticProperty (expectedPropertyName:string) (expectedPropertyValue:'P) (roc:#LDObject) =
-        Expect.isSome (roc.TryGetDynamicPropertyHelper(expectedPropertyName)) $"object did not contain the dynamic property '{expectedPropertyName}'"
+        Expect.isSome (roc.TryGetStaticPropertyHelper(expectedPropertyName)) $"object did not contain the static property '{expectedPropertyName}'"
         Expect.equal
             (DynObj.tryGetTypedPropertyValue<'P> expectedPropertyName roc)
             (Some expectedPropertyValue)
             $"property value of '{expectedPropertyName}' was not correct"
 
-    let inline LDObjectHasExpectedInterfaceMembers (expectedType:string) (expectedId:string) (expectedAdditionalType:string option) (roc:#LDObject) =
+    let inline LDObjectHasExpectedInterfaceMembers (expectedTypes: seq<string>) (expectedId:string) (expectedAdditionalTypes: seq<string>) (roc:#LDObject) =
         let interfacerino = roc :> ILDObject
-        Expect.equal interfacerino.SchemaType expectedType "object did not contain correct @type via interface access"
+        Expect.sequenceEqual interfacerino.SchemaType expectedTypes "object did not contain correct @types via interface access"
         Expect.equal interfacerino.Id expectedId "object did not contain correct @id via interface access"
-        Expect.equal interfacerino.AdditionalType expectedAdditionalType "object did not contain correct additionalType via interface access"
+        Expect.sequenceEqual interfacerino.AdditionalType expectedAdditionalTypes "object did not contain correct additionalTypes via interface access"

--- a/tests/ROCrate/ISAProfile/Assay.Tests.fs
+++ b/tests/ROCrate/ISAProfile/Assay.Tests.fs
@@ -48,8 +48,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Dataset" "assay_mandatory_properties_id" (Some "Assay") mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Dataset" "assay_all_properties_id" (Some "Assay") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Dataset"|] "assay_mandatory_properties_id" [|"Assay"|] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Dataset"|] "assay_all_properties_id" [|"Assay"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/Data.Tests.fs
+++ b/tests/ROCrate/ISAProfile/Data.Tests.fs
@@ -14,7 +14,7 @@ let mandatory_properties = Data(
 let all_properties = Data(
     id = "data_all_properties_id",
     name = "name",
-    additionalType = "additionalType",
+    additionalType = ResizeArray([|"additionalType"|]),
     comment = "comment",
     encodingFormat = "encodingFormat",
     disambiguatingDescription = "disambiguatingDescription"
@@ -38,8 +38,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/MediaObject" "data_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/MediaObject" "data_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/MediaObject"|] "data_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/MediaObject"|] "data_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/Dataset.Tests.fs
+++ b/tests/ROCrate/ISAProfile/Dataset.Tests.fs
@@ -7,7 +7,7 @@ open TestingUtils
 open Common
 
 let mandatory_properties = Dataset("dataset_mandatory_properties_id")
-let all_properties = Dataset("dataset_all_properties_id", additionalType = "additionalType")
+let all_properties = Dataset("dataset_all_properties_id", additionalType = ResizeArray([|"additionalType"|]))
 
 let tests_profile_object_is_valid = testList "constructed properties" [
     testList "mandatory properties" [
@@ -22,8 +22,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Dataset" "dataset_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Dataset" "dataset_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Dataset"|] "dataset_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Dataset"|] "dataset_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/Investigation.Tests.fs
+++ b/tests/ROCrate/ISAProfile/Investigation.Tests.fs
@@ -54,8 +54,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Dataset" "investigation_mandatory_properties_id" (Some "Investigation") mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Dataset" "investigation_all_properties_id" (Some "Investigation") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Dataset"|] "investigation_mandatory_properties_id" [|"Investigation"|] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Dataset"|] "investigation_all_properties_id" [|"Investigation"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/LabProcess.tests.fs
+++ b/tests/ROCrate/ISAProfile/LabProcess.tests.fs
@@ -20,7 +20,7 @@ let all_properties = LabProcess(
     agent = "agent",
     object = "object",
     result = "result",
-    additionalType = "additionalType",
+    additionalType = ResizeArray([|"additionalType"|]),
     executesLabProtocol = "executesLabProtocol",
     parameterValue = "parameterValue",
     endTime = "endTime",
@@ -53,8 +53,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "bioschemas.org/LabProcess" "labprocess_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "bioschemas.org/LabProcess" "labprocess_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"bioschemas.org/LabProcess"|] "labprocess_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"bioschemas.org/LabProcess"|] "labprocess_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/LabProtocol.Tests.fs
+++ b/tests/ROCrate/ISAProfile/LabProtocol.Tests.fs
@@ -12,7 +12,7 @@ let mandatory_properties = LabProtocol(
 
 let all_properties = LabProtocol(
     id = "labprotocol_all_properties_id",
-    additionalType = "additionalType",
+    additionalType = ResizeArray([|"additionalType"|]),
     name = "name",
     intendedUse = "intendedUse",
     description = "description",
@@ -46,8 +46,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "bioschemas.org/LabProtocol" "labprotocol_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "bioschemas.org/LabProtocol" "labprotocol_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"bioschemas.org/LabProtocol"|] "labprotocol_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"bioschemas.org/LabProtocol"|] "labprotocol_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/Person.Tests.fs
+++ b/tests/ROCrate/ISAProfile/Person.Tests.fs
@@ -14,7 +14,7 @@ let mandatory_properties = Person(
 let all_properties = Person(
     id = "person_all_properties_id",
     givenName = "givenName",
-    additionalType = "additionalType",
+    additionalType = ResizeArray([|"additionalType"|]),
     familyName = "familyName",
     email = "email",
     identifier = "identifier",
@@ -52,8 +52,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Person" "person_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Person" "person_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Person"|] "person_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Person"|] "person_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/PropertyValue.Tests.fs
+++ b/tests/ROCrate/ISAProfile/PropertyValue.Tests.fs
@@ -20,7 +20,7 @@ let all_properties = PropertyValue(
     unitCode = "unitCode",
     unitText = "unitText",
     valueReference = "valueReference",
-    additionalType = "additionalType"
+    additionalType = ResizeArray([|"additionalType"|])
 )
 
 let tests_profile_object_is_valid = testList "constructed properties" [
@@ -44,8 +44,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/PropertyValue" "propertyvalue_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/PropertyValue" "propertyvalue_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/PropertyValue"|] "propertyvalue_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/PropertyValue"|] "propertyvalue_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/Sample.tests.fs
+++ b/tests/ROCrate/ISAProfile/Sample.tests.fs
@@ -14,7 +14,7 @@ let mandatory_properties = Sample(
 let all_properties = Sample(
     id = "sample_all_properties_id",
     name = "name",
-    additionalType = "additionalType",
+    additionalType = ResizeArray([|"additionalType"|]),
     additionalProperty = "additionalProperty",
     derivesFrom = "derivesFrom"
 )
@@ -36,8 +36,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "bioschemas.org/Sample" "sample_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "bioschemas.org/Sample" "sample_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"bioschemas.org/Sample"|] "sample_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"bioschemas.org/Sample"|] "sample_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/ScholarlyArticle.Tests.fs
+++ b/tests/ROCrate/ISAProfile/ScholarlyArticle.Tests.fs
@@ -16,7 +16,7 @@ let all_properties = ScholarlyArticle(
     id = "scholarlyarticle_all_properties_id",
     headline = "headline",
     identifier = "identifier",
-    additionalType = "additionalType",
+    additionalType = ResizeArray([|"additionalType"|]),
     author = "author",
     url = "url",
     creativeWorkStatus = "creativeWorkStatus",
@@ -44,8 +44,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/ScholarlyArticle" "scholarlyarticle_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/ScholarlyArticle" "scholarlyarticle_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/ScholarlyArticle"|] "scholarlyarticle_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/ScholarlyArticle"|] "scholarlyarticle_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/ISAProfile/Study.Tests.fs
+++ b/tests/ROCrate/ISAProfile/Study.Tests.fs
@@ -54,8 +54,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Dataset" "study_mandatory_properties_id" (Some "Study") mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "schema.org/Dataset" "study_all_properties_id" (Some "Study") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Dataset"|] "study_mandatory_properties_id" [|"Study"|] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"schema.org/Dataset"|] "study_all_properties_id" [|"Study"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/ROCrate/LDObject.Tests.fs
+++ b/tests/ROCrate/LDObject.Tests.fs
@@ -6,8 +6,19 @@ open DynamicObj
 open TestingUtils
 open Common
 
+let context =
+    new LDContext()
+    |> DynObj.withProperty "more" "context"
+
 let mandatory_properties = LDObject("LDObject_mandatory_properties_id", "someType")
+let mandatory_properties_with_context =
+    LDObject("LDObject_mandatory_properties_id", "someType")
+    |> DynObj.withProperty "@context" context
+
 let all_properties = LDObject("LDObject_all_properties_id", "someType", additionalType = "additionalType")
+let all_properties_with_context =
+    LDObject("LDObject_all_properties_id", "someType", additionalType = "additionalType")
+    |> DynObj.withProperty "@context" (context.CopyDynamicProperties())
 
 let tests_profile_object_is_valid = testList "constructed properties" [
     testList "mandatory properties" [
@@ -58,19 +69,50 @@ let tests_instance_methods = testSequenced (
 
 let tests_static_methods = testSequenced (
     testList "static methods" [
+        testList "context" [
+            let context = new LDContext()
+            context.SetProperty("more", "context")
 
-        let context = new LDContext()
-        context.SetProperty("more", "context")
+            testCase "can set context" <| fun _ ->
+                LDObject.setContext context mandatory_properties
+                Expect.LDObjectHasDynamicProperty "@context" context mandatory_properties
+            testCase "can get context" <| fun _ ->
+                let ctx = LDObject.tryGetContext() mandatory_properties
+                Expect.equal ctx (Some context) "context was not set correctly"
+            testCase "can remove context" <| fun _ ->
+                LDObject.removeContext() mandatory_properties |> ignore
+                Expect.isNone (DynObj.tryGetTypedPropertyValue<DynamicObj> "@context" mandatory_properties) "context was not removed correctly"
+        ]
+        testList "tryFromDynamicObj" [
+            let compatibleDynObj =
+                let tmp = DynamicObj()
+                tmp
+                |> DynObj.withProperty "@type" "someType"
+                |> DynObj.withProperty "@id" "LDObject_all_properties_id"
+                |> DynObj.withProperty "additionalType" "additionalType"
 
-        testCase "can set context" <| fun _ ->
-            LDObject.setContext context mandatory_properties
-            Expect.LDObjectHasDynamicProperty "@context" context mandatory_properties
-        testCase "can get context" <| fun _ ->
-            let ctx = LDObject.tryGetContext() mandatory_properties
-            Expect.equal ctx (Some context) "context was not set correctly"
-        testCase "can remove context" <| fun _ ->
-            LDObject.removeContext() mandatory_properties |> ignore
-            Expect.isNone (DynObj.tryGetTypedPropertyValue<DynamicObj> "@context" mandatory_properties) "context was not removed correctly"
+            let compatibleDynObjWithContext =
+                let tmp = DynamicObj()
+                tmp
+                |> DynObj.withProperty "@type" "someType"
+                |> DynObj.withProperty "@id" "LDObject_all_properties_id"
+                |> DynObj.withProperty "additionalType" "additionalType"
+                |> DynObj.withProperty "@context" context
+
+            let incompatibleDynObj =
+                let tmp = DynamicObj()
+                tmp
+                |> DynObj.withProperty "@type" "someType"
+
+            testCase "can convert compatible DynObj to LDObject" <| fun _ ->
+                let roc = Expect.wantSome (LDObject.tryFromDynamicObj compatibleDynObj) "LDObject.tryFromDynamicObj did not return Some"
+                Expect.equal roc all_properties "LDObject was not created correctly from compatible DynamicObj"
+            testCase "can convert compatible DynObj with context to LDObject" <| fun _ ->
+                let roc = Expect.wantSome (LDObject.tryFromDynamicObj compatibleDynObjWithContext) "LDObject.tryFromDynamicObj did not return Some"
+                Expect.equal roc all_properties_with_context "LDObject was not created correctly from compatible DynamicObj"
+            testCase "cannot convert incompatible DynObj to LDObject" <| fun _ ->
+                Expect.isNone (LDObject.tryFromDynamicObj incompatibleDynObj) "LDObject.tryFromDynamicObj did not return None"
+        ]
     ]
 )
 

--- a/tests/ROCrate/LDObject.Tests.fs
+++ b/tests/ROCrate/LDObject.Tests.fs
@@ -18,7 +18,7 @@ let mandatory_properties_with_context =
 let all_properties = LDObject("LDObject_all_properties_id", ResizeArray[|"someType"|], additionalType = ResizeArray[|"additionalType"|])
 let all_properties_with_context =
     LDObject("LDObject_all_properties_id", ResizeArray[|"someType"|], additionalType = ResizeArray[|"additionalType"|])
-    |> DynObj.withProperty "@context" (context.CopyDynamicProperties())
+    |> DynObj.withProperty "@context" (context.DeepCopyProperties())
 
 let tests_profile_object_is_valid = testList "constructed properties" [
     testList "mandatory properties" [

--- a/tests/ROCrate/LDObject.Tests.fs
+++ b/tests/ROCrate/LDObject.Tests.fs
@@ -10,14 +10,14 @@ let context =
     new LDContext()
     |> DynObj.withProperty "more" "context"
 
-let mandatory_properties = LDObject("LDObject_mandatory_properties_id", "someType")
+let mandatory_properties = LDObject("LDObject_mandatory_properties_id", ResizeArray[|"someType"|])
 let mandatory_properties_with_context =
-    LDObject("LDObject_mandatory_properties_id", "someType")
+    LDObject("LDObject_mandatory_properties_id", ResizeArray[|"someType"|])
     |> DynObj.withProperty "@context" context
 
-let all_properties = LDObject("LDObject_all_properties_id", "someType", additionalType = "additionalType")
+let all_properties = LDObject("LDObject_all_properties_id", ResizeArray[|"someType"|], additionalType = ResizeArray[|"additionalType"|])
 let all_properties_with_context =
-    LDObject("LDObject_all_properties_id", "someType", additionalType = "additionalType")
+    LDObject("LDObject_all_properties_id", ResizeArray[|"someType"|], additionalType = ResizeArray[|"additionalType"|])
     |> DynObj.withProperty "@context" (context.CopyDynamicProperties())
 
 let tests_profile_object_is_valid = testList "constructed properties" [
@@ -33,8 +33,8 @@ let tests_profile_object_is_valid = testList "constructed properties" [
 ]
 
 let tests_interface_members = testList "interface members" [
-    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "someType" "LDObject_mandatory_properties_id" None mandatory_properties
-    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers "someType" "LDObject_all_properties_id" (Some "additionalType") all_properties
+    testCase "mandatoryProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"someType"|] "LDObject_mandatory_properties_id" [||] mandatory_properties
+    testCase "allProperties" <| fun _ -> Expect.LDObjectHasExpectedInterfaceMembers [|"someType"|] "LDObject_all_properties_id" [|"additionalType"|] all_properties
 ]
 
 let tests_dynamic_members = testSequenced (

--- a/tests/TestingUtils/TestObjects.Json/ROCrate.fs
+++ b/tests/TestingUtils/TestObjects.Json/ROCrate.fs
@@ -206,7 +206,7 @@ module GenericObjects =
     let onlyIDAndType =
         """{
             "@id": "MyIdentifier",
-            "@type": ["MyType"]
+            "@type": "MyType"
         }"""
         
     let onlyIDAndTypeNoTypeArray =
@@ -222,9 +222,15 @@ module GenericObjects =
 
     let onlyType =
         """{
-            "@type": ["MyType"]
+            "@type": "MyType"
         }"""
-        
+
+    let twoTypesAndID =
+        """{
+            "@id": "MyIdentifier",
+            "@type": ["MyType" , "MySecondType"]
+        }"""
+
     let onlyTypeNoTypeArray =
         """{
             "@type": "MyType"
@@ -233,7 +239,7 @@ module GenericObjects =
     let withStringFields =
         """{
             "@id": "MyIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "name": "MyName",
             "description": "MyDescription"
         }"""
@@ -249,7 +255,7 @@ module GenericObjects =
     let withIntFields =
         """{
             "@id": "MyIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "number": 42,
             "anotherNumber": 1337
         }"""
@@ -265,7 +271,7 @@ module GenericObjects =
     let withStringArray =
         """{
             "@id": "MyIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "names": ["MyName", "MySecondName"]           
         }"""
 
@@ -279,7 +285,7 @@ module GenericObjects =
     let withNestedObject =
         sprintf """{
             "@id": "OuterIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "nested": %s
         }""" onlyIDAndType
 
@@ -293,7 +299,7 @@ module GenericObjects =
     let withObjectArray =
         sprintf """{
             "@id": "OuterIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "nested": [%s, %s]
         }""" onlyIDAndType onlyIDAndType
 
@@ -307,7 +313,7 @@ module GenericObjects =
     let withMixedArray =
         sprintf """{
             "@id": "OuterIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "nested": [%s, "Value2", 42]
         }""" onlyIDAndType
 
@@ -321,19 +327,19 @@ module GenericObjects =
     let withAdditionalTypeString =
         """{
             "@id": "MyIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "additionalType": "additionalType"
         }"""
 
     let withAdditionalTypeArray =
         """{
             "@id": "MyIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "additionalType": ["additionalType"]
         }"""
     let withAddtionalTypeArrayMultipleEntries =
         """{
             "@id": "MyIdentifier",
-            "@type": ["MyType"],
+            "@type": "MyType",
             "additionalType": ["additionalType1", "additionalType2"]
         }"""

--- a/tests/TestingUtils/TestObjects.Json/ROCrate.fs
+++ b/tests/TestingUtils/TestObjects.Json/ROCrate.fs
@@ -206,6 +206,12 @@ module GenericObjects =
     let onlyIDAndType =
         """{
             "@id": "MyIdentifier",
+            "@type": ["MyType"]
+        }"""
+        
+    let onlyIDAndTypeNoTypeArray =
+        """{
+            "@id": "MyIdentifier",
             "@type": "MyType"
         }"""
 
@@ -216,10 +222,23 @@ module GenericObjects =
 
     let onlyType =
         """{
+            "@type": ["MyType"]
+        }"""
+        
+    let onlyTypeNoTypeArray =
+        """{
             "@type": "MyType"
         }"""
 
     let withStringFields =
+        """{
+            "@id": "MyIdentifier",
+            "@type": ["MyType"],
+            "name": "MyName",
+            "description": "MyDescription"
+        }"""
+
+    let withStringFieldsNoTypeArray =
         """{
             "@id": "MyIdentifier",
             "@type": "MyType",
@@ -230,12 +249,27 @@ module GenericObjects =
     let withIntFields =
         """{
             "@id": "MyIdentifier",
+            "@type": ["MyType"],
+            "number": 42,
+            "anotherNumber": 1337
+        }"""
+        
+    let withIntFieldsNoTypeArray =
+        """{
+            "@id": "MyIdentifier",
             "@type": "MyType",
             "number": 42,
             "anotherNumber": 1337
         }"""
 
     let withStringArray =
+        """{
+            "@id": "MyIdentifier",
+            "@type": ["MyType"],
+            "names": ["MyName", "MySecondName"]           
+        }"""
+
+    let withStringArrayNoTypeArray =
         """{
             "@id": "MyIdentifier",
             "@type": "MyType",
@@ -245,20 +279,61 @@ module GenericObjects =
     let withNestedObject =
         sprintf """{
             "@id": "OuterIdentifier",
-            "@type": "MyType",
+            "@type": ["MyType"],
             "nested": %s
         }""" onlyIDAndType
+
+    let withNestedObjectNoTypeArray =
+        sprintf """{
+            "@id": "OuterIdentifier",
+            "@type": "MyType",
+            "nested": %s
+        }""" onlyIDAndTypeNoTypeArray
 
     let withObjectArray =
         sprintf """{
             "@id": "OuterIdentifier",
-            "@type": "MyType",
+            "@type": ["MyType"],
             "nested": [%s, %s]
         }""" onlyIDAndType onlyIDAndType
+
+    let withObjectArrayNoTypeArray =
+        sprintf """{
+            "@id": "OuterIdentifier",
+            "@type": "MyType",
+            "nested": [%s, %s]
+        }""" onlyIDAndTypeNoTypeArray onlyIDAndTypeNoTypeArray
 
     let withMixedArray =
         sprintf """{
             "@id": "OuterIdentifier",
-            "@type": "MyType",
+            "@type": ["MyType"],
             "nested": [%s, "Value2", 42]
         }""" onlyIDAndType
+
+    let withMixedArrayNoTypeArray =
+        sprintf """{
+            "@id": "OuterIdentifier",
+            "@type": "MyType",
+            "nested": [%s, "Value2", 42]
+        }""" onlyIDAndTypeNoTypeArray
+
+    let withAdditionalTypeString =
+        """{
+            "@id": "MyIdentifier",
+            "@type": ["MyType"],
+            "additionalType": "additionalType"
+        }"""
+
+    let withAdditionalTypeArray =
+        """{
+            "@id": "MyIdentifier",
+            "@type": ["MyType"],
+            "additionalType": ["additionalType"]
+        }"""
+    let withAddtionalTypeArrayMultipleEntries =
+        """{
+            "@id": "MyIdentifier",
+            "@type": ["MyType"],
+            "additionalType": ["additionalType1", "additionalType2"]
+        }"""


### PR DESCRIPTION
This PR (eventually)
- slightly remodels `LDObject` to use arrays for `@type` and `additionalType`. Json encode/decode was adapted to be able to parse string OR array fields, but ALWAYS write array fields (even for singletons)
- Adds many API functions to get typed properties from ISA LDObjects (e.g., get all `Person`s as a `Person []` from the given `Investigation` LDObject)