### PR TITLE
fix python ro_crate parser failing for big graph

### DIFF
--- a/src/Json/ROCrate/LDGraph.fs
+++ b/src/Json/ROCrate/LDGraph.fs
@@ -34,7 +34,7 @@ module rec LDGraph =
                         fun (get : Decode.IGetters) ->
                             let id = get.Optional.Field "@id" Decode.string
                             let context = get.Optional.Field "@context" LDContext.decoder
-                            let nodes = get.Required.Field "@graph" (Decode.seq LDNode.decoder)            
+                            let nodes = get.Required.Field "@graph" (Decode.resizeArray LDNode.decoder)            
                             let o = LDGraph(?id = id, ?context = context)
                             for property in properties do
                                 if property <> "@id" && property <> "@graph" && property <> "@context" then

--- a/tests/Json/ROCrate/LDGraph.Tests.fs
+++ b/tests/Json/ROCrate/LDGraph.Tests.fs
@@ -20,6 +20,16 @@ let private test_read = testList "Read" [
         let secondExpectedObject = LDNode("./", ResizeArray ["Dataset"])
         Expect.equal graph.Nodes.[0] firstExpectedObject "first node should be the metadata"
         Expect.equal graph.Nodes.[1] secondExpectedObject "second node should be the dataset"
+    // https://github.com/nfdi4plants/ARCtrl/issues/545
+    testCase "LargeNodeCount" <| fun _ ->
+        let graph = LDGraph()
+        for i in 1 .. 1000 do
+            let node = LDNode($"node{i}", ResizeArray ["Thing"])
+            graph.AddNode node |> ignore
+        Expect.hasLength graph.Nodes 1000 "should have 1000 nodes"
+        let ro = graph.ToROCrateJsonString()
+        let graph2 = LDGraph.fromROCrateJsonString ro
+        Expect.hasLength graph2.Nodes 1000 "should have 1000 nodes"
 ]
 
 let private test_write = testList "Write" [


### PR DESCRIPTION
closes #545 

This error stems from the general JSON-LD Graph parser, which is the first step in parsing RO-Crate metadata files to the ARCtrl datamodel. 

The error was caused by a sequence expression being used here to parse the single entitites, with the Python transpilation handling it as a recursive function. This crashed the maximum recusion depth:
https://stackoverflow.com/questions/3323001/what-is-the-maximum-recursion-depth-and-how-to-increase-it

Not sure if this is a general problem. We probably should be careful using Seq expressions.