### PR TITLE
Make OntologyAnnotation equality TSR case insensitive

### DIFF
--- a/src/Core/OntologyAnnotation.fs
+++ b/src/Core/OntologyAnnotation.fs
@@ -159,13 +159,13 @@ type OntologyAnnotation(?name,?tsr,?tan, (*?tanInfo, *)?comments) =
             | None -> 0
         match this.TermSourceREF, this.TANInfo with
         | None, Some taninfo -> 
-            HashCodes.mergeHashes (hash taninfo.IDSpace) (hash taninfo.LocalID)
+            HashCodes.mergeHashes (hash (taninfo.IDSpace.ToLower())) (hash taninfo.LocalID)
         | Some tsr, Some taninfo -> 
-            HashCodes.mergeHashes (hash tsr) (hash taninfo.LocalID)
+            HashCodes.mergeHashes (hash (tsr.ToLower())) (hash taninfo.LocalID)
         | Some tsr, None ->
             match this.TermAccessionNumber with
-            | Some tan -> HashCodes.mergeHashes (hash tsr) (hash tan)
-            | None -> hash tsr
+            | Some tan -> HashCodes.mergeHashes (hash (tsr.ToLower())) (hash tan)
+            | None -> hash (tsr.ToLower())
         | None, None ->
             0    
         |> HashCodes.mergeHashes nameHash

--- a/tests/Core/OntologyAnnotation.Tests.fs
+++ b/tests/Core/OntologyAnnotation.Tests.fs
@@ -75,6 +75,10 @@ let private tests_equals = testList "Equals" [
         let oa2 = OntologyAnnotation("instrument model", "MSS", tan= "MS:00000001", comments=ResizeArray [Comment("KeyName", "Value1")])
         Expect.notEqual oa1 oa2 ""
         Expect.isFalse (oa1 = oa2) ""
+    testCase "TSR lowercase" <| fun _ ->
+        let oa1 = OntologyAnnotation("UniProt ID", "edam", "EDAM:2291")
+        let oa2 = OntologyAnnotation("UniProt ID", "EDAM", "EDAM:2291")
+        Expect.equal oa1 oa2 ""
     testCase "not equal" <| fun _ ->   
         let oa1 = OntologyAnnotation("instrument model", "MS", "http://purl.obolibrary.org/obo/MS_00000001", comments = ResizeArray [Comment("KeyName", "Value1")])
         let oa2 = OntologyAnnotation(tan= "MS:00000001", comments=ResizeArray [Comment("KeyName", "Value1")])


### PR DESCRIPTION
Just a small change to an IMO unwanted behaviour