### PR TITLE
Check for Investigation identifier presence

### DIFF
--- a/tests/Spreadsheet/InvestigationFileTests.fs
+++ b/tests/Spreadsheet/InvestigationFileTests.fs
@@ -10,25 +10,30 @@ open TestObjects.Spreadsheet
 
 let private testInvestigationWriterComponents = 
     // Test the single components of invesigation file writing
-    testList "InvestigationWriterPartTests" [       
+    testList "InvestigationWriterPartTests" [
+
         testCase "CreateEmptyWorkbook" (fun () ->
             let wb = new FsWorkbook()
             Expect.isTrue true "Workbook could not be initialized"
         )
+
         testCase "CreateSheet" (fun () ->
             let sheet = FsWorksheet("Investigation")
             Expect.equal sheet.Name "Investigation" "Worksheet could not be initialized"
         )
+
         testCase "InvestigationToRows" (fun () ->
             let i = ArcInvestigation.init("My Investigation")
             let rows = i |> ArcInvestigation.toRows
             Expect.isTrue (rows |> Seq.length |> (<) 0) "Investigation should have at least one row"
         )
+
         testCase "AddEmptyWorksheet" (fun () ->
             let wb = new FsWorkbook()
             let sheet = FsWorksheet("Investigation")
             wb.AddWorksheet(sheet)                                    
         )
+
         testCase "FillWorksheet" (fun () ->
             let i = ArcInvestigation.init("My Identifier")
             let sheet = FsWorksheet("Investigation")
@@ -37,6 +42,7 @@ let private testInvestigationWriterComponents =
             |> Seq.iteri (fun rowI r -> SparseRow.writeToSheet (rowI + 1) r sheet) 
             Expect.isTrue (sheet.Rows |> Seq.length |> (<) 0) "Worksheet should have at least one row"
         )
+
         testCase "AddFilledWorksheet" (fun () ->
             let i = ArcInvestigation.init("My Identifier")
             let wb = new FsWorkbook()
@@ -47,6 +53,7 @@ let private testInvestigationWriterComponents =
             wb.AddWorksheet(sheet)
             Expect.isSome (wb.TryGetWorksheetByName "Investigation") "Worksheet should be added to workbook"
         )
+
         testCase "OnlyConsiderRegisteredStudies" (fun () ->
             let isa = ArcInvestigation("MyInvestigation")
             let registeredStudyIdentifier = "RegisteredStudy"
@@ -92,8 +99,8 @@ let private testInvestigationFile =
                 | err -> Result.Error(sprintf "Reading the test file failed: %s" err.Message)
 
             Expect.isOk readingSuccess (Result.getMessage readingSuccess)
-
         )
+
         testCase "ReaderSuccessDeprecatedSheetName" (fun () -> 
             
             let readingSuccess = 
@@ -104,8 +111,8 @@ let private testInvestigationFile =
                 | err -> Result.Error(sprintf "Reading the test file failed: %s" err.Message)
 
             Expect.isOk readingSuccess (Result.getMessage readingSuccess)
-
         )
+
         testCase "ReaderFailureWrongSheetName" (fun () -> 
             
             let readingSuccess = 
@@ -117,6 +124,30 @@ let private testInvestigationFile =
 
             Expect.isError readingSuccess "Reading the investigation file should fail if the sheet name is wrong"
         )
+
+        testCase "ReaderSuccess1MadeUpKeyAtTop" (fun () ->
+
+            let readingSuccess = 
+                try 
+                    ArcInvestigation.fromFsWorkbook Investigation.BII_I_1.fullInvestigation1MadeUpKey |> ignore
+                    Result.Ok "DidRun"
+                with
+                | err -> Result.Error(sprintf "Reading the test file failed: %s" err.Message)
+
+            Expect.isOk readingSuccess (Result.getMessage readingSuccess)
+        )
+
+        testCase "1MadeUpKeyAtTopInvestigationIdentifierPresent" (fun () ->
+
+            let arcInv = 
+                try 
+                    ArcInvestigation.fromFsWorkbook Investigation.BII_I_1.fullInvestigation1MadeUpKey
+                with
+                | _ -> ArcInvestigation.create ""
+
+            Expect.equal arcInv.Identifier "investigation1MadeUpKey" "Did not retrieve the correct Investigation identifier"
+        )
+
         testCase "WriterSuccess" (fun () ->
 
             let i = ArcInvestigation.fromFsWorkbook Investigation.BII_I_1.fullInvestigation
@@ -152,30 +183,28 @@ let private testInvestigationFile =
             Expect.isEmpty i.Studies "Empty study in investigation should be read to empty ResizeArray"
         )
 
-        testCase "ReaderSuccessEmpty" (fun () -> 
-            
+        testCase "ReaderFailureEmpty" (fun () -> 
             let readingSuccess = 
                 try 
                     ArcInvestigation.fromFsWorkbook Investigation.emptyInvestigation |> ignore
                     Result.Ok "DidRun"
                 with
                 | err -> Result.Error(sprintf "Reading the empty test file failed: %s" err.Message)
-            Expect.isOk readingSuccess (Result.getMessage readingSuccess)
+            Expect.isError readingSuccess (Result.getMessage readingSuccess)
         )
 
-        testCase "WriterSuccessEmpty" (fun () ->
-
-            let i = ArcInvestigation.fromFsWorkbook Investigation.emptyInvestigation
-
+        testCase "WriterFailureEmpty" (fun () ->
             let writingSuccess = 
                 try 
+                    let i = ArcInvestigation.fromFsWorkbook Investigation.emptyInvestigation
                     ArcInvestigation.toFsWorkbook i |> ignore
                     Result.Ok "DidRun"
                 with
                 | err -> Result.Error(sprintf "Writing the empty test file failed: %s" err.Message)
 
-            Expect.isOk writingSuccess (Result.getMessage writingSuccess)
+            Expect.isError writingSuccess (Result.getMessage writingSuccess)
         )
+
         testCase "WriteWithStudyOnlyRegistered" (fun () ->
 
             let studyIdentifiers = ResizeArray ["MyStudy"]
@@ -185,6 +214,7 @@ let private testInvestigationFile =
                 |> ArcInvestigation.fromFsWorkbook
             Expect.sequenceEqual i.RegisteredStudyIdentifiers studyIdentifiers "Registered study Identifier were not written and read correctly"
         )
+
         testCase "TestMetadataCollection" (fun () ->
 
             let investigation =

--- a/tests/TestingUtils/TestObjects.Spreadsheet/Spreadsheet.InvestigationFile.fs
+++ b/tests/TestingUtils/TestObjects.Spreadsheet/Spreadsheet.InvestigationFile.fs
@@ -718,3 +718,193 @@ module BII_I_1 =
         let wb = new FsWorkbook()
         wb.AddWorksheet cp
         wb
+
+    let fullInvestigation1MadeUpKey =
+        let wb = new FsWorkbook()
+        let ws = wb.InitWorksheet("isa_investigation")
+        let row1 = ws.Row(1)
+        row1.[1].Value <- "(lol)"
+        let row2 = ws.Row(2)
+        row2.[1].Value <- "ONTOLOGY SOURCE REFERENCE"
+        let row3 = ws.Row(3)
+        row3.[1].Value <- "Term Source Name"
+        let row4 = ws.Row(4)
+        row4.[1].Value <- "Term Source File"
+        let row5 = ws.Row(5)
+        row5.[1].Value <- "Term Source Version"
+        let row6 = ws.Row(6)
+        row6.[1].Value <- "Term Source Description"
+        let row7 = ws.Row(7)
+        row7.[1].Value <- "INVESTIGATION"
+        let row8 = ws.Row(8)
+        row8.[1].Value <- "Investigation Identifier"
+        row8.[2].Value <- "investigation1MadeUpKey"
+        let row9 = ws.Row(9)
+        row9.[1].Value <- "Investigation Title"
+        let row10 = ws.Row(10)
+        row10.[1].Value <- "Investigation Description"
+        let row11 = ws.Row(11)
+        row11.[1].Value <- "Investigation Submission Date"
+        let row12 = ws.Row(12)
+        row12.[1].Value <- "Investigation Public Release Date"
+        let row13 = ws.Row(13)
+        row13.[1].Value <- "INVESTIGATION PUBLICATIONS"
+        let row14 = ws.Row(14)
+        row14.[1].Value <- "Investigation Publication PubMed ID"
+        let row15 = ws.Row(15)
+        row15.[1].Value <- "Investigation Publication DOI"
+        let row16 = ws.Row(16)
+        row16.[1].Value <- "Investigation Publication Author List"
+        let row17 = ws.Row(17)
+        row17.[1].Value <- "Investigation Publication Title"
+        let row18 = ws.Row(18)
+        row18.[1].Value <- "Investigation Publication Status"
+        let row19 = ws.Row(19)
+        row19.[1].Value <- "Investigation Publication Status Term Accession Number"
+        let row20 = ws.Row(20)
+        row20.[1].Value <- "Investigation Publication Status Term Source REF"
+        let row21 = ws.Row(21)
+        row21.[1].Value <- "INVESTIGATION CONTACTS"
+        let row22 = ws.Row(22)
+        row22.[1].Value <- "Investigation Person Last Name"
+        let row23 = ws.Row(23)
+        row23.[1].Value <- "Investigation Person First Name"
+        let row24 = ws.Row(24)
+        row24.[1].Value <- "Investigation Person Mid Initials"
+        let row25 = ws.Row(25)
+        row25.[1].Value <- "Investigation Person Email"
+        let row26 = ws.Row(26)
+        row26.[1].Value <- "Investigation Person Phone"
+        let row27 = ws.Row(27)
+        row27.[1].Value <- "Investigation Person Fax"
+        let row28 = ws.Row(28)
+        row28.[1].Value <- "Investigation Person Address"
+        let row29 = ws.Row(29)
+        row29.[1].Value <- "Investigation Person Affiliation"
+        let row30 = ws.Row(30)
+        row30.[1].Value <- "Investigation Person Roles"
+        let row31 = ws.Row(31)
+        row31.[1].Value <- "Investigation Person Roles Term Accession Number"
+        let row32 = ws.Row(32)
+        row32.[1].Value <- "Investigation Person Roles Term Source REF"
+        let row33 = ws.Row(33)
+        row33.[1].Value <- "STUDY"
+        let row34 = ws.Row(34)
+        row34.[1].Value <- "Study Identifier"
+        let row35 = ws.Row(35)
+        row35.[1].Value <- "Study Title"
+        let row36 = ws.Row(36)
+        row36.[1].Value <- "Study Description"
+        let row37 = ws.Row(37)
+        row37.[1].Value <- "Study Submission Date"
+        let row38 = ws.Row(38)
+        row38.[1].Value <- "Study Public Release Date"
+        let row39 = ws.Row(39)
+        row39.[1].Value <- "Study File Name"
+        let row40 = ws.Row(40)
+        row40.[1].Value <- "STUDY DESIGN DESCRIPTORS"
+        let row41 = ws.Row(41)
+        row41.[1].Value <- "Study Design Type"
+        let row42 = ws.Row(42)
+        row42.[1].Value <- "Study Design Type Term Accession Number"
+        let row43 = ws.Row(43)
+        row43.[1].Value <- "Study Design Type Term Source REF"
+        let row44 = ws.Row(44)
+        row44.[1].Value <- "STUDY PUBLICATIONS"
+        let row45 = ws.Row(45)
+        row45.[1].Value <- "Study Publication PubMed ID"
+        let row46 = ws.Row(46)
+        row46.[1].Value <- "Study Publication DOI"
+        let row47 = ws.Row(47)
+        row47.[1].Value <- "Study Publication Author List"
+        let row48 = ws.Row(48)
+        row48.[1].Value <- "Study Publication Title"
+        let row49 = ws.Row(49)
+        row49.[1].Value <- "Study Publication Status"
+        let row50 = ws.Row(50)
+        row50.[1].Value <- "Study Publication Status Term Accession Number"
+        let row51 = ws.Row(51)
+        row51.[1].Value <- "Study Publication Status Term Source REF"
+        let row52 = ws.Row(52)
+        row52.[1].Value <- "STUDY FACTORS"
+        let row53 = ws.Row(53)
+        row53.[1].Value <- "Study Factor Name"
+        let row54 = ws.Row(54)
+        row54.[1].Value <- "Study Factor Type"
+        let row55 = ws.Row(55)
+        row55.[1].Value <- "Study Factor Type Term Accession Number"
+        let row56 = ws.Row(56)
+        row56.[1].Value <- "Study Factor Type Term Source REF"
+        let row57 = ws.Row(57)
+        row57.[1].Value <- "STUDY ASSAYS"
+        let row58 = ws.Row(58)
+        row58.[1].Value <- "Study Assay Measurement Type"
+        let row59 = ws.Row(59)
+        row59.[1].Value <- "Study Assay Measurement Type Term Accession Number"
+        let row60 = ws.Row(60)
+        row60.[1].Value <- "Study Assay Measurement Type Term Source REF"
+        let row61 = ws.Row(61)
+        row61.[1].Value <- "Study Assay Technology Type"
+        let row62 = ws.Row(62)
+        row62.[1].Value <- "Study Assay Technology Type Term Accession Number"
+        let row63 = ws.Row(63)
+        row63.[1].Value <- "Study Assay Technology Type Term Source REF"
+        let row64 = ws.Row(64)
+        row64.[1].Value <- "Study Assay Technology Platform"
+        let row65 = ws.Row(65)
+        row65.[1].Value <- "Study Assay File Name"
+        let row66 = ws.Row(66)
+        row66.[1].Value <- "STUDY PROTOCOLS"
+        let row67 = ws.Row(67)
+        row67.[1].Value <- "Study Protocol Name"
+        let row68 = ws.Row(68)
+        row68.[1].Value <- "Study Protocol Type"
+        let row69 = ws.Row(69)
+        row69.[1].Value <- "Study Protocol Type Term Accession Number"
+        let row70 = ws.Row(70)
+        row70.[1].Value <- "Study Protocol Type Term Source REF"
+        let row71 = ws.Row(71)
+        row71.[1].Value <- "Study Protocol Description"
+        let row72 = ws.Row(72)
+        row72.[1].Value <- "Study Protocol URI"
+        let row73 = ws.Row(73)
+        row73.[1].Value <- "Study Protocol Version"
+        let row74 = ws.Row(74)
+        row74.[1].Value <- "Study Protocol Parameters Name"
+        let row75 = ws.Row(75)
+        row75.[1].Value <- "Study Protocol Parameters Term Accession Number"
+        let row76 = ws.Row(76)
+        row76.[1].Value <- "Study Protocol Parameters Term Source REF"
+        let row77 = ws.Row(77)
+        row77.[1].Value <- "Study Protocol Components Name"
+        let row78 = ws.Row(78)
+        row78.[1].Value <- "Study Protocol Components Type"
+        let row79 = ws.Row(79)
+        row79.[1].Value <- "Study Protocol Components Type Term Accession Number"
+        let row80 = ws.Row(80)
+        row80.[1].Value <- "Study Protocol Components Type Term Source REF"
+        let row81 = ws.Row(81)
+        row81.[1].Value <- "STUDY CONTACTS"
+        let row82 = ws.Row(82)
+        row82.[1].Value <- "Study Person Last Name"
+        let row83 = ws.Row(83)
+        row83.[1].Value <- "Study Person First Name"
+        let row84 = ws.Row(84)
+        row84.[1].Value <- "Study Person Mid Initials"
+        let row85 = ws.Row(85)
+        row85.[1].Value <- "Study Person Email"
+        let row86 = ws.Row(86)
+        row86.[1].Value <- "Study Person Phone"
+        let row87 = ws.Row(87)
+        row87.[1].Value <- "Study Person Fax"
+        let row88 = ws.Row(88)
+        row88.[1].Value <- "Study Person Address"
+        let row89 = ws.Row(89)
+        row89.[1].Value <- "Study Person Affiliation"
+        let row90 = ws.Row(90)
+        row90.[1].Value <- "Study Person Roles"
+        let row91 = ws.Row(91)
+        row91.[1].Value <- "Study Person Roles Term Accession Number"
+        let row92 = ws.Row(92)
+        row92.[1].Value <- "Study Person Roles Term Source REF"
+        wb


### PR DESCRIPTION
This PR
- changes the `fromRows` function in `ARCtrl.Spreadsheet.ArcInvestigation` module in such a way that it now checks for the presence of the Investigation identifier and fails if it is empty
  - adds the respective unit test
  - comments out unit tests `ReaderSuccessEmpty` and `WriterSuccessEmpty` since they don't make sense anymore
- fixes #519 
- has **NO** playground files added to the solution (thank God!) @HLWeil 