### PR TITLE
More closely follow file system in RO-Crate metadata json

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-  
+
     # SETUP .NET
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
@@ -66,7 +66,7 @@ jobs:
     - name: Test (Unix)
       if: matrix.os == 'ubuntu-latest'
       working-directory: ./
-      run: ./build.sh runtests
+      run: ./build.sh runtests --fail-on-focused-tests
     - name: Test (Windows)
       if: matrix.os == 'windows-latest'
-      run: .\build.cmd runtests
+      run: .\build.cmd runtests --fail-on-focused-tests

--- a/src/ARCtrl/ARC.fs
+++ b/src/ARCtrl/ARC.fs
@@ -881,7 +881,7 @@ type ARC(identifier : string, ?title : string, ?description : string, ?submissio
 
     member this.ToROCrateJsonString(?spaces) =
         this.MakeDataFilesAbsolute()
-        ARCtrl.Json.ARC.ROCrate.encoder this
+        ARCtrl.Json.ARC.ROCrate.encoder(this, fs = _fs)
         |> ARCtrl.Json.Encode.toJsonString (ARCtrl.Json.Encode.defaultSpaces spaces)
 
         /// exports in json-ld format

--- a/src/ARCtrl/ROCrateIO.fs
+++ b/src/ARCtrl/ROCrateIO.fs
@@ -3,6 +3,7 @@ namespace ARCtrl.Json
 open Thoth.Json.Core
 
 open ARCtrl
+open ARCtrl.FileSystem
 open ARCtrl.ROCrate
 open ARCtrl.Helper
 open ARCtrl.Conversion
@@ -29,11 +30,11 @@ module ARC =
             node.SetProperty("http://schema.org/about", LDRef("./"))
             node
 
-        static member encoder (isa : ArcInvestigation, ?license : obj) =
+        static member encoder (isa : ArcInvestigation, ?license : obj, ?fs : FileSystem) =
             let license = match license with
                           | Some license -> license
                           | None -> ROCrate.getDefaultLicense()
-            let isa = isa.ToROCrateInvestigation()
+            let isa = isa.ToROCrateInvestigation(?fs = fs)
             LDDataset.setSDDatePublishedAsDateTime(isa, System.DateTime.Now)
             LDDataset.setLicenseAsCreativeWork(isa, license)
             let graph = isa.Flatten()
@@ -51,7 +52,7 @@ module ARC =
                     let files =
                         graph.Nodes
                         |> ResizeArray.choose (fun n ->
-                            if LDFile.validate(n, ?context = graph.TryGetContext()) && n.Id.Contains "#" |> not then
+                            if LDFile.validate(n, ?context = graph.TryGetContext()) && n.Id.Contains "#" |> not && n.HasType(LDDataset.schemaType, ?context = graph.TryGetContext()) |> not then
                                 Some n.Id
                             else
                                 None

--- a/src/ARCtrl/__init__.py
+++ b/src/ARCtrl/__init__.py
@@ -13,6 +13,8 @@ from .py.Core.Table.arc_table import ArcTable
 from .py.Core.Table.arc_tables import ArcTables
 from .py.Core.arc_types import ArcAssay, ArcStudy, ArcRun, ArcWorkflow, ArcInvestigation
 from .py.Core.template import Template
+from .py.FileSystem.file_system import FileSystem
+from .py.FileSystem.file_system_tree import FileSystemTree
 from .py.json import JsonController
 from .py.xlsx import XlsxController
 from .py.arc import ARC

--- a/src/ARCtrl/index.ts
+++ b/src/ARCtrl/index.ts
@@ -14,6 +14,8 @@ export { OntologyAnnotation } from './ts/Core/OntologyAnnotation.js'
 export { Comment$ as Comment } from './ts/Core/Comment.js'
 export { Contract } from './ts/Contract/Contract.js'
 export { WebController} from './ts/Template.Web.js'
+export { FileSystem } from './ts/FileSystem/FileSystem.js'
+export { FileSystemTree } from './ts/FileSystem/FileSystemTree.js'
 
 /// RO-Crate
 import { LDNode, LDGraph, LDRef, LDValue} from './ts/ROCrate/LDObject.js'

--- a/tests/ARCtrl/ARCtrl.Tests.fs
+++ b/tests/ARCtrl/ARCtrl.Tests.fs
@@ -1772,7 +1772,7 @@ let tests_ROCrate =
             Expect.sequenceEqual inputCol.Cells expectedCells "First table input column should have correct cells"
             /// Assays
             Expect.equal arc.AssayCount 2 "ARC should contain 2 assays"
-        ftestCase "IncludeFilesystem" <| fun _ ->
+        testCase "IncludeFilesystem" <| fun _ ->
             let arc = ARC("MyARC", title = "MyTitle", description = "MyDescription")
             let assay = arc.InitAssay("MyAssay")
             arc.UpdateFileSystem()

--- a/tests/ARCtrl/ARCtrl.Tests.fs
+++ b/tests/ARCtrl/ARCtrl.Tests.fs
@@ -1772,6 +1772,29 @@ let tests_ROCrate =
             Expect.sequenceEqual inputCol.Cells expectedCells "First table input column should have correct cells"
             /// Assays
             Expect.equal arc.AssayCount 2 "ARC should contain 2 assays"
+        ftestCase "IncludeFilesystem" <| fun _ ->
+            let arc = ARC("MyARC", title = "MyTitle", description = "MyDescription")
+            let assay = arc.InitAssay("MyAssay")
+            arc.UpdateFileSystem()
+            let fs = 
+                arc.FileSystem.AddFile("assays/MyAssay/dataset/MyData.csv")
+                    .AddFile("assays/MyAssay/dataset/ABC.D/SubFile.txt")
+                    .AddFile("assays/MyAssay/dataset/ABC.D/SubFolder/SubSubFile.txt")
+            arc.FileSystem <- fs
+            let table = assay.InitTable("MyTable")
+            table.AddColumn(
+                CompositeHeader.Input IOType.Data,
+                ResizeArray [
+                    CompositeCell.createDataFromString("assays/MyAssay/dataset/MyData.csv")
+                    CompositeCell.createDataFromString("assays/MyAssay/dataset/ABC.D");
+                ]                
+            ) |> ignore
+            let roCrate = arc.ToROCrateJsonString()
+            let arc' = ARC.fromROCrateJsonString(roCrate)
+            Expect.testFileSystemTree arc'.FileSystem.Tree arc.FileSystem.Tree 
+            Expect.equal arc'.Assays[0] arc.Assays[0] "Assays should be equal"
+                    
+        
     ]
 
 

--- a/tests/ARCtrl/ROCrateConversion.Tests.fs
+++ b/tests/ARCtrl/ROCrateConversion.Tests.fs
@@ -269,7 +269,7 @@ let private tests_ProcessInput =
         testCase "Source" (fun () ->
             let header = CompositeHeader.Input(IOType.Source)
             let cell = CompositeCell.createFreeText "MySource"
-            let input = BaseTypes.composeProcessInput header cell
+            let input = BaseTypes.composeProcessInput header cell None
 
             Expect.isTrue (LDSample.validateSource input) "Should be a valid source"
             let name = LDSample.getNameAsString input
@@ -282,7 +282,7 @@ let private tests_ProcessInput =
         testCase "Sample" (fun () ->
             let header = CompositeHeader.Input(IOType.Sample)
             let cell = CompositeCell.createFreeText "MySample"
-            let input = BaseTypes.composeProcessInput header cell
+            let input = BaseTypes.composeProcessInput header cell None
 
             Expect.isTrue (LDSample.validateSample input) "Should be a valid sample"
             let name = LDSample.getNameAsString input
@@ -296,7 +296,7 @@ let private tests_ProcessInput =
             let header = CompositeHeader.Input(IOType.Data)
             let data = Data(name = "MyData", format = "text/csv", selectorFormat = "MySelector")
             let cell = CompositeCell.createData data
-            let input = BaseTypes.composeProcessInput header cell
+            let input = BaseTypes.composeProcessInput header cell None
     
             Expect.isTrue (LDFile.validate input) "Should be a valid data"
             let name = LDFile.getNameAsString input
@@ -310,7 +310,7 @@ let private tests_ProcessInput =
         testCase "Data_Freetext" (fun () ->
             let header = CompositeHeader.Input(IOType.Data)
             let cell = CompositeCell.createFreeText "MyData"
-            let input = BaseTypes.composeProcessInput header cell
+            let input = BaseTypes.composeProcessInput header cell None
     
             Expect.isTrue (LDFile.validate input) "Should be a valid data"
             let name = LDFile.getNameAsString input
@@ -324,7 +324,7 @@ let private tests_ProcessInput =
         testCase "Material" (fun () ->
             let header = CompositeHeader.Input(IOType.Material)
             let cell = CompositeCell.createFreeText "MyMaterial"
-            let input = BaseTypes.composeProcessInput header cell
+            let input = BaseTypes.composeProcessInput header cell None
     
             Expect.isTrue (LDSample.validateMaterial input) "Should be a valid material"
             let name = LDSample.getNameAsString input
@@ -337,7 +337,7 @@ let private tests_ProcessInput =
         testCase "FreeType" (fun () ->
             let header = CompositeHeader.Input (IOType.FreeText "MyInputType")
             let cell = CompositeCell.createFreeText "MyFreeText"
-            let input = BaseTypes.composeProcessInput header cell
+            let input = BaseTypes.composeProcessInput header cell None
 
             let name = LDSample.getNameAsString input
             Expect.equal name "MyFreeText" "Name should match"
@@ -356,7 +356,7 @@ let private tests_ProcessOutput =
         testCase "Sample" (fun () ->
             let header = CompositeHeader.Output(IOType.Sample)
             let cell = CompositeCell.createFreeText "MySample"
-            let output = BaseTypes.composeProcessOutput header cell
+            let output = BaseTypes.composeProcessOutput header cell None
 
             Expect.isTrue (LDSample.validateSample output) "Should be a valid sample"
             let name = LDSample.getNameAsString output
@@ -370,7 +370,7 @@ let private tests_ProcessOutput =
             let header = CompositeHeader.Output(IOType.Data)
             let data = Data(name = "MyData", format = "text/csv", selectorFormat = "MySelector")
             let cell = CompositeCell.createData data
-            let output = BaseTypes.composeProcessOutput header cell
+            let output = BaseTypes.composeProcessOutput header cell None
     
             Expect.isTrue (LDFile.validate output) "Should be a valid data"
             let name = LDFile.getNameAsString output
@@ -384,7 +384,7 @@ let private tests_ProcessOutput =
         testCase "Data_Freetext" (fun () ->
             let header = CompositeHeader.Output(IOType.Data)
             let cell = CompositeCell.createFreeText "MyData"
-            let output = BaseTypes.composeProcessOutput header cell
+            let output = BaseTypes.composeProcessOutput header cell None
     
             Expect.isTrue (LDFile.validate output) "Should be a valid data"
             let name = LDFile.getNameAsString output
@@ -398,7 +398,7 @@ let private tests_ProcessOutput =
         testCase "Material" (fun () ->
             let header = CompositeHeader.Output(IOType.Material)
             let cell = CompositeCell.createFreeText "MyMaterial"
-            let output = BaseTypes.composeProcessOutput header cell
+            let output = BaseTypes.composeProcessOutput header cell None
     
             Expect.isTrue (LDSample.validateMaterial output) "Should be a valid material"
             let name = LDSample.getNameAsString output
@@ -411,7 +411,7 @@ let private tests_ProcessOutput =
         testCase "FreeType" (fun () ->
             let header = CompositeHeader.Output (IOType.FreeText "MyOutputType")
             let cell = CompositeCell.createFreeText "MyFreeText"
-            let output = BaseTypes.composeProcessOutput header cell
+            let output = BaseTypes.composeProcessOutput header cell None
 
             let name = LDSample.getNameAsString output
             Expect.equal name "MyFreeText" "Name should match"
@@ -938,7 +938,7 @@ let private tests_Data =
             let path = "assays/MyAssay/dataset/ABC.D"
             let data = Data(name = path)
             let f = BaseTypes.composeFile(data, fs = fs)
-            Expect.sequenceEqual f.SchemaType [LDFile.schemaType] "Type should match"
+            Expect.sequenceEqual f.SchemaType [LDFile.schemaType; LDDataset.schemaType] "Type should match"
             Expect.equal f.Id path "ID should match"
             let name = Expect.wantSome (LDFile.tryGetNameAsString f) "Should have name"
             Expect.equal name path "Name should match"

--- a/tests/FileSystem/FileSystemTree.Tests.fs
+++ b/tests/FileSystem/FileSystemTree.Tests.fs
@@ -484,6 +484,28 @@ let private tests_AddFile =
             Expect.testFileSystemTree actual expected // use this instead of equal to ensure order of Folder children does not matter
     ]
 
+let private tests_TryGetPath =
+    let files = [|
+        "assays/MyAssay/dataset/ABC.D/SubFile.txt"
+        "assays/MyAssay/dataset/ABC.D/SubFolder/SubSubFile.txt"
+    |]
+    let fs = FileSystemTree.fromFilePaths files
+    testList "TryGetPath" [
+        testCase "ExistingFolder" <| fun _ ->
+            let folder = fs.TryGetPath("assays/MyAssay/dataset/ABC.D")
+            let folder = Expect.wantSome folder "Folder exists"
+            Expect.isTrue folder.isFolder "Should be folder object"
+            Expect.isTrue (folder.ContainsChildWithName "SubFile.txt") "Should contain subfile"
+            Expect.isTrue (folder.ContainsChildWithName "SubFolder") "Should contain subfolder"
+        testCase "ExistingFile" <| fun _ ->
+            let file = fs.TryGetPath("assays/MyAssay/dataset/ABC.D/SubFile.txt")
+            let file = Expect.wantSome file "File exists"
+            Expect.isTrue file.isFile "Should be File object"
+        testCase "NonExistingPath" <| fun _ ->
+            let nonExisting = fs.TryGetPath("assays/MyAssay/dataset/ABC.D/NonExisting.txt")
+            Expect.isNone nonExisting "Should not find non-existing file"
+    ]
+
 let main = testList "FileSystemTree" [
     tests_fromFilePaths
     tests_ToFilePaths
@@ -491,4 +513,5 @@ let main = testList "FileSystemTree" [
     tests_Filter_Folders
     tests_Filter
     tests_AddFile
+    tests_TryGetPath
 ]

--- a/tests/TestingUtils/TestingUtils.fs
+++ b/tests/TestingUtils/TestingUtils.fs
@@ -240,6 +240,7 @@ module Expect =
         | Folder (n1, children1), Folder (n2, children2) -> 
             Expect.equal n1 n2 $"Expects folder names to be equal: {n1} = {n2}"
             let sortByName (children: FileSystemTree []) = children |> Array.sortBy (fun c -> c.Name)
+            Expect.equal children1.Length children2.Length $"Expects folder names to be equal in length: {n1}:{children1.Length} = {n2}{children2.Length}"
             Array.iter2 testFileSystemTree (sortByName children1) (sortByName children2)
         | anyActual, anyExpected ->
             failwith $"Testing FileSystemTree found an issue with unequal states: 


### PR DESCRIPTION
connected to https://github.com/nfdi4plants/arc-export/issues/54

## Background

In ARC Scaffold [Annotation Tables](https://github.com/nfdi4plants/ARC-specification/blob/release/ISA-XLSX.md#annotation-table-sheets), `Data` objects can be used as Inputs or Outputs. In the actual ARC Filesystem, these `Data` annotations can refer to three different entities:
- File
- File Fragment 
- Folder

All of these make sense and there is currently no intention to change this annotation in the ARC Scaffold. 

The problem arises, when mapping the `ARC Scaffold` metadata to `ARC RO-Crate` metadata json. The RO-Crate is meant to be used for various tasks and should be as semantically sound as possible. This is not the case at the moment, as the `Folder` objects in the Annotation Table are just mapped to `Files` in RO-Crate, losing both knowledge about its actual type as well as the files it contains (see https://github.com/nfdi4plants/arc-export/issues/54 for why this is problematic).

## Implemented Solution

We don't want to access the actual Filesystem when mapping the metadata from Scaffold to RO-Crate, so, in this PR, I implemented logic to make use of the In-Memory Filesystem stored as a field in the ARC object. From there we can check, whether an object annotated as `Data` is actually a file or a folder and then map it accordingly.

If the object is a folder, I currently add a second type `Dataset` in addition to `File` and create and reference all subfiles it contains via the `hasPart` property.

E.g. when we have an annotation table that references the folder `ABC.D` as `Input [Data]`, which in turn contains the two files `SubFile.txt` and `SubFolder/SubSubFile.txt`, the output RO-Crate metadata will contain the following objects:

```json
[
    {
      "@id": "assays/MyAssay/dataset/ABC.D/SubFile.txt",
      "@type": "File",
      "name": "assays/MyAssay/dataset/ABC.D/SubFile.txt"
    },
    {
      "@id": "assays/MyAssay/dataset/ABC.D/SubFolder/SubSubFile.txt",
      "@type": "File",
      "name": "assays/MyAssay/dataset/ABC.D/SubFolder/SubSubFile.txt"
    },
    {
      "@id": "assays/MyAssay/dataset/ABC.D",
      "@type": [
        "File",
        "Dataset"
      ],
      "name": "assays/MyAssay/dataset/ABC.D",
      "hasPart": [
        {
          "@id": "assays/MyAssay/dataset/ABC.D/SubFile.txt"
        },
        {
          "@id": "assays/MyAssay/dataset/ABC.D/SubFolder/SubSubFile.txt"
        }
      ]
    },
    {
      "@id": "#Process_A_MyAssay_MyTable_1",
      "@type": "LabProcess",
      "name": "MyTable_1",
      "object": {
        "@id": "assays/MyAssay/dataset/ABC.D"
      },
      "result": [],
      "executesLabProtocol": {
        "@id": "#Protocol_MyTable"
      }
    }
 ]
```

To go full circle, the file and folder objects referenced in the ARC RO-Crate will also be put into the Filesystem of the ARC Scaffold object.