### PR TITLE
YAML-LD

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="FsSpreadsheet.NET"     Version="7.0.0-alpha.1" />
     <PackageVersion Include="FsSpreadsheet.Js"      Version="7.0.0-alpha.1" />
     <PackageVersion Include="FsSpreadsheet.Py"      Version="7.0.0-alpha.1" />
-    <PackageVersion Include="YAMLicious"            Version="1.0.0-alpha.7" />
+    <PackageVersion Include="YAMLicious"            Version="1.0.0-alpha.8" />
     <PackageVersion Include="DynamicObj"            Version="7.1.0" />
     <PackageVersion Include="Fable.SimpleHttp"      Version="3.5.0" />
     <PackageVersion Include="Fable.Fetch"           Version="2.6.0" />

--- a/src/ARCtrl/ARC.fs
+++ b/src/ARCtrl/ARC.fs
@@ -1111,15 +1111,15 @@ type ARC(identifier : string, ?title : string, ?description : string, ?submissio
         | ex -> 
             failwithf "Could not parse ARC-RO-Crate metadata: \n%s" ex.Message
 
-    member this.ToROCrateJsonString(?spaces, ?ignoreBrokenWR) =
+    member this.ToROCrateJsonString(?spaces, ?groupProcesses, ?ignoreBrokenWR) =
         this.MakeDataFilesAbsolute()
-        ARCtrl.Json.ARC.ROCrate.encoder(this, ?license = _license, fs = _fs, ?ignoreBrokenWR = ignoreBrokenWR)
+        ARCtrl.Json.ARC.ROCrate.encoder(this, ?license = _license, ?groupProcesses = groupProcesses, fs = _fs, ?ignoreBrokenWR = ignoreBrokenWR)
         |> ARCtrl.Json.Encode.toJsonString (ARCtrl.Json.Encode.defaultSpaces spaces)
 
         /// exports in json-ld format
-    static member toROCrateJsonString(?spaces, ?ignoreBrokenWR) =
+    static member toROCrateJsonString(?spaces, ?groupProcesses, ?ignoreBrokenWR) =
         fun (obj:ARC) ->
-            obj.ToROCrateJsonString(?spaces = spaces, ?ignoreBrokenWR = ignoreBrokenWR)
+            obj.ToROCrateJsonString(?spaces = spaces, ?groupProcesses = groupProcesses, ?ignoreBrokenWR = ignoreBrokenWR)
 
     member this.GetLicenseWriteContract() =
         this.License |> Option.defaultWith License.GetDefaultLicense |> _.ToCreateContract()

--- a/src/ARCtrl/ARCtrl.Common.props
+++ b/src/ARCtrl/ARCtrl.Common.props
@@ -50,6 +50,7 @@
       <ProjectReference Include="..\ROCrate\ARCtrl.ROCrate.fsproj" />
       <ProjectReference Include="..\FileSystem\ARCtrl.FileSystem.fsproj" />
       <ProjectReference Include="..\Json\ARCtrl.Json.fsproj" />
+      <ProjectReference Include="..\Yaml\ARCtrl.Yaml.fsproj" />
       <ProjectReference Include="..\Spreadsheet\ARCtrl.Spreadsheet.fsproj" />
       <ProjectReference Include="..\WorkflowGraph\ARCtrl.WorkflowGraph.fsproj" />
   </ItemGroup>

--- a/src/ARCtrl/ARCtrl.Javascript.fsproj
+++ b/src/ARCtrl/ARCtrl.Javascript.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageTags>ARC;F#;FSharp;dotnet;.Net;bioinformatics;biology;fable-library;datascience;dataplant;nfdi;metadata;fable-javascript</PackageTags>
@@ -52,6 +52,7 @@
     <Compile Include="JsonIO\Run.fs" />
     <Compile Include="JsonIO\Investigation.fs" />
     <Compile Include="JsonIO\LDObject.fs" />
+    <Compile Include="YamlIO.fs" />
     <Compile Include="CWLRunResolver.fs" />
     <Compile Include="Conversion\ColumnIndex.fs" />
     <Compile Include="Conversion\DateTime.fs" />

--- a/src/ARCtrl/ARCtrl.Python.fsproj
+++ b/src/ARCtrl/ARCtrl.Python.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageTags>ARC;F#;FSharp;dotnet;.Net;bioinformatics;biology;fable-library;datascience;dataplant;nfdi;metadata;fable-python</PackageTags>
@@ -54,6 +54,7 @@
     <Compile Include="JsonIO\Run.fs" />
     <Compile Include="JsonIO\Investigation.fs" />
     <Compile Include="JsonIO\LDObject.fs" />
+    <Compile Include="YamlIO.fs" />
     <Compile Include="CWLRunResolver.fs" />
     <Compile Include="Conversion\ColumnIndex.fs" />
     <Compile Include="Conversion\DateTime.fs" />

--- a/src/ARCtrl/ARCtrl.fsproj
+++ b/src/ARCtrl/ARCtrl.fsproj
@@ -55,6 +55,7 @@
     <Compile Include="JsonIO\Investigation.fs" />
     <Compile Include="JsonIO\Datamap.fs" />
     <Compile Include="JsonIO\LDObject.fs" />
+    <Compile Include="YamlIO.fs" />
     <Compile Include="CWLRunResolver.fs" />
     <Compile Include="Conversion\ColumnIndex.fs" />
     <Compile Include="Conversion\DateTime.fs" />

--- a/src/ARCtrl/Conversion.fs
+++ b/src/ARCtrl/Conversion.fs
@@ -14,22 +14,22 @@ open ARCtrl.Helper.Regex.ActivePatterns
 module TypeExtensions =
 
     type ArcAssay with
-         member this.ToROCrateAssay(?groupProcesses, ?fs) = AssayConversion.composeAssay(this, ?groupProcesses = groupProcesses, ?fs = fs)
+         member this.ToROCrateAssay(?groupProcesses, ?fs, ?skipDatamap) = AssayConversion.composeAssay(this, ?groupProcesses = groupProcesses, ?fs = fs, ?skipDatamap = skipDatamap)
 
          static member fromROCrateAssay (a : LDNode, ?graph : LDGraph, ?context : LDContext) = AssayConversion.decomposeAssay(a, ?graph = graph, ?context = context)
 
     type ArcStudy with
-         member this.ToROCrateStudy(?groupProcesses, ?fs) = StudyConversion.composeStudy(this, ?groupProcesses = groupProcesses, ?fs = fs)
+         member this.ToROCrateStudy(?groupProcesses, ?fs, ?skipDatamap) = StudyConversion.composeStudy(this, ?groupProcesses = groupProcesses, ?fs = fs, ?skipDatamap = skipDatamap)
 
          static member fromROCrateStudy (a : LDNode, ?graph : LDGraph, ?context : LDContext) = StudyConversion.decomposeStudy(a, ?graph = graph, ?context = context)
 
     type ArcWorkflow with
-        member this.ToROCrateWorkflow(?fs) = WorkflowConversion.composeWorkflow(this, ?fs = fs)
+        member this.ToROCrateWorkflow(?fs, ?skipDatamap) = WorkflowConversion.composeWorkflow(this, ?fs = fs, ?skipDatamap = skipDatamap)
 
         static member fromROCrateWorkflow (a : LDNode, ?graph : LDGraph, ?context : LDContext) = WorkflowConversion.decomposeWorkflow(a, ?graph = graph, ?context = context)
 
     type ArcRun with
-        member this.ToROCrateRun(?fs) = RunConversion.composeRun(this, ?fs = fs)
+        member this.ToROCrateRun(?fs, ?skipDatamap) = RunConversion.composeRun(this, ?fs = fs, ?skipDatamap = skipDatamap)
 
         static member fromROCrateRun (a : LDNode, ?graph : LDGraph, ?context : LDContext) = RunConversion.decomposeRun(a, ?graph = graph, ?context = context)
 
@@ -48,17 +48,17 @@ module TypeExtensions =
         // Study
         static member toArcStudy(a : LDNode, ?graph : LDGraph, ?context : LDContext) = StudyConversion.decomposeStudy(a, ?graph = graph, ?context = context)
 
-        static member fromArcStudy (a : ArcStudy, ?groupProcesses : bool, ?fs : FileSystem) = StudyConversion.composeStudy(a, ?groupProcesses = groupProcesses, ?fs = fs)
+        static member fromArcStudy (a : ArcStudy, ?groupProcesses : bool, ?skipDatamap : bool, ?fs : FileSystem) = StudyConversion.composeStudy(a, ?groupProcesses = groupProcesses, ?skipDatamap = skipDatamap, ?fs = fs)
 
         // Workflow
         static member toArcWorkflow(a : LDNode, ?graph : LDGraph, ?context : LDContext) = WorkflowConversion.decomposeWorkflow(a, ?graph = graph, ?context = context)
 
-        static member fromArcWorkflow (a : ArcWorkflow) = WorkflowConversion.composeWorkflow a
+        static member fromArcWorkflow (a : ArcWorkflow, ?skipDatamap : bool, ?fs : FileSystem) = WorkflowConversion.composeWorkflow(a, ?skipDatamap = skipDatamap, ?fs = fs)
 
         // Run
         static member toArcRun(a : LDNode, ?graph : LDGraph, ?context : LDContext) = RunConversion.decomposeRun(a, ?graph = graph, ?context = context)
 
-        static member fromArcRun (a : ArcRun) = RunConversion.composeRun a
+        static member fromArcRun (a : ArcRun, ?skipDatamap : bool, ?fs : FileSystem) = RunConversion.composeRun(a, ?skipDatamap = skipDatamap, ?fs = fs)
 
         // Investigation
         static member toArcInvestigation(a : LDNode, ?graph : LDGraph, ?context : LDContext) = InvestigationConversion.decomposeInvestigation(a, ?graph = graph, ?context = context)
@@ -76,19 +76,19 @@ module TypeExtensions =
             ArcAssay.fromROCrateAssay(a, ?graph = graph, ?context = context)
 
         // Study
-        static member arcStudyToDataset(a : ArcStudy, ?groupProcesses, ?fs) = a.ToROCrateStudy(?groupProcesses = groupProcesses, ?fs = fs)
+        static member arcStudyToDataset(a : ArcStudy, ?groupProcesses, ?skipDatamap, ?fs) = a.ToROCrateStudy(?groupProcesses = groupProcesses, ?skipDatamap = skipDatamap, ?fs = fs)
 
         static member datasetToArcStudy(a : LDNode, ?graph : LDGraph, ?context : LDContext) =
             ArcStudy.fromROCrateStudy(a, ?graph = graph, ?context = context)
 
         // Workflow
-        static member arcWorkflowToDataset(a : ArcWorkflow, ?fs) = a.ToROCrateWorkflow(?fs = fs)
+        static member arcWorkflowToDataset(a : ArcWorkflow, ?skipDatamap, ?fs) = a.ToROCrateWorkflow(?skipDatamap = skipDatamap, ?fs = fs)
 
         static member datasetToArcWorkflow(a : LDNode, ?graph : LDGraph, ?context : LDContext) =
             ArcWorkflow.fromROCrateWorkflow(a, ?graph = graph, ?context = context)
 
         // Run
-        static member arcRunToDataset(a : ArcRun, ?fs) = a.ToROCrateRun(?fs = fs)
+        static member arcRunToDataset(a : ArcRun, ?skipDatamap, ?fs) = a.ToROCrateRun(?skipDatamap = skipDatamap, ?fs = fs)
 
         static member datasetToArcRun(a : LDNode, ?graph : LDGraph, ?context : LDContext) =
             ArcRun.fromROCrateRun(a, ?graph = graph, ?context = context)

--- a/src/ARCtrl/Conversion.fs
+++ b/src/ARCtrl/Conversion.fs
@@ -14,12 +14,12 @@ open ARCtrl.Helper.Regex.ActivePatterns
 module TypeExtensions =
 
     type ArcAssay with
-         member this.ToROCrateAssay(?fs) = AssayConversion.composeAssay(this, ?fs = fs)
+         member this.ToROCrateAssay(?groupProcesses, ?fs) = AssayConversion.composeAssay(this, ?groupProcesses = groupProcesses, ?fs = fs)
 
          static member fromROCrateAssay (a : LDNode, ?graph : LDGraph, ?context : LDContext) = AssayConversion.decomposeAssay(a, ?graph = graph, ?context = context)
 
     type ArcStudy with
-         member this.ToROCrateStudy(?fs) = StudyConversion.composeStudy(this, ?fs = fs)
+         member this.ToROCrateStudy(?groupProcesses, ?fs) = StudyConversion.composeStudy(this, ?groupProcesses = groupProcesses, ?fs = fs)
 
          static member fromROCrateStudy (a : LDNode, ?graph : LDGraph, ?context : LDContext) = StudyConversion.decomposeStudy(a, ?graph = graph, ?context = context)
 
@@ -34,7 +34,7 @@ module TypeExtensions =
         static member fromROCrateRun (a : LDNode, ?graph : LDGraph, ?context : LDContext) = RunConversion.decomposeRun(a, ?graph = graph, ?context = context)
 
     type ArcInvestigation with
-        member this.ToROCrateInvestigation(?fs, ?ignoreBrokenWR) = InvestigationConversion.composeInvestigation(this, ?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
+        member this.ToROCrateInvestigation(?groupProcesses, ?fs, ?ignoreBrokenWR) = InvestigationConversion.composeInvestigation(this, ?groupProcesses = groupProcesses, ?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
     
         static member fromROCrateInvestigation (a : LDNode, ?graph : LDGraph, ?context : LDContext) = InvestigationConversion.decomposeInvestigation(a, ?graph = graph, ?context = context)
 
@@ -43,12 +43,12 @@ module TypeExtensions =
         // Assay
         static member toArcAssay(a : LDNode, ?graph : LDGraph, ?context : LDContext) = AssayConversion.decomposeAssay(a, ?graph = graph, ?context = context)
 
-        static member fromArcAssay (a : ArcAssay) = AssayConversion.composeAssay a
+        static member fromArcAssay (a : ArcAssay, ?groupProcesses : bool, ?fs : FileSystem) = AssayConversion.composeAssay(a, ?groupProcesses = groupProcesses, ?fs = fs)
 
         // Study
         static member toArcStudy(a : LDNode, ?graph : LDGraph, ?context : LDContext) = StudyConversion.decomposeStudy(a, ?graph = graph, ?context = context)
 
-        static member fromArcStudy (a : ArcStudy) = StudyConversion.composeStudy a
+        static member fromArcStudy (a : ArcStudy, ?groupProcesses : bool, ?fs : FileSystem) = StudyConversion.composeStudy(a, ?groupProcesses = groupProcesses, ?fs = fs)
 
         // Workflow
         static member toArcWorkflow(a : LDNode, ?graph : LDGraph, ?context : LDContext) = WorkflowConversion.decomposeWorkflow(a, ?graph = graph, ?context = context)
@@ -63,20 +63,20 @@ module TypeExtensions =
         // Investigation
         static member toArcInvestigation(a : LDNode, ?graph : LDGraph, ?context : LDContext) = InvestigationConversion.decomposeInvestigation(a, ?graph = graph, ?context = context)
 
-        static member fromArcInvestigation (a : ArcInvestigation) = InvestigationConversion.composeInvestigation a
+        static member fromArcInvestigation (a : ArcInvestigation, ?groupProcesses : bool, ?fs : FileSystem, ?ignoreBrokenWR) = InvestigationConversion.composeInvestigation(a, ?groupProcesses = groupProcesses, ?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
 
 
     [<Fable.Core.AttachMembers>]
     type Conversion =
 
         // Assay
-        static member arcAssayToDataset(a : ArcAssay, ?fs) = a.ToROCrateAssay(?fs = fs)
+        static member arcAssayToDataset(a : ArcAssay, ?groupProcesses, ?fs) = a.ToROCrateAssay(?groupProcesses = groupProcesses, ?fs = fs)
 
         static member datasetToArcAssay(a : LDNode, ?graph : LDGraph, ?context : LDContext) =
             ArcAssay.fromROCrateAssay(a, ?graph = graph, ?context = context)
 
         // Study
-        static member arcStudyToDataset(a : ArcStudy, ?fs) = a.ToROCrateStudy(?fs = fs)
+        static member arcStudyToDataset(a : ArcStudy, ?groupProcesses, ?fs) = a.ToROCrateStudy(?groupProcesses = groupProcesses, ?fs = fs)
 
         static member datasetToArcStudy(a : LDNode, ?graph : LDGraph, ?context : LDContext) =
             ArcStudy.fromROCrateStudy(a, ?graph = graph, ?context = context)
@@ -94,7 +94,7 @@ module TypeExtensions =
             ArcRun.fromROCrateRun(a, ?graph = graph, ?context = context)
 
         // Investigation
-        static member arcInvestigationToDataset(a : ArcInvestigation, ?fs, ?ignoreBrokenWR) = a.ToROCrateInvestigation(?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
+        static member arcInvestigationToDataset(a : ArcInvestigation, ?groupProcesses, ?fs, ?ignoreBrokenWR) = a.ToROCrateInvestigation(?groupProcesses = groupProcesses, ?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
 
         static member datasetToArcInvestigation(a : LDNode, ?graph : LDGraph, ?context : LDContext) =
             ArcInvestigation.fromROCrateInvestigation(a, ?graph = graph, ?context = context)       

--- a/src/ARCtrl/Conversion/Assay.fs
+++ b/src/ARCtrl/Conversion/Assay.fs
@@ -62,7 +62,8 @@ type AssayConversion =
             )
         ResizeArray.append files filesFromfragments
 
-    static member composeAssay (assay : ArcAssay, ?groupProcesses : bool, ?fs : FileSystem) =
+    static member composeAssay (assay : ArcAssay, ?groupProcesses : bool, ?fs : FileSystem, ?skipDatamap) =
+        let includeDatamap = defaultArg skipDatamap false |> not
         let measurementMethod = assay.TechnologyType |> Option.map BaseTypes.composeDefinedTerm
         let measurementTechnique = assay.TechnologyPlatform |> Option.map BaseTypes.composeDefinedTerm
         let variableMeasured = assay.MeasurementType |> Option.map BaseTypes.composePropertyValueFromOA
@@ -78,8 +79,9 @@ type AssayConversion =
             |> ResizeArray
             |> Option.fromSeq
         let fragmentDescriptors =
-            assay.Datamap
-            |> Option.map DatamapConversion.composeFragmentDescriptors
+            match assay.Datamap with
+            | Some d when includeDatamap -> Some (DatamapConversion.composeFragmentDescriptors d)
+            | _ -> None
         let dataFiles = 
             processSequence
             |> Option.map (fun ps -> AssayConversion.getDataFilesFromProcesses(ps, ?fragmentDescriptors = fragmentDescriptors))

--- a/src/ARCtrl/Conversion/Assay.fs
+++ b/src/ARCtrl/Conversion/Assay.fs
@@ -62,7 +62,7 @@ type AssayConversion =
             )
         ResizeArray.append files filesFromfragments
 
-    static member composeAssay (assay : ArcAssay, ?fs : FileSystem) =
+    static member composeAssay (assay : ArcAssay, ?groupProcesses : bool, ?fs : FileSystem) =
         let measurementMethod = assay.TechnologyType |> Option.map BaseTypes.composeDefinedTerm
         let measurementTechnique = assay.TechnologyPlatform |> Option.map BaseTypes.composeDefinedTerm
         let variableMeasured = assay.MeasurementType |> Option.map BaseTypes.composePropertyValueFromOA
@@ -70,8 +70,11 @@ type AssayConversion =
             assay.Performers
             |> ResizeArray.map (fun c -> PersonConversion.composePerson c)
             |> Option.fromSeq
-        let processSequence = 
-            ArcTables(assay.Tables).GetProcesses(assayName = assay.Identifier, ?fs = fs)
+        let processSequence =
+            if groupProcesses |> Option.defaultValue false then
+                ArcTables(assay.Tables).GetProcessesGroupedByParameters(assayName = assay.Identifier, ?fs = fs)
+            else
+                ArcTables(assay.Tables).GetProcesses(assayName = assay.Identifier, ?fs = fs)
             |> ResizeArray
             |> Option.fromSeq
         let fragmentDescriptors =

--- a/src/ARCtrl/Conversion/Investigation.fs
+++ b/src/ARCtrl/Conversion/Investigation.fs
@@ -12,7 +12,7 @@ open ARCtrl.Helper.Regex.ActivePatterns
 
 type InvestigationConversion =
 
-    static member composeInvestigation (investigation : ArcInvestigation, ?fs : FileSystem, ?ignoreBrokenWR) =
+    static member composeInvestigation (investigation : ArcInvestigation, ?groupProcesses : bool, ?fs : FileSystem, ?ignoreBrokenWR) =
         let name = match investigation.Title with | Some t -> t | None -> failwith "Investigation must have a title"
         let dateCreated = investigation.SubmissionDate |> Option.bind DateTime.tryFromString
         let datePublished =
@@ -34,8 +34,8 @@ type InvestigationConversion =
             |> Option.fromSeq
         let hasParts =
             [
-                yield! (investigation.Assays |> ResizeArray.map (fun a -> AssayConversion.composeAssay(a, ?fs = fs)))
-                yield! (investigation.Studies |> ResizeArray.map (fun s -> StudyConversion.composeStudy(s, ?fs = fs)))
+                yield! (investigation.Assays |> ResizeArray.map (fun a -> AssayConversion.composeAssay(a, ?groupProcesses = groupProcesses, ?fs = fs)))
+                yield! (investigation.Studies |> ResizeArray.map (fun s -> StudyConversion.composeStudy(s, ?groupProcesses = groupProcesses, ?fs = fs)))
                 yield! (investigation.Workflows |> ResizeArray.choose (fun w ->
                     try 
                         WorkflowConversion.composeWorkflow(w, ?fs = fs) |> Some

--- a/src/ARCtrl/Conversion/Process.fs
+++ b/src/ARCtrl/Conversion/Process.fs
@@ -353,6 +353,181 @@ type ProcessConversion =
 
                 )
 
+    /// Given the header sequence of an ArcTable, returns a function for parsing grouped rows to processes.
+    static member getGroupedProcessGetter (assayName: string option) (studyName : string option) (processNameRoot : string) (headers : CompositeHeader seq) (fs : FileSystem option) =
+
+        let headers =
+            headers
+            |> Seq.indexed
+
+        let valueHeaders =
+            headers
+            |> Seq.filter (snd >> fun h -> h.IsCvParamColumn)
+            |> Seq.indexed
+            |> Seq.toList
+
+        let charGetters =
+            valueHeaders
+            |> List.choose (fun (valueI,(generalI,header)) -> ProcessConversion.tryCharacteristicGetter generalI valueI header)
+
+        let factorValueGetters =
+            valueHeaders
+            |> List.choose (fun (valueI,(generalI,header)) -> ProcessConversion.tryFactorGetter generalI valueI header)
+
+        let parameterValueGetters =
+            valueHeaders
+            |> List.choose (fun (valueI,(generalI,header)) -> ProcessConversion.tryParameterGetter generalI valueI header)
+
+        let componentGetters =
+            valueHeaders
+            |> List.choose (fun (valueI,(generalI,header)) -> ProcessConversion.tryComponentGetter generalI valueI header)
+
+        let protocolTypeGetter =
+            headers
+            |> Seq.tryPick (fun (generalI,header) -> ProcessConversion.tryGetProtocolTypeGetter generalI header)
+
+        let protocolREFGetter =
+            headers
+            |> Seq.tryPick (fun (generalI,header) -> ProcessConversion.tryGetProtocolREFGetter generalI header)
+
+        let protocolDescriptionGetter =
+            headers
+            |> Seq.tryPick (fun (generalI,header) -> ProcessConversion.tryGetProtocolDescriptionGetter generalI header)
+
+        let protocolURIGetter =
+            headers
+            |> Seq.tryPick (fun (generalI,header) -> ProcessConversion.tryGetProtocolURIGetter generalI header)
+
+        let protocolVersionGetter =
+            headers
+            |> Seq.tryPick (fun (generalI,header) -> ProcessConversion.tryGetProtocolVersionGetter generalI header)
+
+        let performerGetter =
+            headers
+            |> Seq.tryPick (fun (generalI,header) -> ProcessConversion.tryGetPerformerGetter generalI header)
+
+        let commentGetters =
+            headers
+            |> Seq.choose (fun (generalI,header) -> ProcessConversion.tryGetCommentGetter generalI header)
+            |> Seq.toList
+
+        let inputGetter =
+            match headers |> Seq.tryPick (fun (generalI,header) -> ProcessConversion.tryGetInputGetter generalI header fs) with
+            | Some inputGetter ->
+                fun (table : ArcTable) i ->
+                    let chars = charGetters |> Seq.map (fun f -> f table i) |> ResizeArray
+                    let input = inputGetter table i
+
+                    if chars.Count > 0 then
+                        LDSample.setAdditionalProperties(input,chars)
+                    input
+                    |> ResizeArray.singleton
+            | None when charGetters.Length <> 0 ->
+                fun (table : ArcTable) i ->
+                    let chars = charGetters |> Seq.map (fun f -> f table i) |> ResizeArray
+                    LDSample.createSample(name = $"{processNameRoot}_Input_{i}", additionalProperties = chars)
+                    |> ResizeArray.singleton
+            | None ->
+                fun (_ : ArcTable) _ ->
+                    ResizeArray []
+
+        let outputGetter =
+            match headers |> Seq.tryPick (fun (generalI,header) -> ProcessConversion.tryGetOutputGetter generalI header fs) with
+            | Some outputGetter ->
+                fun (table : ArcTable) i ->
+                    let factors = factorValueGetters |> Seq.map (fun f -> f table i) |> ResizeArray
+                    let output = outputGetter table i
+                    if factors.Count > 0 then
+                        LDSample.setAdditionalProperties(output,factors)
+                    output
+                    |> ResizeArray.singleton
+            | None when factorValueGetters.Length <> 0 ->
+                fun (table : ArcTable) i ->
+                    let factors = factorValueGetters |> Seq.map (fun f -> f table i) |> ResizeArray
+                    LDSample.createSample(name = $"{processNameRoot}_Output_{i}", additionalProperties = factors)
+                    |> ResizeArray.singleton
+            | None ->
+                fun (_ : ArcTable) _ ->
+                    ResizeArray []
+
+        let rowGroupingKeyGetter (table : ArcTable) i =
+            [
+                parameterValueGetters |> Seq.map (fun f -> (f table i).Id) |> HashCodes.boxHashSeq
+                componentGetters |> Seq.map (fun f -> (f table i).Id) |> HashCodes.boxHashSeq
+                protocolTypeGetter |> Option.map (fun f -> (f table i).Id) |> HashCodes.boxHashOption
+                protocolREFGetter |> Option.map (fun f -> f table i) |> HashCodes.boxHashOption
+                protocolDescriptionGetter |> Option.map (fun f -> f table i) |> HashCodes.boxHashOption
+                protocolURIGetter |> Option.map (fun f -> f table i) |> HashCodes.boxHashOption
+                protocolVersionGetter |> Option.map (fun f -> f table i) |> HashCodes.boxHashOption
+                performerGetter |> Option.map (fun f -> (f table i).Id) |> HashCodes.boxHashOption
+                commentGetters |> Seq.map (fun f -> f table i) |> HashCodes.boxHashSeq
+            ]
+            |> HashCodes.boxHashSeq
+
+        let createProcessFromRows (table : ArcTable) (rowIndices : int list) (processI : int) (processCount : int) =
+
+            let firstRow = rowIndices |> List.head
+
+            let pn =
+                if processCount = 1 then processNameRoot
+                else ProcessConversion.composeProcessName processNameRoot processI
+
+            let paramvalues = parameterValueGetters |> List.map (fun f -> f table firstRow) |> Option.fromValueWithDefault [] |> Option.map ResizeArray
+
+            let comments = commentGetters |> List.map (fun f -> f table firstRow) |> Option.fromValueWithDefault [] |> Option.map ResizeArray
+
+            let components = componentGetters |> List.map (fun f -> f table firstRow) |> Option.fromValueWithDefault [] |> Option.map ResizeArray
+
+            let id = LDLabProcess.genId(processNameRoot,?assayName = assayName, ?studyName = studyName) + $"_{processI}"
+
+            let protocol : LDNode option =
+                let name = (protocolREFGetter |> Option.map (fun f -> f table firstRow))
+                let protocolId = LDLabProtocol.genId(?name = name, processName = processNameRoot)
+                LDLabProtocol.create(
+                    id = protocolId,
+                    ?name = name,
+                    ?description = (protocolDescriptionGetter |> Option.map (fun f -> f table firstRow)),
+                    ?intendedUse = (protocolTypeGetter |> Option.map (fun f -> f table firstRow)),
+                    ?url = (protocolURIGetter |> Option.map (fun f -> f table firstRow)),
+                    ?version = (protocolVersionGetter |> Option.map (fun f -> f table firstRow)),
+                    ?labEquipments = components
+                )
+                |> Some
+
+            let input =
+                rowIndices
+                |> List.collect (fun i -> inputGetter table i |> Seq.toList)
+                |> ResizeArray
+
+            let output =
+                rowIndices
+                |> List.collect (fun i -> outputGetter table i |> Seq.toList)
+                |> ResizeArray
+
+            let agent = performerGetter |> Option.map (fun f -> f table firstRow)
+
+            LDLabProcess.create(
+                name = pn,
+                objects = input,
+                results = output,
+                id = id,
+                ?agent = agent,
+                ?executesLabProtocol = protocol,
+                ?parameterValues = paramvalues,
+                ?disambiguatingDescriptions = comments
+            )
+
+        fun (table : ArcTable) ->
+            let groupedRowIndices =
+                [0 .. table.RowCount - 1]
+                |> List.groupBy (fun i -> rowGroupingKeyGetter table i)
+                |> List.map snd
+
+            groupedRowIndices
+            |> List.mapi (fun processI rowIndices ->
+                createProcessFromRows table rowIndices processI groupedRowIndices.Length
+            )
+
     /// Groups processes by their name, or by the name of the protocol they execute
     ///
     /// Process names are taken from the Worksheet name and numbered: SheetName_1, SheetName_2, etc.

--- a/src/ARCtrl/Conversion/Process.fs
+++ b/src/ARCtrl/Conversion/Process.fs
@@ -450,19 +450,36 @@ type ProcessConversion =
                 fun (_ : ArcTable) _ ->
                     ResizeArray []
 
+        let groupingHeaders =
+            headers
+            |> Seq.filter (fun (_, header) ->
+                match header with
+                | CompositeHeader.Parameter _
+                | CompositeHeader.Component _
+                | CompositeHeader.ProtocolType
+                | CompositeHeader.ProtocolREF
+                | CompositeHeader.ProtocolDescription
+                | CompositeHeader.ProtocolUri
+                | CompositeHeader.ProtocolVersion
+                | CompositeHeader.Performer
+                | CompositeHeader.Comment _ -> true
+                | _ -> false
+            )
+            |> Seq.toList
+
         let rowGroupingKeyGetter (table : ArcTable) i =
-            [
-                parameterValueGetters |> Seq.map (fun f -> (f table i).Id) |> HashCodes.boxHashSeq
-                componentGetters |> Seq.map (fun f -> (f table i).Id) |> HashCodes.boxHashSeq
-                protocolTypeGetter |> Option.map (fun f -> (f table i).Id) |> HashCodes.boxHashOption
-                protocolREFGetter |> Option.map (fun f -> f table i) |> HashCodes.boxHashOption
-                protocolDescriptionGetter |> Option.map (fun f -> f table i) |> HashCodes.boxHashOption
-                protocolURIGetter |> Option.map (fun f -> f table i) |> HashCodes.boxHashOption
-                protocolVersionGetter |> Option.map (fun f -> f table i) |> HashCodes.boxHashOption
-                performerGetter |> Option.map (fun f -> (f table i).Id) |> HashCodes.boxHashOption
-                commentGetters |> Seq.map (fun f -> f table i) |> HashCodes.boxHashSeq
-            ]
-            |> HashCodes.boxHashSeq
+            groupingHeaders
+            |> List.fold (fun acc (generalI, header) ->
+                let cell =
+                    match ArcTableAux.Unchecked.tryGetCellAt(generalI, i) table.Values with
+                    | Some cell -> cell
+                    | None -> ArcTableAux.getEmptyCellForHeader header None
+
+                let headerHash = HashCodes.hash header
+                let cellHash = HashCodes.hash cell
+                let withHeader = HashCodes.mergeHashes acc headerHash
+                HashCodes.mergeHashes withHeader cellHash
+            ) 0
 
         let createProcessFromRows (table : ArcTable) (rowIndices : int list) (processI : int) (processCount : int) =
 
@@ -494,15 +511,13 @@ type ProcessConversion =
                 )
                 |> Some
 
-            let input =
-                rowIndices
-                |> List.collect (fun i -> inputGetter table i |> Seq.toList)
-                |> ResizeArray
+            let input = ResizeArray()
+            for rowI in rowIndices do
+                input.AddRange(inputGetter table rowI)
 
-            let output =
-                rowIndices
-                |> List.collect (fun i -> outputGetter table i |> Seq.toList)
-                |> ResizeArray
+            let output = ResizeArray()
+            for rowI in rowIndices do
+                output.AddRange(outputGetter table rowI)
 
             let agent = performerGetter |> Option.map (fun f -> f table firstRow)
 

--- a/src/ARCtrl/Conversion/Run.fs
+++ b/src/ARCtrl/Conversion/Run.fs
@@ -171,7 +171,8 @@ type RunConversion =
             )
         cwlDescription, parameterRefs
 
-    static member composeRun (run : ArcRun, ?fs : FileSystem) =
+    static member composeRun (run : ArcRun, ?fs : FileSystem, ?skipDatamap) =
+        let includeDatamap = defaultArg skipDatamap false |> not
         let workflowProtocol =
             let workflowFilePath = Identifier.Run.cwlFileNameFromIdentifier run.Identifier
             match run.CWLDescription with
@@ -194,8 +195,9 @@ type RunConversion =
         LDComputationalWorkflow.setSdPublisher(workflowProtocol, publisher)
         LDComputationalWorkflow.setDateCreatedAsDateTime(workflowProtocol, dateCreated)
         let fragmentDescriptors =
-            run.Datamap
-            |> Option.map DatamapConversion.composeFragmentDescriptors
+            match run.Datamap with
+            | Some d when includeDatamap -> Some (DatamapConversion.composeFragmentDescriptors d)
+            | _ -> None
         let dataFiles = 
             workflowInvocations
             |> Option.map (fun ps -> AssayConversion.getDataFilesFromProcesses(ps, ?fragmentDescriptors = fragmentDescriptors))

--- a/src/ARCtrl/Conversion/Study.fs
+++ b/src/ARCtrl/Conversion/Study.fs
@@ -13,7 +13,7 @@ open ARCtrl.Helper.Regex.ActivePatterns
 
 type StudyConversion = 
 
-    static member composeStudy (study : ArcStudy, ?fs : FileSystem) =
+    static member composeStudy (study : ArcStudy, ?groupProcesses : bool, ?fs : FileSystem) =
         let dateCreated = study.SubmissionDate |> Option.bind DateTime.tryFromString
         let datePublished = study.PublicReleaseDate |> Option.bind DateTime.tryFromString
         let dateModified = System.DateTime.Now
@@ -26,7 +26,10 @@ type StudyConversion =
             |> ResizeArray.map (fun c -> PersonConversion.composePerson c)
             |> Option.fromSeq
         let processSequence = 
-            ArcTables(study.Tables).GetProcesses(studyName = study.Identifier, ?fs = fs)
+            (if groupProcesses |> Option.defaultValue false then
+                ArcTables(study.Tables).GetProcessesGroupedByParameters(studyName = study.Identifier, ?fs = fs)
+            else
+                ArcTables(study.Tables).GetProcesses(studyName = study.Identifier, ?fs = fs))
             |> ResizeArray
             |> Option.fromSeq
         let fragmentDescriptors =

--- a/src/ARCtrl/Conversion/Study.fs
+++ b/src/ARCtrl/Conversion/Study.fs
@@ -13,7 +13,8 @@ open ARCtrl.Helper.Regex.ActivePatterns
 
 type StudyConversion = 
 
-    static member composeStudy (study : ArcStudy, ?groupProcesses : bool, ?fs : FileSystem) =
+    static member composeStudy (study : ArcStudy, ?groupProcesses : bool, ?fs : FileSystem, ?skipDatamap) =
+        let includeDatamap = defaultArg skipDatamap false |> not
         let dateCreated = study.SubmissionDate |> Option.bind DateTime.tryFromString
         let datePublished = study.PublicReleaseDate |> Option.bind DateTime.tryFromString
         let dateModified = System.DateTime.Now
@@ -33,8 +34,9 @@ type StudyConversion =
             |> ResizeArray
             |> Option.fromSeq
         let fragmentDescriptors =
-            study.Datamap
-            |> Option.map DatamapConversion.composeFragmentDescriptors
+            match study.Datamap with
+            | Some d when includeDatamap -> Some (DatamapConversion.composeFragmentDescriptors d)
+            | _ -> None
         let dataFiles = 
             processSequence
             |> Option.map (fun ps -> AssayConversion.getDataFilesFromProcesses(ps, ?fragmentDescriptors = fragmentDescriptors))

--- a/src/ARCtrl/Conversion/Table.fs
+++ b/src/ARCtrl/Conversion/Table.fs
@@ -119,6 +119,18 @@ module TableTypeExtensions =
                 ]
                 //|> ProcessConversion.mergeIdenticalProcesses
 
+        /// Returns the list of processes specified in this ArcTable, grouping rows with identical process-level metadata.
+        ///
+        /// Parameter values (and other process-level fields) are taken from the first row of each group.
+        /// Inputs and outputs of all grouped rows are aggregated in order.
+        member this.GetProcessesGroupedByParameters(?assayName, ?studyName, ?fs : FileSystem) : LDNode list =
+            if this.RowCount = 0 then
+                LDLabProcess.create(name = this.Name)
+                |> List.singleton
+            else
+                let getter = ProcessConversion.getGroupedProcessGetter assayName studyName this.Name this.Headers fs
+                getter this
+
 
         /// Create a new table from a list of processes
         ///
@@ -138,6 +150,12 @@ module TableTypeExtensions =
             this.Tables
             |> Seq.toList
             |> List.collect (fun t -> t.GetProcesses(?assayName = assayName, ?studyName = studyName, ?fs = fs))
+
+        /// Return a list of grouped processes in all tables.
+        member this.GetProcessesGroupedByParameters(?assayName, ?studyName, ?fs) : LDNode list =
+            this.Tables
+            |> Seq.toList
+            |> List.collect (fun t -> t.GetProcessesGroupedByParameters(?assayName = assayName, ?studyName = studyName, ?fs = fs))
 
         /// Create a collection of tables from a list of processes.
         ///

--- a/src/ARCtrl/Conversion/Workflow.fs
+++ b/src/ARCtrl/Conversion/Workflow.fs
@@ -503,7 +503,8 @@ type WorkflowConversion =
             WorkflowConversion.decomposeWorkflowProtocolToToolDescription(protocol, ?context = context, ?graph = graph)
             |> CWL.CommandLineTool              
 
-    static member composeWorkflow (workflow : ArcWorkflow, ?fs : FileSystem) =
+    static member composeWorkflow (workflow : ArcWorkflow, ?fs : FileSystem, ?skipDatamap) =
+        let includeDatamap = defaultArg skipDatamap false |> not
         let workflowProtocol =
             let workflowFilePath = Identifier.Workflow.cwlFileNameFromIdentifier workflow.Identifier
             match workflow.CWLDescription with
@@ -534,8 +535,9 @@ type WorkflowConversion =
         //        )
         //    LDLabProtocol.set(workflowProtocol, inputs)
         let fragmentDescriptors =
-            workflow.Datamap
-            |> Option.map DatamapConversion.composeFragmentDescriptors
+            match workflow.Datamap with
+            | Some d when includeDatamap -> Some (DatamapConversion.composeFragmentDescriptors d)
+            | _ -> None
         let dataFiles =
             fragmentDescriptors
             |> Option.defaultValue (ResizeArray [])

--- a/src/ARCtrl/Json.fs
+++ b/src/ARCtrl/Json.fs
@@ -80,7 +80,7 @@ module JsonHelper =
     [<AttachMembers>]
     type ARCJson() =
         member _.fromROCrateJsonString (s: string) = ARC.fromROCrateJsonString s
-        member _.toROCrateJsonString(?spaces) = ARC.toROCrateJsonString(?spaces=spaces)
+        member _.toROCrateJsonString(?spaces, ?groupProcesses, ?ignoreBrokenWR) = ARC.toROCrateJsonString(?spaces=spaces, ?groupProcesses = groupProcesses, ?ignoreBrokenWR = ignoreBrokenWR)
 
     [<AttachMembers>]
     type LDGraphJson() =

--- a/src/ARCtrl/JsonIO/LDObject.fs
+++ b/src/ARCtrl/JsonIO/LDObject.fs
@@ -3,7 +3,6 @@ namespace ARCtrl.Json
 open ARCtrl
 open ARCtrl.ROCrate
 open System
-open ARCtrl.ROCrate
 open Thoth.Json.Core
 open DynamicObj
 open Fable.Core
@@ -34,7 +33,7 @@ module LDNodeExtensions =
         static member toROCrateJsonString(node : LDNode, ?spaces) =
             LDNode.encoder node
             |> Encode.toJsonString (Encode.defaultSpaces spaces)
-
+        
 [<AutoOpen>]
 module LDGraphExtensions =
 

--- a/src/ARCtrl/ROCrateIO.fs
+++ b/src/ARCtrl/ROCrateIO.fs
@@ -55,7 +55,7 @@ module ARC =
 
         static member getAsGraph (isa : ArcInvestigation, ?license : License, ?fs : FileSystem, ?ignoreBrokenWR) =
             let license = ROCrate.createLicenseNode(license)
-            let isa = isa.ToROCrateInvestigation(?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
+            let isa = isa.ToROCrateInvestigation(?groupProcesses = groupProcesses, ?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
             LDDataset.setSDDatePublishedAsDateTime(isa, System.DateTime.Now)
             LDDataset.setLicenseAsCreativeWork(isa, license)
             let graph = isa.Flatten()

--- a/src/ARCtrl/ROCrateIO.fs
+++ b/src/ARCtrl/ROCrateIO.fs
@@ -53,7 +53,7 @@ module ARC =
             | path, Some text -> Some (License(contentType = Fulltext,content = text, path = path))
             | path, None -> Some (License(contentType = Fulltext,content = "", path = path))
 
-        static member getAsGraph (isa : ArcInvestigation, ?license : License, ?fs : FileSystem, ?ignoreBrokenWR) =
+        static member getAsGraph (isa : ArcInvestigation, ?license : License, ?groupProcesses, ?fs : FileSystem, ?ignoreBrokenWR) =
             let license = ROCrate.createLicenseNode(license)
             let isa = isa.ToROCrateInvestigation(?groupProcesses = groupProcesses, ?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
             LDDataset.setSDDatePublishedAsDateTime(isa, System.DateTime.Now)
@@ -65,8 +65,8 @@ module ARC =
             graph.Compact_InPlace()
             graph
 
-        static member encoder (isa : ArcInvestigation, ?license : License, ?fs : FileSystem, ?ignoreBrokenWR) =
-            let graph = ROCrate.getAsGraph(isa, ?license = license, ?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
+        static member encoder (isa : ArcInvestigation, ?license : License, ?groupProcesses, ?fs : FileSystem, ?ignoreBrokenWR) =
+            let graph = ROCrate.getAsGraph(isa, ?license = license, ?groupProcesses = groupProcesses,?fs = fs, ?ignoreBrokenWR = ignoreBrokenWR)
             LDGraph.encoder graph
 
         /// Returns ArcInvestigation, list of file Ids, and optional License

--- a/src/ARCtrl/Yaml.fs
+++ b/src/ARCtrl/Yaml.fs
@@ -2,6 +2,8 @@ namespace ARCtrl
 
 open ARCtrl.CWL
 open Fable.Core
+open ARCtrl.ROCrate
+open ARCtrl.Yaml
 
 module YamlHelper =
 
@@ -27,9 +29,21 @@ module YamlHelper =
                 |> Seq.toList
             Encode.yMap pairs |> Encode.writeYaml
 
+    [<AttachMembers>]
+    type LDGraphYAML() =
+        member _.fromROCrateYamlString (s : string)  = LDGraph.fromROCrateYamlString s
+        member _.toROCrateYamlString(?spaces) = LDGraph.toROCrateYamlString(?spaces=spaces)
+
+    [<AttachMembers>]
+    type LDNodeYAML() =
+        member _.fromROCrateYamlString (s : string) = LDNode.fromROCrateYamlString s
+        member _.toROCrateYamlString(?spaces) = LDNode.toROCrateYamlString(?spaces=spaces)
+
 open YamlHelper
 
 [<AttachMembers>]
 type YamlController =
     static member ProcessingUnit = ProcessingUnitYAML()
     static member ParameterReference = ParameterReferenceYAML()
+    static member LDNode = LDNodeYAML()
+    static member LDGraph = LDGraphYAML()

--- a/src/ARCtrl/YamlIO.fs
+++ b/src/ARCtrl/YamlIO.fs
@@ -1,0 +1,60 @@
+namespace ARCtrl.Yaml
+
+open ARCtrl
+open System
+open ARCtrl.ROCrate
+open DynamicObj
+open YAMLicious
+open Fable.Core
+
+[<AutoOpen>]
+module LDNodeExtensions =
+
+    type LDNode with
+
+        static member fromROCrateYamlString (s:string) = 
+            ARCtrl.Yaml.Decode.fromYamlString ARCtrl.Yaml.ROCrate.LDNode.decoder s
+
+        static member toROCrateYamlString(?spaces) =
+            fun (obj:LDNode) ->
+                ARCtrl.Yaml.ROCrate.LDNode.encoder obj
+                |> ARCtrl.Yaml.Encode.toYamlString (ARCtrl.Yaml.Encode.defaultWhitespace spaces)
+
+        member this.ToROCrateYamlString(?spaces) =
+            LDNode.toROCrateYamlString(?spaces=spaces) this
+
+    [<AttachMembers>]
+    type PyJsInterop =
+
+        static member fromROCrateYamlString (s:string) = 
+            ARCtrl.Yaml.Decode.fromYamlString ARCtrl.Yaml.ROCrate.LDNode.decoder s
+
+        static member toROCrateYamlString(node : LDNode, ?spaces) =
+            ARCtrl.Yaml.ROCrate.LDNode.encoder node
+            |> ARCtrl.Yaml.Encode.toYamlString (ARCtrl.Yaml.Encode.defaultWhitespace spaces)
+[<AutoOpen>]
+module LDGraphExtensions =
+
+    type LDGraph with
+
+        static member fromROCrateYamlString (s:string) = 
+            ARCtrl.Yaml.Decode.fromYamlString ARCtrl.Yaml.ROCrate.LDGraph.decoder s
+
+        static member toROCrateYamlString(?spaces) =
+            fun (obj:LDGraph) ->
+                ARCtrl.Yaml.ROCrate.LDGraph.encoder obj
+                |> ARCtrl.Yaml.Encode.toYamlString (ARCtrl.Yaml.Encode.defaultWhitespace spaces)
+
+        member this.ToROCrateYamlString(?spaces) =
+            LDGraph.toROCrateYamlString(?spaces=spaces) this
+
+
+    [<AttachMembers>]
+    type PyJsInterop =
+
+        static member fromROCrateYamlString (s:string) = 
+            ARCtrl.Yaml.Decode.fromYamlString ARCtrl.Yaml.ROCrate.LDGraph.decoder s
+
+        static member toROCrateYamlString(graph : LDGraph, ?spaces) =
+            ARCtrl.Yaml.ROCrate.LDGraph.encoder graph
+            |> ARCtrl.Yaml.Encode.toYamlString (ARCtrl.Yaml.Encode.defaultWhitespace spaces)

--- a/src/Json/Encode.fs
+++ b/src/Json/Encode.fs
@@ -73,6 +73,11 @@ module Encode =
             |> Seq.map encoder
             |> Encode.seq
 
+    let orderedList (values: list<IEncodable>) =   
+        values
+        |> Encode.list
+        |> fun s -> Encode.object [ "@list", s]
+
     let dictionary (keyEncoder : Encoder<'key>) (valueEncoder : Encoder<'value>) (values: System.Collections.Generic.IDictionary<'key, 'value>) =
         if values.Count = 0 then
             Encode.nil

--- a/src/Json/ROCrate/LDNode.fs
+++ b/src/Json/ROCrate/LDNode.fs
@@ -43,7 +43,8 @@ module rec LDNode =
         | SomeObj o -> genericEncoder o
         #endif
         | null -> Encode.nil
-        | :? System.Collections.IEnumerable as l -> [ for x in l -> genericEncoder x] |> Encode.list
+        | :? System.Collections.IEnumerable as l ->
+            [ for x in l -> genericEncoder x] |> Encode.list //|> Encode.orderedList
         | _ -> failwith "Unknown type"
 
     let rec encoder(obj: LDNode) =

--- a/src/Yaml/ARCtrl.Yaml.fsproj
+++ b/src/Yaml/ARCtrl.Yaml.fsproj
@@ -10,15 +10,22 @@
   <ItemGroup>
     <Compile Include="Encode.fs" />
     <Compile Include="Decode.fs" />
+    <Compile Include="ROCrate\Helpers.fs" />
+    <Compile Include="ROCrate\LDContext.fs" />
+    <Compile Include="ROCrate\LDValue.fs" />
+    <Compile Include="ROCrate\LDRef.fs" />
+    <Compile Include="ROCrate\LDNode.fs" />
+    <Compile Include="ROCrate\LDGraph.fs" />
     <Compile Include="ValidationPackage.fs" />
     <Compile Include="ValidationPackagesConfig.fs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YAMLicious"/>
+    <PackageReference Include="YAMLicious" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\ARCtrl.Core.fsproj" />
+    <ProjectReference Include="..\ROCrate\ARCtrl.ROCrate.fsproj" />
     <ProjectReference Include="..\ValidationPackages\ARCtrl.ValidationPackages.fsproj" />
   </ItemGroup>
 </Project>

--- a/src/Yaml/ROCrate/Helpers.fs
+++ b/src/Yaml/ROCrate/Helpers.fs
@@ -1,0 +1,135 @@
+namespace ARCtrl.Yaml.ROCrate
+
+open System
+open System.Globalization
+open YAMLicious.YAMLiciousTypes
+
+module Helpers =
+
+    let private keyAliases =
+        dict [
+            "id", "@id"
+            "type", "@type"
+            "context", "@context"
+            "value", "@value"
+            "graph", "@graph"
+        ]
+
+    let private normalizeKey (key: string) =
+        let k = key.Trim().Trim('"').Trim('\'')
+        match keyAliases.TryGetValue(k) with
+        | true, canonical -> canonical
+        | _ -> k
+
+    let sanitizeROCrateYamlKeys (yaml: string) =
+        let replaceKey (source: string) (target: string) (text: string) =
+            text
+            |> fun t -> t.Replace($"'{source}':", $"{target}:")
+            |> fun t -> t.Replace($"\"{source}\":", $"{target}:")
+            |> fun t -> t.Replace($"{source}:", $"{target}:")
+
+        yaml
+        |> replaceKey "@id" "id"
+        |> replaceKey "@type" "type"
+        |> replaceKey "@context" "context"
+        |> replaceKey "@value" "value"
+        |> replaceKey "@graph" "graph"
+
+    let unwrapSingleObject = function
+        | YAMLElement.Object [single] ->
+            match single with
+            | YAMLElement.Mapping _ -> YAMLElement.Object [single]
+            | _ -> single
+        | other -> other
+
+    let tryGetMappings = function
+        | YAMLElement.Object elements ->
+            elements
+            |> List.choose (function
+                | YAMLElement.Mapping (k, v) -> Some (normalizeKey k.Value, v)
+                | _ -> None
+            )
+            |> Some
+        | _ -> None
+
+    let getMappings element =
+        element
+        |> unwrapSingleObject
+        |> tryGetMappings
+        |> Option.defaultValue []
+
+    let tryGetField name element =
+        getMappings element
+        |> List.tryPick (fun (k, v) -> if normalizeKey k = name then Some v else None)
+
+    let requireField name element =
+        match tryGetField name element with
+        | Some value -> value
+        | None -> failwithf "Required field '%s' is missing." name
+
+    let tryDecodeString = function
+        | YAMLElement.Value v -> Some v.Value
+        | YAMLElement.Object [YAMLElement.Value v] -> Some v.Value
+        | _ -> None
+
+    let decodeString element =
+        match tryDecodeString element with
+        | Some s -> s
+        | None -> failwithf "Expected string-like YAML value but got %A" element
+
+    let tryDecodeStringResizeArray element =
+        match unwrapSingleObject element with
+        | YAMLElement.Sequence elements ->
+            elements
+            |> List.map decodeString
+            |> ResizeArray
+            |> Some
+        | _ ->
+            tryDecodeString element
+            |> Option.map (fun s -> ResizeArray [s])
+
+    let decodeStringResizeArray element =
+        match tryDecodeStringResizeArray element with
+        | Some values -> values
+        | None -> failwithf "Expected string or sequence of strings but got %A" element
+
+    let tryDecodeSequence = function
+        | YAMLElement.Sequence elements -> Some elements
+        | YAMLElement.Object [YAMLElement.Sequence elements] -> Some elements
+        | _ -> None
+
+    let parseScalarToObj (value: string) : obj =
+        let text = value.Trim()
+
+        if text.Equals("null", StringComparison.OrdinalIgnoreCase) || text = "~" then
+            null
+        else
+            let mutable boolValue = false
+            let mutable intValue = 0
+            let mutable decimalValue = 0M
+            if Boolean.TryParse(text, &boolValue) then box boolValue
+            elif Int32.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, &intValue) then box intValue
+            elif Decimal.TryParse(text, NumberStyles.Number, CultureInfo.InvariantCulture, &decimalValue) then box decimalValue
+            else box value
+
+    let yamlValue (s: string) =
+        YAMLElement.Value (YAMLContent.create s)
+
+    let yamlMap (pairs: (string * YAMLElement) list) =
+        pairs
+        |> List.map (fun (k,v) -> YAMLElement.Mapping (YAMLContent.create k, v))
+        |> YAMLElement.Object
+
+    let yamlSeq (items: YAMLElement list) =
+        YAMLElement.Sequence items
+
+    let objToScalarYaml (value: obj) =
+        match value with
+        | null -> yamlValue "null"
+        | :? string as s -> yamlValue s
+        | :? int as i -> yamlValue (string i)
+        | :? bool as b -> yamlValue (if b then "true" else "false")
+        | :? float as f -> yamlValue (f.ToString(CultureInfo.InvariantCulture))
+        | :? decimal as d -> yamlValue (d.ToString(CultureInfo.InvariantCulture))
+        | :? DateTime as d -> yamlValue (d.ToString("O", CultureInfo.InvariantCulture))
+        | _ -> failwithf "Unsupported scalar type for YAML encoder: %s" (value.GetType().FullName)

--- a/src/Yaml/ROCrate/Helpers.fs
+++ b/src/Yaml/ROCrate/Helpers.fs
@@ -115,6 +115,7 @@ module Helpers =
             else box value
 
     let yamlValue (s: string) =
+        let s = if s.Contains("#") then $"\"{s}\"" else s
         YAMLElement.Value (YAMLContent.create s)
 
     let yamlMap (pairs: (string * YAMLElement) list) =

--- a/src/Yaml/ROCrate/Helpers.fs
+++ b/src/Yaml/ROCrate/Helpers.fs
@@ -116,11 +116,11 @@ module Helpers =
 
     let yamlValue (s: string) =
         let s = if s.Contains("#") then $"\"{s}\"" else s
-        YAMLElement.Value (YAMLContent.create s)
+        YAMLElement.Value (YAMLContent.create(s,style = ScalarStyle.Plain))
 
     let yamlMap (pairs: (string * YAMLElement) list) =
         pairs
-        |> List.map (fun (k,v) -> YAMLElement.Mapping (YAMLContent.create k, v))
+        |> List.map (fun (k,v) -> YAMLElement.Mapping (YAMLContent.create(k,style = ScalarStyle.Plain), v))
         |> YAMLElement.Object
 
     let yamlSeq (items: YAMLElement list) =

--- a/src/Yaml/ROCrate/Helpers.fs
+++ b/src/Yaml/ROCrate/Helpers.fs
@@ -6,34 +6,36 @@ open YAMLicious.YAMLiciousTypes
 
 module Helpers =
 
-    let private keyAliases =
-        dict [
-            "id", "@id"
-            "type", "@type"
-            "context", "@context"
-            "value", "@value"
-            "graph", "@graph"
-        ]
+    let normalizeKey (key: string) =
+        key.Trim().Trim('"').Trim('\'')
 
-    let private normalizeKey (key: string) =
-        let k = key.Trim().Trim('"').Trim('\'')
-        match keyAliases.TryGetValue(k) with
-        | true, canonical -> canonical
-        | _ -> k
+    let ensureSingleYamlDocument (yaml: string) =
+        let lines =
+            yaml.Replace("\r\n", "\n").Split('\n')
+            |> Array.map (fun l -> l.Trim())
 
-    let sanitizeROCrateYamlKeys (yaml: string) =
-        let replaceKey (source: string) (target: string) (text: string) =
-            text
-            |> fun t -> t.Replace($"'{source}':", $"{target}:")
-            |> fun t -> t.Replace($"\"{source}\":", $"{target}:")
-            |> fun t -> t.Replace($"{source}:", $"{target}:")
+        let nonEmpty = lines |> Array.filter (String.IsNullOrWhiteSpace >> not)
+        let separators =
+            lines
+            |> Array.indexed
+            |> Array.choose (fun (i, l) -> if l = "---" then Some i else None)
+
+        if separators.Length > 1 then
+            failwith "YAML-LD parser supports only a single YAML document in a stream."
+
+        if separators.Length = 1 then
+            let firstNonEmptyIndex =
+                lines
+                |> Array.tryFindIndex (String.IsNullOrWhiteSpace >> not)
+                |> Option.defaultValue 0
+
+            if separators.[0] <> firstNonEmptyIndex then
+                failwith "YAML-LD parser supports only a single YAML document in a stream."
+
+        if nonEmpty.Length = 0 then
+            failwith "YAML-LD document is empty."
 
         yaml
-        |> replaceKey "@id" "id"
-        |> replaceKey "@type" "type"
-        |> replaceKey "@context" "context"
-        |> replaceKey "@value" "value"
-        |> replaceKey "@graph" "graph"
 
     let unwrapSingleObject = function
         | YAMLElement.Object [single] ->

--- a/src/Yaml/ROCrate/LDContext.fs
+++ b/src/Yaml/ROCrate/LDContext.fs
@@ -1,0 +1,49 @@
+namespace ARCtrl.Yaml.ROCrate
+
+open ARCtrl.ROCrate
+open YAMLicious.YAMLiciousTypes
+
+module LDContext =
+
+    let rec decoder (value: YAMLElement) : LDContext =
+        match Helpers.unwrapSingleObject value with
+        | YAMLElement.Object _ ->
+            let context = ARCtrl.ROCrate.LDContext()
+            for (k, v) in Helpers.getMappings value do
+                context.AddMapping(k, Helpers.decodeString v)
+            context
+        | YAMLElement.Sequence items ->
+            let baseContexts = items |> List.map decoder |> ResizeArray
+            ARCtrl.ROCrate.LDContext(baseContexts = baseContexts)
+        | YAMLElement.Value v ->
+            let s = v.Value
+            if s = Context.proxy_V1_2DRAFT || s = Context.proxy_V1_2 then
+                Context.initV1_2()
+            elif s = Context.proxy_V1_1 then
+                Context.initV1_1()
+            else
+                failwithf "Unsupported context string: %s" s
+        | _ ->
+            failwithf "Unsupported @context YAML format: %A" value
+
+    let rec encoder (ctx: LDContext) =
+        match ctx.Name with
+        | Some Context.proxy_V1_2DRAFT -> Helpers.yamlValue Context.proxy_V1_2DRAFT
+        | Some Context.proxy_V1_2 -> Helpers.yamlValue Context.proxy_V1_2
+        | Some Context.proxy_V1_1 -> Helpers.yamlValue Context.proxy_V1_1
+        | _ ->
+            let mappings =
+                ctx.Mappings
+                |> Seq.map (fun kv -> kv.Key, Helpers.yamlValue (string kv.Value))
+                |> Seq.toList
+                |> Helpers.yamlMap
+            if ctx.BaseContexts.Count = 0 then
+                mappings
+            elif ctx.BaseContexts.Count = 1 && ctx.Mappings.Count = 0 then
+                ctx.BaseContexts.[0] |> encoder
+            else
+                ctx.BaseContexts
+                |> Seq.map encoder
+                |> Seq.append [if ctx.Mappings.Count <> 0 then mappings]
+                |> Seq.toList
+                |> Helpers.yamlSeq

--- a/src/Yaml/ROCrate/LDGraph.fs
+++ b/src/Yaml/ROCrate/LDGraph.fs
@@ -29,16 +29,16 @@ module LDGraph =
     let encoder (obj: ARCtrl.ROCrate.LDGraph) =
         [
             match obj.Id with
-            | Some id -> yield "@id", Helpers.yamlValue id
+            | Some id -> yield "\"@id\"", Helpers.yamlValue id
             | None -> ()
             match obj.TryGetContext() with
-            | Some ctx -> yield "@context", LDContext.encoder ctx
+            | Some ctx -> yield "\"@context\"", LDContext.encoder ctx
             | None -> ()
             for kv in (obj.GetProperties true) do
                 let l = kv.Key.ToLower()
                 if l <> "id" && l <> "@context" && l <> "nodes" && l <> "mappings" then
                     yield kv.Key, LDNode.genericEncoder kv.Value
-            yield "@graph", (obj.Nodes |> Seq.map LDNode.encoder |> Seq.toList |> Helpers.yamlSeq)
+            yield "\"@graph\"", (obj.Nodes |> Seq.map LDNode.encoder |> Seq.toList |> Helpers.yamlSeq)
         ]
         |> Helpers.yamlMap
 

--- a/src/Yaml/ROCrate/LDGraph.fs
+++ b/src/Yaml/ROCrate/LDGraph.fs
@@ -1,0 +1,52 @@
+namespace ARCtrl.Yaml.ROCrate
+
+open ARCtrl.ROCrate
+open YAMLicious.YAMLiciousTypes
+
+module LDGraph =
+
+    let decoder (value: YAMLElement) : ARCtrl.ROCrate.LDGraph =
+        let id = Helpers.tryGetField "@id" value |> Option.map Helpers.decodeString
+        let context = Helpers.tryGetField "@context" value |> Option.map LDContext.decoder
+        let graphValues = Helpers.requireField "@graph" value
+
+        let nodes =
+            match Helpers.tryDecodeSequence graphValues with
+            | Some elements -> elements |> List.map LDNode.decoder |> ResizeArray
+            | None -> failwithf "Expected '@graph' to be a sequence but got %A" graphValues
+
+        let graph = ARCtrl.ROCrate.LDGraph(?id = id, ?context = context)
+
+        for (property, propertyValue) in Helpers.getMappings value do
+            if property <> "@id" && property <> "@graph" && property <> "@context" then
+                graph.SetProperty(property, LDNode.genericDecoder propertyValue)
+
+        for node in nodes do
+            graph.AddNode node
+
+        graph
+
+    let encoder (obj: ARCtrl.ROCrate.LDGraph) =
+        [
+            match obj.Id with
+            | Some id -> yield "@id", Helpers.yamlValue id
+            | None -> ()
+            match obj.TryGetContext() with
+            | Some ctx -> yield "@context", LDContext.encoder ctx
+            | None -> ()
+            for kv in (obj.GetProperties true) do
+                let l = kv.Key.ToLower()
+                if l <> "id" && l <> "@context" && l <> "nodes" && l <> "mappings" then
+                    yield kv.Key, LDNode.genericEncoder kv.Value
+            yield "@graph", (obj.Nodes |> Seq.map LDNode.encoder |> Seq.toList |> Helpers.yamlSeq)
+        ]
+        |> Helpers.yamlMap
+
+    let fromROCrateYamlString (s: string) =
+        s
+        |> Helpers.sanitizeROCrateYamlKeys
+        |> ARCtrl.Yaml.Decode.fromYamlString decoder
+
+    let toROCrateYamlString (whitespace: int option) (obj: ARCtrl.ROCrate.LDGraph) =
+        encoder obj
+        |> ARCtrl.Yaml.Encode.toYamlString (ARCtrl.Yaml.Encode.defaultWhitespace whitespace)

--- a/src/Yaml/ROCrate/LDGraph.fs
+++ b/src/Yaml/ROCrate/LDGraph.fs
@@ -44,7 +44,7 @@ module LDGraph =
 
     let fromROCrateYamlString (s: string) =
         s
-        |> Helpers.sanitizeROCrateYamlKeys
+        |> Helpers.ensureSingleYamlDocument
         |> ARCtrl.Yaml.Decode.fromYamlString decoder
 
     let toROCrateYamlString (whitespace: int option) (obj: ARCtrl.ROCrate.LDGraph) =

--- a/src/Yaml/ROCrate/LDNode.fs
+++ b/src/Yaml/ROCrate/LDNode.fs
@@ -1,0 +1,105 @@
+namespace ARCtrl.Yaml.ROCrate
+
+open ARCtrl.ROCrate
+open YAMLicious.YAMLiciousTypes
+
+module rec LDNode =
+
+    #if !FABLE_COMPILER
+    let (|SomeObj|_|) =
+        let ty = typedefof<option<_>>
+        fun (a:obj) ->
+            if isNull a then
+                None
+            else
+                let aty = a.GetType()
+                let v = aty.GetProperty("Value")
+                if aty.IsGenericType && aty.GetGenericTypeDefinition() = ty then
+                    Some(v.GetValue(a, [| |]))
+                else
+                    None
+    #endif
+
+    let rec genericDecoder (value: YAMLElement) : obj =
+        match Helpers.unwrapSingleObject value with
+        | YAMLElement.Value v -> Helpers.parseScalarToObj v.Value
+        | YAMLElement.Sequence elements ->
+            elements
+            |> List.map genericDecoder
+            |> ResizeArray
+            |> box
+        | YAMLElement.Object _ when Helpers.tryGetField "@value" value |> Option.isSome ->
+            LDValue.decoder value |> box
+        | YAMLElement.Object _ when Helpers.tryGetField "@type" value |> Option.isSome ->
+            decoder value |> box
+        | YAMLElement.Object _ when Helpers.tryGetField "@id" value |> Option.isSome ->
+            LDRef.decoder value |> box
+        | _ ->
+            failwithf "Unsupported YAML element for generic RO-Crate value: %A" value
+
+    let rec genericEncoder (obj : obj) =
+        match obj with
+        | :? string as s -> Helpers.yamlValue s
+        | :? int as i -> Helpers.yamlValue (string i)
+        | :? bool as b -> Helpers.yamlValue (if b then "true" else "false")
+        | :? float as f -> Helpers.yamlValue (f.ToString(System.Globalization.CultureInfo.InvariantCulture))
+        | :? System.DateTime as d -> Helpers.yamlValue (d.ToString("O", System.Globalization.CultureInfo.InvariantCulture))
+        | :? LDValue as v -> LDValue.encoder v
+        | :? LDRef as r -> LDRef.encoder r
+        | :? ARCtrl.ROCrate.LDNode as o -> encoder o
+        #if !FABLE_COMPILER
+        | SomeObj o -> genericEncoder o
+        #endif
+        | null -> Helpers.yamlValue "null"
+        | :? System.Collections.IEnumerable as l ->
+            l
+            |> Seq.cast<obj>
+            |> Seq.map genericEncoder
+            |> Seq.toList
+            |> Helpers.yamlSeq
+        | _ -> failwith "Unknown type"
+
+    and decoder (value: YAMLElement) : ARCtrl.ROCrate.LDNode =
+        let schemaType = Helpers.requireField "@type" value |> Helpers.decodeStringResizeArray
+        let id = Helpers.requireField "@id" value |> Helpers.decodeString
+        let context = Helpers.tryGetField "@context" value |> Option.map LDContext.decoder
+        let additionalType = Helpers.tryGetField "additionalType" value |> Option.map Helpers.decodeStringResizeArray
+
+        let node = ARCtrl.ROCrate.LDNode(id, schemaType, ?additionalType = additionalType)
+
+        for (property, propertyValue) in Helpers.getMappings value do
+            if property <> "@id" && property <> "@type" && property <> "@context" then
+                let decoded = genericDecoder propertyValue
+                if decoded <> null then
+                    node.SetProperty(property, decoded)
+
+        match context with
+        | Some ctx -> node.SetContext ctx
+        | None -> ()
+
+        node
+
+    and encoder (obj: ARCtrl.ROCrate.LDNode) =
+        [
+            yield "@id", Helpers.yamlValue obj.Id
+            yield "@type", (obj.SchemaType |> Seq.map Helpers.yamlValue |> Seq.toList |> Helpers.yamlSeq)
+            if obj.AdditionalType.Count <> 0 then
+                yield "additionalType", (obj.AdditionalType |> Seq.map Helpers.yamlValue |> Seq.toList |> Helpers.yamlSeq)
+            match obj.TryGetContext() with
+            | Some ctx -> yield "@context", LDContext.encoder ctx
+            | _ -> ()
+            for kv in (obj.GetProperties true) do
+                let l = kv.Key.ToLower()
+                if l <> "id" && l <> "schematype" && l <> "additionaltype" && l <> "@context" && (l.StartsWith("init@") |> not) && (l.StartsWith("init_") |> not) then
+                    yield kv.Key, genericEncoder kv.Value
+        ]
+        |> Helpers.yamlMap
+
+    let fromROCrateYamlString (s: string) =
+        s
+        |> Helpers.sanitizeROCrateYamlKeys
+        |> ARCtrl.Yaml.Decode.fromYamlString decoder
+
+    let toROCrateYamlString (whitespace: int option) (obj: ARCtrl.ROCrate.LDNode) =
+        encoder obj
+        |> ARCtrl.Yaml.Encode.toYamlString (ARCtrl.Yaml.Encode.defaultWhitespace whitespace)

--- a/src/Yaml/ROCrate/LDNode.fs
+++ b/src/Yaml/ROCrate/LDNode.fs
@@ -97,7 +97,7 @@ module rec LDNode =
 
     let fromROCrateYamlString (s: string) =
         s
-        |> Helpers.sanitizeROCrateYamlKeys
+        |> Helpers.ensureSingleYamlDocument
         |> ARCtrl.Yaml.Decode.fromYamlString decoder
 
     let toROCrateYamlString (whitespace: int option) (obj: ARCtrl.ROCrate.LDNode) =

--- a/src/Yaml/ROCrate/LDNode.fs
+++ b/src/Yaml/ROCrate/LDNode.fs
@@ -57,7 +57,7 @@ module rec LDNode =
             |> Seq.map genericEncoder
             |> Seq.toList
             |> Helpers.yamlSeq
-        | _ -> failwith "Unknown type"
+        | _ -> failwith $"Could not encode object {obj}: Unknown type"
 
     and decoder (value: YAMLElement) : ARCtrl.ROCrate.LDNode =
         let schemaType = Helpers.requireField "@type" value |> Helpers.decodeStringResizeArray

--- a/src/Yaml/ROCrate/LDNode.fs
+++ b/src/Yaml/ROCrate/LDNode.fs
@@ -81,12 +81,12 @@ module rec LDNode =
 
     and encoder (obj: ARCtrl.ROCrate.LDNode) =
         [
-            yield "@id", Helpers.yamlValue obj.Id
-            yield "@type", (obj.SchemaType |> Seq.map Helpers.yamlValue |> Seq.toList |> Helpers.yamlSeq)
+            yield "\"@id\"", Helpers.yamlValue obj.Id
+            yield "\"@type\"", (obj.SchemaType |> Seq.map Helpers.yamlValue |> Seq.toList |> Helpers.yamlSeq)
             if obj.AdditionalType.Count <> 0 then
                 yield "additionalType", (obj.AdditionalType |> Seq.map Helpers.yamlValue |> Seq.toList |> Helpers.yamlSeq)
             match obj.TryGetContext() with
-            | Some ctx -> yield "@context", LDContext.encoder ctx
+            | Some ctx -> yield "\"@context\"", LDContext.encoder ctx
             | _ -> ()
             for kv in (obj.GetProperties true) do
                 let l = kv.Key.ToLower()

--- a/src/Yaml/ROCrate/LDRef.fs
+++ b/src/Yaml/ROCrate/LDRef.fs
@@ -1,0 +1,16 @@
+namespace ARCtrl.Yaml.ROCrate
+
+open ARCtrl.ROCrate
+open YAMLicious.YAMLiciousTypes
+
+module LDRef =
+
+    let decoder (value: YAMLElement) : LDRef =
+        let id = Helpers.requireField "@id" value |> Helpers.decodeString
+        LDRef(id)
+
+    let encoder (r: LDRef) =
+        [
+            "@id", Helpers.yamlValue r.Id
+        ]
+        |> Helpers.yamlMap

--- a/src/Yaml/ROCrate/LDRef.fs
+++ b/src/Yaml/ROCrate/LDRef.fs
@@ -11,6 +11,6 @@ module LDRef =
 
     let encoder (r: LDRef) =
         [
-            "@id", Helpers.yamlValue r.Id
+            "\"@id\"", Helpers.yamlValue r.Id
         ]
         |> Helpers.yamlMap

--- a/src/Yaml/ROCrate/LDValue.fs
+++ b/src/Yaml/ROCrate/LDValue.fs
@@ -1,0 +1,26 @@
+namespace ARCtrl.Yaml.ROCrate
+
+open ARCtrl.ROCrate
+open YAMLicious.YAMLiciousTypes
+
+module LDValue =
+
+    let genericDecoder (value: YAMLElement) : obj =
+        match Helpers.unwrapSingleObject value with
+        | YAMLElement.Value v -> Helpers.parseScalarToObj v.Value
+        | _ -> failwithf "Expected scalar value for @value but got %A" value
+
+    let decoder (value: YAMLElement) : LDValue =
+        let valueField = Helpers.requireField "@value" value |> genericDecoder
+        let valueType = Helpers.tryGetField "@type" value |> Option.map Helpers.decodeString
+        LDValue(valueField, ?valueType = valueType)
+
+    let genericEncoder (value : obj) =
+        Helpers.objToScalarYaml value
+
+    let encoder (v: LDValue) =
+        [
+            "@value", genericEncoder v.Value
+            "@type", Helpers.yamlValue v.ValueType
+        ]
+        |> Helpers.yamlMap

--- a/src/Yaml/ROCrate/LDValue.fs
+++ b/src/Yaml/ROCrate/LDValue.fs
@@ -20,7 +20,7 @@ module LDValue =
 
     let encoder (v: LDValue) =
         [
-            "@value", genericEncoder v.Value
-            "@type", Helpers.yamlValue v.ValueType
+            "\"@value\"", genericEncoder v.Value
+            "\"@type\"", Helpers.yamlValue v.ValueType
         ]
         |> Helpers.yamlMap

--- a/tests/ARCtrl/ROCrateConversion.Tests.fs
+++ b/tests/ARCtrl/ROCrateConversion.Tests.fs
@@ -783,6 +783,27 @@ let private tests_ArcTableProcess =
             Expect.arcTableEqual table expectedTable "Table should be equal"
         )
 
+        testCase "TwoRowsSameParamValue GetProcessesGroupedByParameters" (fun () ->
+            let t = twoRowsSameParamValue.Copy()
+            let processes = t.GetProcessesGroupedByParameters()
+            Expect.equal processes.Length 1 "Should have 1 grouped process"
+            let p = processes.[0]
+            let inputs = LDLabProcess.getObjects(p)
+            let outputs = LDLabProcess.getResults(p)
+            let pvs = LDLabProcess.getParameterValues(p)
+            Expect.equal inputs.Count 2 "Grouped process should have 2 inputs"
+            Expect.equal outputs.Count 2 "Grouped process should have 2 outputs"
+            Expect.equal pvs.Count 1 "Grouped process should have 1 parameter value"
+        )
+
+        testCase "TwoRowsSameParamValue GroupedGetAndFromProcesses" (fun () ->
+            let t = twoRowsSameParamValue.Copy()
+            let processes = t.GetProcessesGroupedByParameters()
+            let table = ArcTable.fromProcesses(tableName1,processes)
+            let expectedTable = t
+            Expect.arcTableEqual table expectedTable "Table should be equal"
+        )
+
         testCase "TwoRowsDifferentParamValues GetProcesses" (fun () ->
             let t = twoRowsDifferentParamValue.Copy()
             let processes = t.GetProcesses()
@@ -795,6 +816,12 @@ let private tests_ArcTableProcess =
             let table = ArcTable.fromProcesses(tableName1,processes)
             let expectedTable = t
             Expect.arcTableEqual table expectedTable "Table should be equal"
+        )
+
+        testCase "TwoRowsDifferentParamValues GetProcessesGroupedByParameters" (fun () ->
+            let t = twoRowsDifferentParamValue.Copy()
+            let processes = t.GetProcessesGroupedByParameters()
+            Expect.equal processes.Length 2 "Should have 2 grouped processes"
         )
 
         testCase "SingleRowWithProtocolREF GetProcesses" (fun () ->

--- a/tests/TestingUtils/TestObjects.Yaml/ROCrate.fs
+++ b/tests/TestingUtils/TestObjects.Yaml/ROCrate.fs
@@ -1,0 +1,185 @@
+/// YAML RO-Crate test objects for parser tests.
+module TestObjects.Yaml.ROCrate
+
+open System
+
+let private yaml (s: string) =
+    let lines = s.Replace("\r\n", "\n").Split('\n')
+    let content =
+        lines
+        |> Array.skipWhile String.IsNullOrWhiteSpace
+        |> Array.rev
+        |> Array.skipWhile String.IsNullOrWhiteSpace
+        |> Array.rev
+    let minIndent =
+        content
+        |> Array.filter (String.IsNullOrWhiteSpace >> not)
+        |> Array.map (fun l -> l.Length - l.TrimStart(' ').Length)
+        |> Array.min
+    content
+    |> Array.map (fun l -> if l.Length >= minIndent then l.Substring(minIndent) else l)
+    |> String.concat "\n"
+
+let context_DefinedTerm = yaml """
+annotationValue: http://schema.org/name
+category: http://schema.org/category
+unit: http://schema.org/unitCode
+id: @id
+type: @type
+value: @value
+"""
+
+let roCrate_minimal = yaml """
+@context: https://w3id.org/ro/crate/1.2/context
+@graph:
+  - @id: ro-crate-metadata.json
+    @type: CreativeWork
+    about:
+      @id: ./
+    conformsTo:
+      @id: https://w3id.org/ro/crate/1.2
+  - @id: ./
+    @type: Dataset
+"""
+
+let roCrate_withTopLevelProperties = yaml """
+@id: my-graph
+@context: https://w3id.org/ro/crate/1.2/context
+name: Example graph
+version: 2
+@graph:
+  - @id: ./
+    @type: Dataset
+"""
+
+let roCrate_invalidGraphNotSequence = yaml """
+@context: https://w3id.org/ro/crate/1.2/context
+@graph:
+  @id: ./
+  @type: Dataset
+"""
+
+let roCrate_missingGraph = yaml """
+@context: https://w3id.org/ro/crate/1.2/context
+"""
+
+module GenericObjects =
+
+    let onlyIDAndType = yaml """
+@id: MyIdentifier
+@type: MyType
+"""
+
+    let twoTypesAndID = yaml """
+@id: MyIdentifier
+@type:
+  - MyType
+  - MySecondType
+"""
+
+    let onlyID = yaml """
+@id: MyIdentifier
+"""
+
+    let onlyType = yaml """
+@type: MyType
+"""
+
+    let withStringFields = yaml """
+@id: MyIdentifier
+@type: MyType
+name: MyName
+description: MyDescription
+"""
+
+    let withIntFields = yaml """
+@id: MyIdentifier
+@type: MyType
+number: 42
+anotherNumber: 1337
+"""
+
+    let withStringArray = yaml """
+@id: MyIdentifier
+@type: MyType
+names:
+  - MyName
+  - MySecondName
+"""
+
+    let withExpandedStringFieldNoType = yaml """
+@id: MyIdentifier
+@type: MyType
+name:
+  @value: MyName
+"""
+
+    let withExpandedIntFieldWithType = yaml """
+@id: MyIdentifier
+@type: MyType
+number:
+  @value: 42
+  @type: http://www.w3.org/2001/XMLSchema#int
+"""
+
+    let withLDRefObject = yaml """
+@id: MyIdentifier
+@type: MyType
+nested:
+  @id: RefIdentifier
+"""
+
+    let withNestedObject = yaml """
+@id: OuterIdentifier
+@type: MyType
+nested:
+  @id: MyIdentifier
+  @type: MyType
+"""
+
+    let withObjectArray = yaml """
+@id: OuterIdentifier
+@type: MyType
+nested:
+  - @id: MyIdentifier
+    @type: MyType
+  - @id: MySecondIdentifier
+    @type: MyType
+"""
+
+    let withAdditionalTypeString = yaml """
+@id: MyIdentifier
+@type: MyType
+additionalType: additionalType
+"""
+
+    let withAdditionalTypeArray = yaml """
+@id: MyIdentifier
+@type: MyType
+additionalType:
+  - additionalType1
+  - additionalType2
+"""
+
+    let withNullValue = yaml """
+@id: MyIdentifier
+@type: MyType
+name: null
+"""
+
+    let withoutAtKeywords = yaml """
+id: MyIdentifier
+type: MyType
+"""
+
+    let withMixedFields = yaml """
+@id: OuterIdentifier
+@type: MyType
+name: MyName
+number: 42
+nested:
+  - @id: MyIdentifier
+    @type: MyType
+  - Value2
+  - 1337
+"""

--- a/tests/TestingUtils/TestObjects.Yaml/ROCrate.fs
+++ b/tests/TestingUtils/TestObjects.Yaml/ROCrate.fs
@@ -24,146 +24,146 @@ let context_DefinedTerm = yaml """
 annotationValue: http://schema.org/name
 category: http://schema.org/category
 unit: http://schema.org/unitCode
-id: @id
-type: @type
-value: @value
+id: "@id"
+type: "@type"
+value: "@value"
 """
 
 let roCrate_minimal = yaml """
-@context: https://w3id.org/ro/crate/1.2/context
-@graph:
-  - @id: ro-crate-metadata.json
-    @type: CreativeWork
+"@context": https://w3id.org/ro/crate/1.2/context
+"@graph":
+  - "@id": ro-crate-metadata.json
+    "@type": CreativeWork
     about:
-      @id: ./
+      "@id": ./
     conformsTo:
-      @id: https://w3id.org/ro/crate/1.2
-  - @id: ./
-    @type: Dataset
+      "@id": https://w3id.org/ro/crate/1.2
+  - "@id": ./
+    "@type": Dataset
 """
 
 let roCrate_withTopLevelProperties = yaml """
-@id: my-graph
-@context: https://w3id.org/ro/crate/1.2/context
+"@id": my-graph
+"@context": https://w3id.org/ro/crate/1.2/context
 name: Example graph
 version: 2
-@graph:
-  - @id: ./
-    @type: Dataset
+"@graph":
+  - "@id": ./
+    "@type": Dataset
 """
 
 let roCrate_invalidGraphNotSequence = yaml """
-@context: https://w3id.org/ro/crate/1.2/context
-@graph:
-  @id: ./
-  @type: Dataset
+"@context": https://w3id.org/ro/crate/1.2/context
+"@graph":
+  "@id": ./
+  "@type": Dataset
 """
 
 let roCrate_missingGraph = yaml """
-@context: https://w3id.org/ro/crate/1.2/context
+"@context": https://w3id.org/ro/crate/1.2/context
 """
 
 module GenericObjects =
 
     let onlyIDAndType = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 """
 
     let twoTypesAndID = yaml """
-@id: MyIdentifier
-@type:
+"@id": MyIdentifier
+"@type":
   - MyType
   - MySecondType
 """
 
     let onlyID = yaml """
-@id: MyIdentifier
+"@id": MyIdentifier
 """
 
     let onlyType = yaml """
-@type: MyType
+"@type": MyType
 """
 
     let withStringFields = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 name: MyName
 description: MyDescription
 """
 
     let withIntFields = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 number: 42
 anotherNumber: 1337
 """
 
     let withStringArray = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 names:
   - MyName
   - MySecondName
 """
 
     let withExpandedStringFieldNoType = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 name:
-  @value: MyName
+  "@value": MyName
 """
 
     let withExpandedIntFieldWithType = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 number:
-  @value: 42
-  @type: http://www.w3.org/2001/XMLSchema#int
+  "@value": 42
+  "@type": http://www.w3.org/2001/XMLSchema#int
 """
 
     let withLDRefObject = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 nested:
-  @id: RefIdentifier
+  "@id": RefIdentifier
 """
 
     let withNestedObject = yaml """
-@id: OuterIdentifier
-@type: MyType
+"@id": OuterIdentifier
+"@type": MyType
 nested:
-  @id: MyIdentifier
-  @type: MyType
+  "@id": MyIdentifier
+  "@type": MyType
 """
 
     let withObjectArray = yaml """
-@id: OuterIdentifier
-@type: MyType
+"@id": OuterIdentifier
+"@type": MyType
 nested:
-  - @id: MyIdentifier
-    @type: MyType
-  - @id: MySecondIdentifier
-    @type: MyType
+  - "@id": MyIdentifier
+    "@type": MyType
+  - "@id": MySecondIdentifier
+    "@type": MyType
 """
 
     let withAdditionalTypeString = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 additionalType: additionalType
 """
 
     let withAdditionalTypeArray = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 additionalType:
   - additionalType1
   - additionalType2
 """
 
     let withNullValue = yaml """
-@id: MyIdentifier
-@type: MyType
+"@id": MyIdentifier
+"@type": MyType
 name: null
 """
 
@@ -173,13 +173,13 @@ type: MyType
 """
 
     let withMixedFields = yaml """
-@id: OuterIdentifier
-@type: MyType
+"@id": OuterIdentifier
+"@type": MyType
 name: MyName
 number: 42
 nested:
-  - @id: MyIdentifier
-    @type: MyType
+  - "@id": MyIdentifier
+    "@type": MyType
   - Value2
   - 1337
 """

--- a/tests/TestingUtils/TestingUtils.fsproj
+++ b/tests/TestingUtils/TestingUtils.fsproj
@@ -23,6 +23,8 @@
     <Compile Include="TestObjects.ROCrate\ArcPrototype_ed123499_deprecated.fs" />
     <Compile Include="TestObjects.Json\Study.fs" />
     <Compile Include="TestObjects.Json\ROCrate.fs" />
+    <Compile Include="TestObjects.Yaml\ROCrate.fs" />
+    <Compile Include="TestObjects.Yaml\ROCrate.fs" />
     <Content Include="TestObjects.Json\MinimalJson.json" />
     <Compile Include="TestObjects.Json\Assay.fs" />
     <Compile Include="TestObjects.Json\Investigation.fs" />

--- a/tests/Yaml/ARCtrl.Yaml.Tests.fsproj
+++ b/tests/Yaml/ARCtrl.Yaml.Tests.fsproj
@@ -6,6 +6,9 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ROCrate.LDContext.Tests.fs" />
+    <Compile Include="ROCrate.LDGraph.Tests.fs" />
+    <Compile Include="ROCrate.LDNode.Tests.fs" />
     <Compile Include="ValidationPackage.Tests.fs" />
     <Compile Include="ValidationPackageConfig.Tests.fs" />
     <Compile Include="Main.fs" />

--- a/tests/Yaml/Main.fs
+++ b/tests/Yaml/Main.fs
@@ -5,6 +5,9 @@ open Fable.Pyxpecto
 let all = testSequenced <| testList "Yaml" [
     Tests.ValidationPackage.main
     Tests.ValidationPackagesConfig.main
+    Tests.ROCrate.LDContext.main
+    Tests.ROCrate.LDNode.main
+    Tests.ROCrate.LDGraph.main
 ]
 
 #if !TESTS_ALL

--- a/tests/Yaml/ROCrate.LDContext.Tests.fs
+++ b/tests/Yaml/ROCrate.LDContext.Tests.fs
@@ -1,0 +1,35 @@
+module Tests.ROCrate.LDContext
+
+open TestingUtils
+open ARCtrl.Yaml.ROCrate
+
+let private contextYaml =
+    """
+annotationValue: http://schema.org/name
+category: http://schema.org/category
+unit: http://schema.org/unitCode
+id: '@id'
+type: '@type'
+value: '@value'
+"""
+
+let private readTests = testList "Read" [
+    testCase "DefinedTerm" <| fun _ ->
+        let context = ARCtrl.Yaml.Decode.fromYamlString LDContext.decoder contextYaml
+        let resolvedName = Expect.wantSome (context.TryResolveTerm("annotationValue")) "Could not resolve term"
+        Expect.equal resolvedName "http://schema.org/name" "term was not resolved correctly"
+        Expect.hasLength context.Mappings 6 "context was not read correctly"
+]
+
+let private writeTests = testList "Write" [
+    testCase "Roundtrip" <| fun _ ->
+        let context = ARCtrl.Yaml.Decode.fromYamlString LDContext.decoder contextYaml
+        let yaml = LDContext.encoder context |> ARCtrl.Yaml.Encode.toYamlString 2
+        let parsed = ARCtrl.Yaml.Decode.fromYamlString LDContext.decoder yaml
+        Expect.equal parsed context "context was not written/read correctly"
+]
+
+let main = testList "ROCrate.LDContext" [
+    readTests
+    writeTests
+]

--- a/tests/Yaml/ROCrate.LDContext.Tests.fs
+++ b/tests/Yaml/ROCrate.LDContext.Tests.fs
@@ -3,27 +3,21 @@ module Tests.ROCrate.LDContext
 open TestingUtils
 open ARCtrl.Yaml.ROCrate
 
-let private contextYaml =
-    """
-annotationValue: http://schema.org/name
-category: http://schema.org/category
-unit: http://schema.org/unitCode
-id: '@id'
-type: '@type'
-value: '@value'
-"""
+module YamlFixtures = TestObjects.Yaml.ROCrate
 
 let private readTests = testList "Read" [
     testCase "DefinedTerm" <| fun _ ->
-        let context = ARCtrl.Yaml.Decode.fromYamlString LDContext.decoder contextYaml
+        let context = ARCtrl.Yaml.Decode.fromYamlString LDContext.decoder YamlFixtures.context_DefinedTerm
         let resolvedName = Expect.wantSome (context.TryResolveTerm("annotationValue")) "Could not resolve term"
+        let resolvedId = Expect.wantSome (context.TryResolveTerm("id")) "Could not resolve id term"
         Expect.equal resolvedName "http://schema.org/name" "term was not resolved correctly"
+        Expect.equal resolvedId "@id" "id keyword alias mapping should be preserved as a regular context term"
         Expect.hasLength context.Mappings 6 "context was not read correctly"
 ]
 
 let private writeTests = testList "Write" [
     testCase "Roundtrip" <| fun _ ->
-        let context = ARCtrl.Yaml.Decode.fromYamlString LDContext.decoder contextYaml
+        let context = ARCtrl.Yaml.Decode.fromYamlString LDContext.decoder YamlFixtures.context_DefinedTerm
         let yaml = LDContext.encoder context |> ARCtrl.Yaml.Encode.toYamlString 2
         let parsed = ARCtrl.Yaml.Decode.fromYamlString LDContext.decoder yaml
         Expect.equal parsed context "context was not written/read correctly"

--- a/tests/Yaml/ROCrate.LDGraph.Tests.fs
+++ b/tests/Yaml/ROCrate.LDGraph.Tests.fs
@@ -3,24 +3,13 @@ module Tests.ROCrate.LDGraph
 open TestingUtils
 open ARCtrl.ROCrate
 open ARCtrl.Yaml.ROCrate
+open DynamicObj
 
-let private roCrateMinimalYaml =
-    """
-'@context': https://w3id.org/ro/crate/1.2/context
-'@graph':
-  - '@id': ro-crate-metadata.json
-    '@type': CreativeWork
-    about:
-      '@id': ./
-    conformsTo:
-      '@id': https://w3id.org/ro/crate/1.2
-  - '@id': ./
-    '@type': Dataset
-"""
+module YamlFixtures = TestObjects.Yaml.ROCrate
 
 let private readTests = testList "Read" [
     testCase "Minimal_ROCrate" <| fun _ ->
-        let graph = LDGraph.fromROCrateYamlString roCrateMinimalYaml
+        let graph = LDGraph.fromROCrateYamlString YamlFixtures.roCrate_minimal
         Expect.isSome (graph.TryGetContext()) "context should exist"
         Expect.hasLength graph.Nodes 2 "should have 2 nodes"
 
@@ -31,11 +20,44 @@ let private readTests = testList "Read" [
 
         Expect.equal graph.Nodes.[0] firstExpectedNode "first node should be metadata"
         Expect.equal graph.Nodes.[1] secondExpectedNode "second node should be dataset"
+
+    testCase "TopLevelProperties_AreParsed" <| fun _ ->
+        let graph = LDGraph.fromROCrateYamlString YamlFixtures.roCrate_withTopLevelProperties
+        Expect.equal graph.Id (Some "my-graph") "graph id should be parsed"
+        let name = Expect.wantSome (DynObj.tryGetTypedPropertyValue<string> "name" graph) "custom string property should exist"
+        let version = Expect.wantSome (DynObj.tryGetTypedPropertyValue<int> "version" graph) "custom int property should exist"
+        Expect.equal name "Example graph" "custom string property should be parsed"
+        Expect.equal version 2 "custom int property should be parsed"
+        Expect.hasLength graph.Nodes 1 "graph should have one node"
+
+    testCase "Reject_Missing_Graph" <| fun _ ->
+        Expect.throws (fun () -> LDGraph.fromROCrateYamlString YamlFixtures.roCrate_missingGraph |> ignore) "@graph is required"
+
+    testCase "Reject_Graph_Not_Sequence" <| fun _ ->
+        Expect.throws (fun () -> LDGraph.fromROCrateYamlString YamlFixtures.roCrate_invalidGraphNotSequence |> ignore) "@graph must be a sequence"
+
+    testCase "Allow_SingleDocument_With_Leading_Separator" <| fun _ ->
+        let yaml = "---\n" + YamlFixtures.roCrate_minimal
+        let graph = LDGraph.fromROCrateYamlString yaml
+        Expect.hasLength graph.Nodes 2 "single document with leading separator should be accepted"
+
+    testCase "Reject_MultiDocument_Stream" <| fun _ ->
+        let yaml =
+            YamlFixtures.roCrate_minimal + "\n---\n'@context': https://w3id.org/ro/crate/1.2/context\n'@graph': []\n"
+        Expect.throws (fun () -> LDGraph.fromROCrateYamlString yaml |> ignore) "YAML-LD parser should reject multi-document streams"
+
+    testCase "LargeNodeCount" <| fun _ ->
+        let graph = LDGraph()
+        for i in 1 .. 1000 do
+            graph.AddNode(LDNode($"node{i}", ResizeArray ["Thing"])) |> ignore
+        let yaml = LDGraph.toROCrateYamlString (Some 2) graph
+        let graph2 = LDGraph.fromROCrateYamlString yaml
+        Expect.hasLength graph2.Nodes 1000 "should have 1000 nodes after roundtrip"
 ]
 
 let private writeTests = testList "Write" [
     testCase "Roundtrip" <| fun _ ->
-        let graph = LDGraph.fromROCrateYamlString roCrateMinimalYaml
+        let graph = LDGraph.fromROCrateYamlString YamlFixtures.roCrate_minimal
         let yaml = LDGraph.toROCrateYamlString (Some 2) graph
         let parsed = LDGraph.fromROCrateYamlString yaml
         Expect.equal parsed graph "graph roundtrip should preserve content"

--- a/tests/Yaml/ROCrate.LDGraph.Tests.fs
+++ b/tests/Yaml/ROCrate.LDGraph.Tests.fs
@@ -1,0 +1,47 @@
+module Tests.ROCrate.LDGraph
+
+open TestingUtils
+open ARCtrl.ROCrate
+open ARCtrl.Yaml.ROCrate
+
+let private roCrateMinimalYaml =
+    """
+'@context': https://w3id.org/ro/crate/1.2/context
+'@graph':
+  - '@id': ro-crate-metadata.json
+    '@type': CreativeWork
+    about:
+      '@id': ./
+    conformsTo:
+      '@id': https://w3id.org/ro/crate/1.2
+  - '@id': ./
+    '@type': Dataset
+"""
+
+let private readTests = testList "Read" [
+    testCase "Minimal_ROCrate" <| fun _ ->
+        let graph = LDGraph.fromROCrateYamlString roCrateMinimalYaml
+        Expect.isSome (graph.TryGetContext()) "context should exist"
+        Expect.hasLength graph.Nodes 2 "should have 2 nodes"
+
+        let firstExpectedNode = LDNode("ro-crate-metadata.json", ResizeArray ["CreativeWork"])
+        firstExpectedNode.SetProperty("about", LDRef("./"))
+        firstExpectedNode.SetProperty("conformsTo", LDRef("https://w3id.org/ro/crate/1.2"))
+        let secondExpectedNode = LDNode("./", ResizeArray ["Dataset"])
+
+        Expect.equal graph.Nodes.[0] firstExpectedNode "first node should be metadata"
+        Expect.equal graph.Nodes.[1] secondExpectedNode "second node should be dataset"
+]
+
+let private writeTests = testList "Write" [
+    testCase "Roundtrip" <| fun _ ->
+        let graph = LDGraph.fromROCrateYamlString roCrateMinimalYaml
+        let yaml = LDGraph.toROCrateYamlString (Some 2) graph
+        let parsed = LDGraph.fromROCrateYamlString yaml
+        Expect.equal parsed graph "graph roundtrip should preserve content"
+]
+
+let main = testList "ROCrate.LDGraph" [
+    readTests
+    writeTests
+]

--- a/tests/Yaml/ROCrate.LDNode.Tests.fs
+++ b/tests/Yaml/ROCrate.LDNode.Tests.fs
@@ -5,60 +5,136 @@ open ARCtrl.ROCrate
 open ARCtrl.Yaml.ROCrate
 open DynamicObj
 
-let private yaml_onlyIDAndType =
-    """
-'@id': MyIdentifier
-'@type': MyType
-"""
-
-let private yaml_twoTypesAndID =
-    """
-'@id': MyIdentifier
-'@type':
-  - MyType
-  - MySecondType
-"""
-
-let private yaml_withMixedFields =
-    """
-'@id': OuterIdentifier
-'@type': MyType
-name: MyName
-number: 42
-nested:
-  - '@id': MyIdentifier
-    '@type': MyType
-  - Value2
-  - 1337
-"""
+module YamlFixtures = TestObjects.Yaml.ROCrate
 
 let private readTests = testList "Read" [
+    testCase "Fixture_Contains_AtType_Key" <| fun _ ->
+        let element = ARCtrl.Yaml.Decode.fromYamlString id YamlFixtures.GenericObjects.onlyIDAndType
+        let mappings = ARCtrl.Yaml.ROCrate.Helpers.getMappings element
+        let keys = mappings |> List.map fst
+        Expect.containsAll keys ["@id"; "@type"] "Fixture YAML should parse with both @id and @type keys"
+
+    testCase "Unquoted_At_Keys_Are_Parsed" <| fun _ ->
+        let element = ARCtrl.Yaml.Decode.fromYamlString id "@id: MyIdentifier\n@type: MyType"
+        let mappings = ARCtrl.Yaml.ROCrate.Helpers.getMappings element
+        let keys = mappings |> List.map fst
+        Expect.containsAll keys ["@id"; "@type"] "Unquoted @-keys should parse"
+
     testCase "onlyIDAndType" <| fun _ ->
-        let node = LDNode.fromROCrateYamlString yaml_onlyIDAndType
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.onlyIDAndType
         Expect.equal node.Id "MyIdentifier" "id was not parsed correctly"
         Expect.sequenceEqual node.SchemaType (ResizeArray ["MyType"]) "type was not parsed correctly"
 
+    testCase "onlyID" <| fun _ ->
+        Expect.throws (fun () -> LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.onlyID |> ignore) "Should fail if @type is missing"
+
+    testCase "onlyType" <| fun _ ->
+        Expect.throws (fun () -> LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.onlyType |> ignore) "Should fail if @id is missing"
+
+    testCase "Strict_At_Keywords_Required" <| fun _ ->
+        Expect.throws (fun () -> LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withoutAtKeywords |> ignore) "Should require JSON-LD '@' keywords"
+
     testCase "twoTypesAndID" <| fun _ ->
-        let node = LDNode.fromROCrateYamlString yaml_twoTypesAndID
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.twoTypesAndID
         Expect.equal node.Id "MyIdentifier" "id was not parsed correctly"
         Expect.sequenceEqual node.SchemaType (ResizeArray ["MyType"; "MySecondType"]) "type was not parsed correctly"
 
     testCase "withMixedFields" <| fun _ ->
-        let node = LDNode.fromROCrateYamlString yaml_withMixedFields
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withMixedFields
         let name = Expect.wantSome (DynObj.tryGetTypedPropertyValue<string> "name" node) "name was not parsed"
         let number = Expect.wantSome (DynObj.tryGetTypedPropertyValue<int> "number" node) "number was not parsed"
         let nested = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "nested" node) "nested was not parsed"
         Expect.equal name "MyName" "name value was wrong"
         Expect.equal number 42 "number value was wrong"
         Expect.equal nested.Count 3 "nested count was wrong"
+
+    testCase "withStringFields" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withStringFields
+        let name = Expect.wantSome (DynObj.tryGetTypedPropertyValue<string> "name" node) "name was not parsed"
+        let description = Expect.wantSome (DynObj.tryGetTypedPropertyValue<string> "description" node) "description was not parsed"
+        Expect.equal name "MyName" "name value was wrong"
+        Expect.equal description "MyDescription" "description value was wrong"
+
+    testCase "withIntFields" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withIntFields
+        let number = Expect.wantSome (DynObj.tryGetTypedPropertyValue<int> "number" node) "number was not parsed"
+        let anotherNumber = Expect.wantSome (DynObj.tryGetTypedPropertyValue<int> "anotherNumber" node) "anotherNumber was not parsed"
+        Expect.equal number 42 "number value was wrong"
+        Expect.equal anotherNumber 1337 "anotherNumber value was wrong"
+
+    testCase "withStringArray" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withStringArray
+        let names = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "names" node) "names was not parsed"
+        Expect.equal names.Count 2 "names count was wrong"
+        Expect.equal names.[0] "MyName" "first name was wrong"
+        Expect.equal names.[1] "MySecondName" "second name was wrong"
+
+    testCase "withExpandedStringFieldNoType" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withExpandedStringFieldNoType
+        let name = Expect.wantSome (node.TryGetProperty "name") "name was not parsed"
+        Expect.equal name (LDValue("MyName")) "expanded string value was wrong"
+
+    testCase "withExpandedIntFieldWithType" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withExpandedIntFieldWithType
+        let number = Expect.wantSome (node.TryGetProperty "number") "number was not parsed"
+        Expect.equal number (LDValue(42, valueType = "http://www.w3.org/2001/XMLSchema#int")) "expanded int value was wrong"
+
+    testCase "withLDRefObject" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withLDRefObject
+        let refObj = Expect.wantSome (node.TryGetProperty "nested") "nested ref was not parsed"
+        Expect.equal refObj (LDRef("RefIdentifier")) "LDRef value was wrong"
+
+    testCase "withNestedObject" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withNestedObject
+        let nested = Expect.wantSome (DynObj.tryGetTypedPropertyValue<LDNode> "nested" node) "nested node was not parsed"
+        Expect.equal nested.Id "MyIdentifier" "nested id was wrong"
+        Expect.sequenceEqual nested.SchemaType (ResizeArray ["MyType"]) "nested type was wrong"
+
+    testCase "withObjectArray" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withObjectArray
+        let nested = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "nested" node) "nested array was not parsed"
+        Expect.equal nested.Count 2 "nested count was wrong"
+        let n1 = nested.[0] :?> LDNode
+        let n2 = nested.[1] :?> LDNode
+        Expect.equal n1.Id "MyIdentifier" "first nested id was wrong"
+        Expect.equal n2.Id "MySecondIdentifier" "second nested id was wrong"
+
+    testCase "withAdditionalTypeString" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withAdditionalTypeString
+        Expect.sequenceEqual node.AdditionalType (ResizeArray ["additionalType"]) "additionalType string was not parsed"
+
+    testCase "withAdditionalTypeArray" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withAdditionalTypeArray
+        Expect.sequenceEqual node.AdditionalType (ResizeArray ["additionalType1"; "additionalType2"]) "additionalType array was not parsed"
+
+    testCase "nullValue" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withNullValue
+        Expect.isNone (node.TryGetProperty "name") "null properties should not be set"
+
+    testCase "Reject_MultiDocument_Stream" <| fun _ ->
+        let yaml = YamlFixtures.GenericObjects.onlyIDAndType + "\n---\n'@id': Another\n'@type': MyType\n"
+        Expect.throws (fun () -> LDNode.fromROCrateYamlString yaml |> ignore) "YAML-LD parser should reject multi-document streams"
 ]
 
 let private writeTests = testList "Write" [
     testCase "roundtrip (toYaml >> fromYaml)" <| fun _ ->
-        let original = LDNode.fromROCrateYamlString yaml_withMixedFields
+        let original = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withMixedFields
         let yaml = LDNode.toROCrateYamlString (Some 2) original
         let parsed = LDNode.fromROCrateYamlString yaml
         Expect.equal parsed original "Roundtrip conversion failed"
+
+    testCase "roundtrip_bool_property" <| fun _ ->
+        let original = LDNode("MyID", ResizeArray ["MyType"])
+        original.SetProperty("isTrue", true)
+        let yaml = LDNode.toROCrateYamlString (Some 2) original
+        let parsed = LDNode.fromROCrateYamlString yaml
+        Expect.equal parsed original "Bool property roundtrip failed"
+
+    testCase "roundtrip_additionalType" <| fun _ ->
+        let original = LDNode.fromROCrateYamlString YamlFixtures.GenericObjects.withAdditionalTypeArray
+        let yaml = LDNode.toROCrateYamlString (Some 2) original
+        let parsed = LDNode.fromROCrateYamlString yaml
+        Expect.equal parsed original "additionalType roundtrip failed"
 ]
 
 let main = testList "ROCrate.LDNode" [

--- a/tests/Yaml/ROCrate.LDNode.Tests.fs
+++ b/tests/Yaml/ROCrate.LDNode.Tests.fs
@@ -1,0 +1,67 @@
+module Tests.ROCrate.LDNode
+
+open TestingUtils
+open ARCtrl.ROCrate
+open ARCtrl.Yaml.ROCrate
+open DynamicObj
+
+let private yaml_onlyIDAndType =
+    """
+'@id': MyIdentifier
+'@type': MyType
+"""
+
+let private yaml_twoTypesAndID =
+    """
+'@id': MyIdentifier
+'@type':
+  - MyType
+  - MySecondType
+"""
+
+let private yaml_withMixedFields =
+    """
+'@id': OuterIdentifier
+'@type': MyType
+name: MyName
+number: 42
+nested:
+  - '@id': MyIdentifier
+    '@type': MyType
+  - Value2
+  - 1337
+"""
+
+let private readTests = testList "Read" [
+    testCase "onlyIDAndType" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString yaml_onlyIDAndType
+        Expect.equal node.Id "MyIdentifier" "id was not parsed correctly"
+        Expect.sequenceEqual node.SchemaType (ResizeArray ["MyType"]) "type was not parsed correctly"
+
+    testCase "twoTypesAndID" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString yaml_twoTypesAndID
+        Expect.equal node.Id "MyIdentifier" "id was not parsed correctly"
+        Expect.sequenceEqual node.SchemaType (ResizeArray ["MyType"; "MySecondType"]) "type was not parsed correctly"
+
+    testCase "withMixedFields" <| fun _ ->
+        let node = LDNode.fromROCrateYamlString yaml_withMixedFields
+        let name = Expect.wantSome (DynObj.tryGetTypedPropertyValue<string> "name" node) "name was not parsed"
+        let number = Expect.wantSome (DynObj.tryGetTypedPropertyValue<int> "number" node) "number was not parsed"
+        let nested = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "nested" node) "nested was not parsed"
+        Expect.equal name "MyName" "name value was wrong"
+        Expect.equal number 42 "number value was wrong"
+        Expect.equal nested.Count 3 "nested count was wrong"
+]
+
+let private writeTests = testList "Write" [
+    testCase "roundtrip (toYaml >> fromYaml)" <| fun _ ->
+        let original = LDNode.fromROCrateYamlString yaml_withMixedFields
+        let yaml = LDNode.toROCrateYamlString (Some 2) original
+        let parsed = LDNode.fromROCrateYamlString yaml
+        Expect.equal parsed original "Roundtrip conversion failed"
+]
+
+let main = testList "ROCrate.LDNode" [
+    readTests
+    writeTests
+]


### PR DESCRIPTION
The main aim of this PR is to add a generic YAML-LD parser according to the freshly released [YAML-LD 1.0 specification](https://w3c.github.io/yaml-ld/), which works just the same as the JSON-LD parser for the LD objects used for the RO-Crate representation.



#### JSON:
```json
{
  "@id": "assays/MyAssay/",
  "@type": "http://schema.org/Dataset",
  "additionalType": "Assay",
  "http://schema.org/identifier": "MyAssay",
  "http://schema.org/creator": [
    {
      "@id": "http://orcid.org/1234-5678-1234-5678",
      "@type": "http://schema.org/Person",
      "http://schema.org/givenName": "Lukas"
    }
  ],
  "http://schema.org/name": "This assay is fire!"
}
```

#### YAML:
```yaml
"@id": assays/MyAssay/
"@type": [http://schema.org/Dataset]
additionalType: [Assay]
http://schema.org/identifier: MyAssay
http://schema.org/creator:
  -
    "@id": http://orcid.org/1234-5678-1234-5678
    "@type": [http://schema.org/Person]
    http://schema.org/givenName: Lukas
http://schema.org/name: This assay is fire!
```

In addition, some new options were added to the Tabular-Process based conversion:
- Datamap can be skipped
- Processes can be grouped
  This groups all processes of the same annotation table with no differing parameter values. Instead of one process per input/output pair, grouped processes contain multiple inputs/outputs
  
  