### PR TITLE
Hotfix CompositeCell Hash clashes in Javascript through linear probing

### DIFF
--- a/src/Core/OntologyAnnotation.fs
+++ b/src/Core/OntologyAnnotation.fs
@@ -171,7 +171,38 @@ type OntologyAnnotation(?name,?tsr,?tan, (*?tanInfo, *)?comments) =
         |> HashCodes.mergeHashes nameHash
 
     override this.Equals(obj) : bool =
-        HashCodes.hash this = HashCodes.hash obj
+        match obj with
+        | :? OntologyAnnotation as oa ->
+            let equalName =
+                match this.Name, oa.Name with
+                | Some n1, Some n2 -> n1 = n2
+                | None, None -> true
+                | _ -> false
+            match this.TANInfo with
+            | Some taninfo1 ->
+                match oa.TANInfo with
+                | Some taninfo2 ->
+                    let equalTSR =
+                        match this.TermSourceREF, oa.TermSourceREF with
+                        | Some t1, Some t2 -> t1.ToLower() = t2.ToLower()
+                        | _, _ -> true
+                    equalName && equalTSR && taninfo1.IDSpace.ToLower() = taninfo2.IDSpace.ToLower() && taninfo1.LocalID = taninfo2.LocalID
+                | None -> false
+            | None ->
+                let equalTSR =
+                    match this.TermSourceREF, oa.TermSourceREF with
+                    | Some t1, Some t2 -> t1.ToLower() = t2.ToLower()
+                    | None, None -> true
+                    | _ -> false
+                let equalTAN =
+                    match this.TermAccessionNumber, oa.TermAccessionNumber with
+                    | Some tan1, Some tan2 -> tan1.ToLower() = tan2.ToLower()
+                    | None, None -> true
+                    | _ -> false
+                equalName && equalTSR && equalTAN         
+        | _ -> false
+
+        //HashCodes.hash this = HashCodes.hash obj
    
     interface System.IComparable with
         member this.CompareTo(obj) =

