### PR TITLE
Small fix and addition to RO-Crate parsing

### DIFF
--- a/src/ARCtrl/ARC.fs
+++ b/src/ARCtrl/ARC.fs
@@ -872,8 +872,9 @@ type ARC(identifier : string, ?title : string, ?description : string, ?submissio
 
     static member fromROCrateJsonString (s:string) =
         try 
-            let isa = ARCtrl.Json.Decode.fromJsonString ARCtrl.Json.ARC.ROCrate.decoder s
-            ARC.fromArcInvestigation(isa = isa)
+            let isa, files = ARCtrl.Json.Decode.fromJsonString ARCtrl.Json.ARC.ROCrate.decoder s
+            let fileSystem = Array.ofSeq files |> FileSystem.fromFilePaths
+            ARC.fromArcInvestigation(isa = isa, fs = fileSystem)
         with
         | ex -> 
             failwithf "Could not parse ARC-RO-Crate metadata: \n%s" ex.Message

--- a/src/Core/Data.fs
+++ b/src/Core/Data.fs
@@ -90,13 +90,19 @@ type Data(?id,?name : string,?dataType,?format,?selectorFormat,?comments) =
         |> Option.defaultValue ""
 
     member this.GetAbsolutePathBy(f : string -> string, ?checkExistenceFromRoot : string -> bool) =
+        let trimStart (subString : string) (s : string) =
+            if s.StartsWith(subString) then
+                s.Substring(subString.Length)
+            else
+                s    
         let checkExistenceFromRoot = Option.defaultValue (fun _ -> false) checkExistenceFromRoot
         let isPartOfSubFolder (p : string) =
             p.StartsWith("assays/") || p.StartsWith("studies/") || p.StartsWith("workflows/") || p.StartsWith("runs/")
         let isOnlineRessource (p : string) =
             p.StartsWith("http:") || p.StartsWith("https:")
         match this.FilePath with
-        | Some p -> 
+        | Some p ->
+            let p = p.TrimStart('/') |> trimStart "./"
             if checkExistenceFromRoot p || isPartOfSubFolder p || isOnlineRessource p then
                 p
             else

--- a/tests/Core/Data.Tests.fs
+++ b/tests/Core/Data.Tests.fs
@@ -1,4 +1,4 @@
-﻿module Data.Tests
+module Data.Tests
 
 open ARCtrl
 
@@ -21,8 +21,68 @@ let private tests_GetHashCode = testList "GetHashCode" [
         Expect.notEqual hash1 hash2 "HashCode should not be equal"
     ]
 
+let private tests_AbsoluteFilePath = testList "AbsoluteFilePath" [
+    testCase "Study_Relative" <| fun _ ->
+        let fileName = "MyFile"
+        let studyName = "MyStudy"
+        let d = Data(name = fileName)
+        let absolute = d.GetAbsolutePathForStudy(studyName)
+        let expected = $"studies/{studyName}/resources/{fileName}"
+        Expect.equal absolute expected "Absolute path should match expected path"
+    testCase "Study_Absolute" <| fun _ ->
+        let fileName = "studies/MyStudy/resources/MyFile"
+        let studyName = "MyStudy"
+        let d = Data(name = fileName)
+        let absolute = d.GetAbsolutePathForStudy(studyName)
+        let expected = $"studies/{studyName}/resources/MyFile"
+        Expect.equal absolute expected "Absolute path should match expected path"
+    testCase "Study_Absolute_/" <| fun _ ->
+        let fileName = "/studies/MyStudy/resources/MyFile"
+        let studyName = "MyStudy"
+        let d = Data(name = fileName)
+        let absolute = d.GetAbsolutePathForStudy(studyName)
+        let expected = $"studies/{studyName}/resources/MyFile"
+        Expect.equal absolute expected "Absolute path should match expected path"
+    testCase "Study_Absolute_./" <| fun _ ->
+        let fileName = "./studies/MyStudy/resources/MyFile"
+        let studyName = "MyStudy"
+        let d = Data(name = fileName)
+        let absolute = d.GetAbsolutePathForStudy(studyName)
+        let expected = $"studies/{studyName}/resources/MyFile"
+        Expect.equal absolute expected "Absolute path should match expected path"
+    testCase "Assay_Relative" <| fun _ ->
+        let fileName = "MyFile"
+        let assayName = "MyAssay"
+        let d = Data(name = fileName)
+        let absolute = d.GetAbsolutePathForAssay(assayName)
+        let expected = $"assays/{assayName}/dataset/{fileName}"
+        Expect.equal absolute expected "Absolute path should match expected path"
+    testCase "Assay_Absolute" <| fun _ ->
+        let fileName = "assays/MyAssay/dataset/MyFile"
+        let assayName = "MyAssay"
+        let d = Data(name = fileName)
+        let absolute = d.GetAbsolutePathForAssay(assayName)
+        let expected = $"assays/{assayName}/dataset/MyFile"
+        Expect.equal absolute expected "Absolute path should match expected path"
+    testCase "Assay_Absolute_/" <| fun _ ->
+        let fileName = "/assays/MyAssay/dataset/MyFile"
+        let assayName = "MyAssay"
+        let d = Data(name = fileName)
+        let absolute = d.GetAbsolutePathForAssay(assayName)
+        let expected = $"assays/{assayName}/dataset/MyFile"
+        Expect.equal absolute expected "Absolute path should match expected path"
+    testCase "Assay_Absolute_./" <| fun _ ->
+        let fileName = "./assays/MyAssay/dataset/MyFile"
+        let assayName = "MyAssay"
+        let d = Data(name = fileName)
+        let absolute = d.GetAbsolutePathForAssay(assayName)
+        let expected = $"assays/{assayName}/dataset/MyFile"
+        Expect.equal absolute expected "Absolute path should match expected path"
+    ]
+
 
 let main = 
     testList "Data" [
-        tests_GetHashCode       
+        tests_GetHashCode
+        tests_AbsoluteFilePath
     ]

--- a/tests/Spreadsheet/CompositeCellTests.fs
+++ b/tests/Spreadsheet/CompositeCellTests.fs
@@ -1,7 +1,20 @@
-﻿module CompositeCellTests
+module CompositeCellTests
 
 open TestingUtils
+open ARCtrl
+open ARCtrl.Spreadsheet
 
 let main = 
     testList "CompositeCell" [
+        testList "Data" [
+            testCase "ReadFullPathWith./" <| fun () -> 
+                let s = "./assays/MassHunter_targets/dataset/QuantResults/22-0005_exp001.batch_a.bin.batch.bin"
+                let c = CompositeCell.dataFromStringCells None None [|s|]
+                Expect.isTrue c.isData "Cell should be a data cell"
+                let d = c.AsData
+                let name = Expect.wantSome d.Name "Data cell should have a name"
+                Expect.equal name s "FullPath should match the input string"
+                Expect.isNone d.Format "Data cell should not have a format"
+                Expect.isNone d.Selector "Data cell should not have a selector"
+        ]
     ]

--- a/tests/Spreadsheet/Main.fs
+++ b/tests/Spreadsheet/Main.fs
@@ -7,6 +7,7 @@ let all = testSequenced <| testList "Spreadsheet" [
     RegexTests.main
     ArcInvestigationTests.main
     CompositeColumnTests.main
+    CompositeCellTests.main
     CompositeHeaderTests.main
     ArcTableTests.main
     DataMapTests.main


### PR DESCRIPTION
- fix #513 
- ARC RO-Crate reader now reads files annotated in RO-Crate and puts them into ARC FileSystem Tree