### PR TITLE
Fix read license always containing default path

### DIFF
--- a/src/ARCtrl/License.fs
+++ b/src/ARCtrl/License.fs
@@ -78,7 +78,7 @@ type License( contentType: LicenseContentType, content: string, ?path : string) 
         | {Operation = READ; DTOType = Some DTOType.PlainText; DTO = Some (DTO.Text txt)} when
             c.Path = ArcPathHelper.LICENSEFileName || Seq.contains c.Path ArcPathHelper.alternativeLICENSEFileNames
             ->
-            License.initFulltext txt |> Some
+            License.initFulltext(txt, path = c.Path) |> Some
         | _ -> None
 
     static member GetDefaultLicense () =

--- a/tests/ARCtrl/ARCtrl.Tests.fs
+++ b/tests/ARCtrl/ARCtrl.Tests.fs
@@ -390,7 +390,7 @@ let private tests_SetISAFromContracts = testList "SetISAFromContracts" [
             )
         let arc = ARC("MyIdentifier")
         arc.SetISAFromContracts [|SimpleISA.Investigation.investigationReadContract; licenseContract|]
-        let expectedLicense = License(LicenseContentType.Fulltext, content = licenseText)
+        let expectedLicense = License(LicenseContentType.Fulltext, content = licenseText, path = licensePath)
         let actualLicense = Expect.wantSome arc.License "License was not set"
         Expect.equal actualLicense expectedLicense "License was not set correctly"
     )


### PR DESCRIPTION
After reading a license file from an alternative path (e.g. "LICENSE.rst"), the License object would still point to the default path "LICENSE".