### PR TITLE
[RO Crate] Give LabProcesses more unique random IDs

### DIFF
--- a/src/ARCtrl/Conversion.fs
+++ b/src/ARCtrl/Conversion.fs
@@ -6,6 +6,30 @@ open ARCtrl.Helper
 open System.Collections.Generic
 //open ColumnIndex
 
+module HashHelper =
+
+    let rnd = System.Random()
+
+    let byteToHexString (b : byte) =
+        System.String.Format("{0:X}", b)
+
+    let intToBytes (i : int) =
+        System.BitConverter.GetBytes(i)
+
+    let bytesToHexString (bytes : byte[]) =
+        bytes
+        |> Array.map byteToHexString
+        |> String.concat ""
+
+    let get32bitHash () =
+        let bytes = intToBytes (rnd.Next())
+        bytesToHexString bytes
+
+    let get64bitHash () =
+        let bytes = intToBytes (rnd.Next())
+        let bytes2 = intToBytes (rnd.Next())
+        System.String.Concat(bytesToHexString bytes, bytesToHexString bytes2)
+
 module DateTime =
 
     let tryFromString (s : string) =
@@ -613,6 +637,8 @@ type ProcessConversion =
 
             let components = componentGetters |> List.map (fun f -> f matrix i) |> Option.fromValueWithDefault [] |> Option.map ResizeArray
 
+            let id = $"#Process_{processNameRoot}_{HashHelper.get64bitHash()}"
+            
             let protocol : LDNode option =
                 let name = (protocolREFGetter |> Option.map (fun f -> f matrix i))
                 let protocolId = LDLabProtocol.genId(?name = name, processName = processNameRoot)
@@ -636,6 +662,7 @@ type ProcessConversion =
                 name = pn,
                 objects = input,
                 results = output,
+                id = id,
                 ?agent = agent,
                 ?executesLabProtocol = protocol,
                 ?parameterValues = paramvalues,

--- a/tests/ARCtrl/ROCrateConversion.Tests.fs
+++ b/tests/ARCtrl/ROCrateConversion.Tests.fs
@@ -1622,7 +1622,7 @@ let tests_Investigation =
         // This test is meant to check, that two processes created from two different tables with the same name are distinctly named
         // This is important to ensure they are not merged
         // https://github.com/nfdi4plants/ARCtrl/issues/514
-        ftestCase "DistinctProcessNaming" (fun () ->
+        testCase "DistinctProcessIDGeneration" (fun () ->
             // Setup
             let arc = ArcInvestigation("MyArc", title = "MyTitle")
             let study1 = arc.InitStudy "Study1"

--- a/tests/ARCtrl/ROCrateConversion.Tests.fs
+++ b/tests/ARCtrl/ROCrateConversion.Tests.fs
@@ -1629,16 +1629,21 @@ let tests_Investigation =
             let study2 = arc.InitStudy "Study2"
             let table1 = study1.InitTable("Growth")
             let table2 = study2.InitTable("Growth")
-            table1.AddColumn(CompositeHeader.Input(IOType.Source),[|CompositeCell.createFreeText "Source"|])
+            table1.AddColumn(CompositeHeader.Input(IOType.Source),[|CompositeCell.createFreeText "Source1"; CompositeCell.createFreeText "Source2"|])
             table2.AddColumn(CompositeHeader.Input(IOType.Sample),[|CompositeCell.createFreeText "Sample"|])
             // Check Json LD
             let ro_Investigation = InvestigationConversion.composeInvestigation arc
             let subDatasets = ro_Investigation |> LDDataset.getHasPartsAsDataset
             let s1 = Expect.wantSome (subDatasets |> Seq.tryFind (fun s -> s.Id = "studies/Study1/")) "Study1 should exist"
             let s2 = Expect.wantSome (subDatasets |> Seq.tryFind (fun s -> s.Id = "studies/Study2/")) "Study2 should exist"
-            let p1 = Expect.wantSome (s1 |> LDDataset.getAboutsAsLabProcess |> Seq.tryExactlyOne) "Study1 should have a process"
+            let s1ps = s1 |> LDDataset.getAboutsAsLabProcess
+            Expect.hasLength s1ps 2 "Study1 should have two processes"
+            let s1p1 = s1ps.[0]
+            let s1p2 = s1ps.[1]
             let p2 = Expect.wantSome (s2 |> LDDataset.getAboutsAsLabProcess |> Seq.tryExactlyOne) "Study2 should have a process"
-            Expect.notEqual p1.Id p2.Id "Processes should have different Ids"
+            Expect.notEqual s1p1.Id s1p2.Id "Processes should have different Ids (1)"
+            Expect.notEqual s1p1.Id p2.Id "Processes should have different Ids (2)"
+            Expect.notEqual s1p2.Id p2.Id "Processes should have different Ids (3)"
             // Check reparsed scaffold
             let arc' = InvestigationConversion.decomposeInvestigation(ro_Investigation)
             let study1' = Expect.wantSome (arc'.TryGetStudy("Study1")) "Study1 should exist"


### PR DESCRIPTION
This PR tackles the issue of Annotation Tables with the same name in different Studies/Assays being given the same `@id` in RO-Crate.

For this, I generate a random 64bit hash for each process.

e.g.
```json
    {
      "@id": "#Process_Growth_97215676FC8B3F3D",
      "@type": "LabProcess",
      "name": "Growth",
      "object": {
        "@id": "#Sample_Sample"
      },
      "result": [],
      "executesLabProtocol": {
        "@id": "#Protocol_Growth"
      }
    },
```

closes #514 