--- a/src/Core/Table/ArcTableAux.fs
+++ b/src/Core/Table/ArcTableAux.fs
@@ -18,14 +18,23 @@ let getEmptyCellForHeader (header:CompositeHeader) (columCellOption: CompositeCe
         | Some (CompositeCell.Unitized _)   -> CompositeCell.emptyUnitized
         | _                                 -> failwith "[extendBodyCells] This should never happen, IsTermColumn header must be paired with either term or unitized cell."
 
+/// For a given CompositeCell, check whether its hash is already part of the valueMap. If it is, return the hash. If it is not, add it to the valueMap and return the hash. In case of a hash collision, we add a fixed value (linear probing).
 let ensureCellHashInValueMap (value: CompositeCell) (valueMap: Dictionary<int, CompositeCell>) =
-    let hash = value.GetHashCode()
-    if valueMap.ContainsKey hash then
-        hash
-    else
-        // If value is not in the map, add it.
-        valueMap.Add(hash, value)
-        hash
+    let rec loop (hash : int option) =
+        let hash =
+            match hash with
+            | Some hash -> hash
+            | None -> value.GetHashCode()
+        if valueMap.ContainsKey hash then
+            if valueMap[hash] = value then
+                hash
+            else
+                loop (Some (hash + 4269))
+        else
+            // If value is not in the map, add it.
+            valueMap.Add(hash, value)
+            hash
+    loop None
 
 type ColumnValueRefs =
     | Constant of int

--- a/tests/Core/ArcTable.Tests.fs
+++ b/tests/Core/ArcTable.Tests.fs
@@ -2897,6 +2897,74 @@ let private tests_fillMissing = testList "fillMissing" [
             Expect.notEqual cell otherCell "Should not be the same cell"        
     ]
 
+let tests_CompositeCellHashClash = testList "CompositeCellHashClash" [
+    testCase "HashClash_Freetext" <| fun _ ->
+        let cc1 = CompositeCell.createFreeText("VBT04P")
+        let cc2 = CompositeCell.createFreeText("VBT07s")
+
+        let t = ArcTable.init("dawd")
+
+        t.AddColumn(CompositeHeader.Input (IOType.Sample), ResizeArray [cc1; cc2])
+
+        let inputs = t.GetInputColumn().Cells
+
+        Expect.equal inputs.[0] cc1 "First cell should be cc1"
+        Expect.equal inputs.[1] cc2 "Second cell should be cc2"
+    testCase "HashClash_TermCell" <| fun _ ->
+        let cc1 = CompositeCell.createTermFromString(name = "VBT04P")
+        let cc2 = CompositeCell.createTermFromString(name = "VBT07s")
+
+        let t = ArcTable.init("dawd")
+
+        t.AddColumn(CompositeHeader.Parameter (OntologyAnnotation(name = "ABC")), ResizeArray [cc1; cc2])
+
+        let inputs = t.GetColumn(0).Cells
+
+        Expect.equal inputs.[0].AsTerm.NameText cc1.AsTerm.NameText "First cell should be cc1"
+        Expect.equal inputs.[1].AsTerm.NameText cc2.AsTerm.NameText "Second cell should be cc2"
+    testCase "NoHashDuplication_Freetext" <| fun _ ->
+        let cc1 = CompositeCell.createFreeText("VBT04P")
+        let cc2 = CompositeCell.createFreeText("VBT07s")
+
+        let t = ArcTable.init("dawd")
+
+        t.AddColumn(CompositeHeader.Input (IOType.Sample), ResizeArray [cc1; cc2; cc1])
+
+        let inputs = t.GetInputColumn().Cells
+
+        Expect.equal inputs.[0] cc1 "First cell should be cc1"
+        Expect.equal inputs.[1] cc2 "Second cell should be cc2"
+        Expect.equal inputs.[2] cc1 "Third cell should be cc1"
+
+        let col = t.Values.Columns.[0].AsSparse()
+
+        let hashes = 
+            col.Values
+            |> Seq.distinct
+            |> Seq.toArray
+
+        printfn "Row keys: %A" hashes
+
+        Expect.equal (Seq.length hashes) 2 "There should only be 2 distinct keys in the column"
+    testCase "NoHashDuplication_TermCell" <| fun _ ->
+        let cc1 = CompositeCell.createTermFromString(name = "VBT04P")
+        let cc2 = CompositeCell.createTermFromString(name = "VBT07s")
+        let t = ArcTable.init("dawd")
+        t.AddColumn(CompositeHeader.Parameter (OntologyAnnotation(name = "ABC")), ResizeArray [cc1; cc2; cc1])
+        let inputs = t.GetColumn(0).Cells
+        Expect.equal inputs.[0].AsTerm.NameText cc1.AsTerm.NameText "First cell should be cc1"
+        Expect.equal inputs.[1].AsTerm.NameText cc2.AsTerm.NameText "Second cell should be cc2"
+        Expect.equal inputs.[2].AsTerm.NameText cc1.AsTerm.NameText "Third cell should be cc1"
+        let col = t.Values.Columns.[0].AsSparse()
+        let hashes = 
+            col.Values
+            |> Seq.distinct
+            |> Seq.toArray
+        printfn "Row keys: %A" hashes
+        Expect.equal (Seq.length hashes) 2 "There should only be 2 distinct keys in the column"
+]
+
+
 let main = 
     testList "ArcTable" [
         tests_SanityChecks
@@ -2930,4 +2998,5 @@ let main =
         tests_equality
         tests_copy
         tests_fillMissing
+        tests_CompositeCellHashClash
     ]

--- a/tests/Core/CompositeCell.Tests.fs
+++ b/tests/Core/CompositeCell.Tests.fs
@@ -190,11 +190,16 @@ let private tests_GetHashCode = testList "GetHashCode" [
             let cc = CompositeCell.createFreeText("TestTerm")
             cc.GetHashCode() |> ignore
             Expect.isTrue true " "
+        ftestCase "FreeText does not clash" <| fun _ ->
+            let cc1 = CompositeCell.createFreeText("VBT04P")
+            let cc2 = CompositeCell.createFreeText("VBT07s")
+            Expect.notEqual (cc1.GetHashCode()) (cc2.GetHashCode()) "FreeText VBT04P and FreeText VBT07s should not have the same hash code"
         testCase "Data" <| fun _ ->
             let d = Data(name = "MyData#row=1", format = "text/csv", selectorFormat = "MySelector")
             let cc = CompositeCell.createData d
             cc.GetHashCode() |> ignore
             Expect.isTrue true " "
+
     ]
 ]
 

--- a/tests/Core/CompositeCell.Tests.fs
+++ b/tests/Core/CompositeCell.Tests.fs
@@ -190,7 +190,8 @@ let private tests_GetHashCode = testList "GetHashCode" [
             let cc = CompositeCell.createFreeText("TestTerm")
             cc.GetHashCode() |> ignore
             Expect.isTrue true " "
-        ftestCase "FreeText does not clash" <| fun _ ->
+        // Fix in future, js hash codes for strings are unfortunately not avalanching
+        ptestCase "FreeText does not clash" <| fun _ ->
             let cc1 = CompositeCell.createFreeText("VBT04P")
             let cc2 = CompositeCell.createFreeText("VBT07s")
             Expect.notEqual (cc1.GetHashCode()) (cc2.GetHashCode()) "FreeText VBT04P and FreeText VBT07s should not have the same hash code"

--- a/tests/Core/OntologyAnnotation.Tests.fs
+++ b/tests/Core/OntologyAnnotation.Tests.fs
@@ -14,27 +14,32 @@ module Helper =
 open Helper
 
 let private tests_hashcode = testList "GetHashCode" [
-    testCase "Empty" (fun () ->
+    testCase "Empty" <| fun _ ->
         let oa1 = OntologyAnnotation()
         let oa2 = OntologyAnnotation()
         let h1 = oa1.GetHashCode()
         let h2 = oa2.GetHashCode()
         Expect.equal h1 h2 "Hashes should be equal"    
-    )
-    testCase "Equal" (fun () ->
+    testCase "Equal"  <| fun _ ->
         let oa1 = OntologyAnnotation("MyOntology",tsr = "EFO",tan = uri)
         let oa2 = OntologyAnnotation("MyOntology",tsr = "EFO",tan = uri)
         let h1 = oa1.GetHashCode()
         let h2 = oa2.GetHashCode()
         Expect.equal h1 h2 "Hashes should be equal"
-    )
-    testCase "Different" (fun () ->
+    testCase "Different"  <| fun _ ->
         let oa1 = OntologyAnnotation("MyOntology",tsr = "EFO",tan = uri)
         let oa2 = OntologyAnnotation("YourOntology",tsr = "NCBI",tan = "http://purl.obolibrary.org/obo/NCBI_0000123")
         let h1 = oa1.GetHashCode()
         let h2 = oa2.GetHashCode()
         Expect.notEqual h1 h2 "Hashes should not be equal"
-    )
+    // Fix in future, js hash codes for strings are unfortunately not avalanching
+    ptestCase "js_clash" <| fun _ ->
+        let oa1 = OntologyAnnotation(name = "VBT04P")
+        let oa2 = OntologyAnnotation(name = "VBT07s")
+        let h1 = oa1.GetHashCode()
+        let h2 = oa2.GetHashCode()
+        Expect.notEqual h1 h2 "Hashes should not be equal"
+
 ]
 
 let private tests_equals = testList "Equals" [
@@ -82,6 +87,10 @@ let private tests_equals = testList "Equals" [
     testCase "not equal" <| fun _ ->   
         let oa1 = OntologyAnnotation("instrument model", "MS", "http://purl.obolibrary.org/obo/MS_00000001", comments = ResizeArray [Comment("KeyName", "Value1")])
         let oa2 = OntologyAnnotation(tan= "MS:00000001", comments=ResizeArray [Comment("KeyName", "Value1")])
+        Expect.notEqual oa1 oa2 ""
+    testCase "js_clash" <| fun _ ->
+        let oa1 = OntologyAnnotation(name = "VBT04P")
+        let oa2 = OntologyAnnotation(name = "VBT07s")
         Expect.notEqual oa1 oa2 ""
 ]
 


### PR DESCRIPTION
This pull request addresses hash code collisions in ArcTable in Javascript caused by the native string hash functions. These do not avalanche, i.e. similar string result in similar hashes, with quite some potential for hash collisions.

To tackle this in the HashTable of ArcTables, we implemented  linear probing. After checking for Hash equality, we additionally check for Structural equality of CompositeCells, and recursively increase the hash by a fixed amount, if there was a hash collision for unequal objects.

@caroott 