### PR TITLE
Improve CWL edge csae handling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="FsSpreadsheet.NET"     Version="7.0.0-alpha.1" />
     <PackageVersion Include="FsSpreadsheet.Js"      Version="7.0.0-alpha.1" />
     <PackageVersion Include="FsSpreadsheet.Py"      Version="7.0.0-alpha.1" />
-    <PackageVersion Include="YAMLicious"            Version="1.0.0-alpha.9" />
+    <PackageVersion Include="YAMLicious"            Version="1.0.0-alpha.10" />
     <PackageVersion Include="DynamicObj"            Version="7.1.0" />
     <PackageVersion Include="Fable.SimpleHttp"      Version="3.5.0" />
     <PackageVersion Include="Fable.Fetch"           Version="2.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="FsSpreadsheet.NET"     Version="7.0.0-alpha.1" />
     <PackageVersion Include="FsSpreadsheet.Js"      Version="7.0.0-alpha.1" />
     <PackageVersion Include="FsSpreadsheet.Py"      Version="7.0.0-alpha.1" />
-    <PackageVersion Include="YAMLicious"            Version="1.0.0-alpha.10" />
+    <PackageVersion Include="YAMLicious"            Version="1.0.0-alpha.11" />
     <PackageVersion Include="DynamicObj"            Version="7.1.0" />
     <PackageVersion Include="Fable.SimpleHttp"      Version="3.5.0" />
     <PackageVersion Include="Fable.Fetch"           Version="2.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="FsSpreadsheet.NET"     Version="7.0.0-alpha.1" />
     <PackageVersion Include="FsSpreadsheet.Js"      Version="7.0.0-alpha.1" />
     <PackageVersion Include="FsSpreadsheet.Py"      Version="7.0.0-alpha.1" />
-    <PackageVersion Include="YAMLicious"            Version="1.0.0-alpha.7" />
+    <PackageVersion Include="YAMLicious"            Version="1.0.0-alpha.9" />
     <PackageVersion Include="DynamicObj"            Version="7.1.0" />
     <PackageVersion Include="Fable.SimpleHttp"      Version="3.5.0" />
     <PackageVersion Include="Fable.Fetch"           Version="2.6.0" />

--- a/src/CWL/ARCtrl.CWL.fsproj
+++ b/src/CWL/ARCtrl.CWL.fsproj
@@ -9,6 +9,7 @@
   
   <ItemGroup> 
     <Compile Include="HashHelpers.fs" /> 
+    <Compile Include="DynamicObjHelpers.fs" /> 
     <Compile Include="CWLTypes.fs" /> 
     <Compile Include="Requirements.fs" /> 
     <Compile Include="Outputs.fs" /> 

--- a/src/CWL/CWLTypes.fs
+++ b/src/CWL/CWLTypes.fs
@@ -106,7 +106,7 @@ type FileInstance (
         and set(value) = _contents <- value
 
     static member KnownFieldNames =
-        ResizeArray [|
+        Set [|
             "class"
             "type"
             "location"
@@ -186,7 +186,7 @@ type DirectoryInstance (
         and set(value) = _listing <- value
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "type"; "location"; "path"; "basename"; "listing" |]
+        Set [ "class"; "type"; "location"; "path"; "basename"; "listing" ]
 
     override this.Equals (o: obj): bool =
         match o with
@@ -234,7 +234,7 @@ type DirentInstance (entry: SchemaSaladString, ?entryname: SchemaSaladString, ?w
         hash (this.Entry, this.Entryname, this.Writable, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "entry"; "entryname"; "writable" |]
+        Set [ "entry"; "entryname"; "writable" ]
 
 /// Represents an enumeration type with a defined set of valid symbol values.
 /// Per the CWL specification, symbol order is semantically significant and preserved during serialization.
@@ -281,7 +281,7 @@ type InputEnumSchema (symbols: ResizeArray<string>, ?label: string, ?doc: string
         hash (this.Symbols |> Seq.toList, this.Label, this.Doc, this.Name, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "type"; "symbols"; "label"; "doc"; "name" |]
+        Set [ "type"; "symbols"; "label"; "doc"; "name" ]
 
 /// Represents a field in an InputRecordSchema
 [<AttachMembers>]
@@ -323,7 +323,7 @@ type InputRecordField (name: string, type_: CWLType, ?doc: string, ?label: strin
         hash (this.Name, this.Type, this.Doc, this.Label, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "name"; "type"; "doc"; "label" |]
+        Set [ "name"; "type"; "doc"; "label" ]
 
 /// Represents a record schema for workflow input parameters
 and [<AttachMembers>] InputRecordSchema (?fields: ResizeArray<InputRecordField>, ?label: string, ?doc: string, ?name: string) =
@@ -374,7 +374,7 @@ and [<AttachMembers>] InputRecordSchema (?fields: ResizeArray<InputRecordField>,
         hash (fieldsHash, this.Label, this.Doc, this.Name, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "type"; "fields"; "label"; "doc"; "name" |]
+        Set [ "type"; "fields"; "label"; "doc"; "name" ]
 
 /// Represents an array schema for workflow input parameters
 and [<AttachMembers>] InputArraySchema (items: CWLType, ?label: string, ?doc: string, ?name: string) =
@@ -415,7 +415,7 @@ and [<AttachMembers>] InputArraySchema (items: CWLType, ?label: string, ?doc: st
         hash (this.Items, this.Label, this.Doc, this.Name, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "type"; "items"; "label"; "doc"; "name" |]
+        Set [ "type"; "items"; "label"; "doc"; "name" ]
 
 /// Primitive types with the concept of a file and directory as a builtin type.
 and [<CustomEquality; NoComparison>] CWLType =
@@ -513,7 +513,7 @@ type SchemaDefRequirementType (name: string, type_: CWLType) =
         hash (this.Name, this.Type_, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "name"; "type" |]
+        Set [ "name"; "type" ]
 
 [<AttachMembers>]
 type SoftwarePackage (package: string, ?version: ResizeArray<string>, ?specs: ResizeArray<string>) =
@@ -548,4 +548,4 @@ type SoftwarePackage (package: string, ?version: ResizeArray<string>, ?specs: Re
         hash (this.Package, this.Version, this.Specs, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "package"; "version"; "specs" |]
+        Set [ "package"; "version"; "specs" ]

--- a/src/CWL/CWLTypes.fs
+++ b/src/CWL/CWLTypes.fs
@@ -1,6 +1,7 @@
 namespace ARCtrl.CWL
 
 open DynamicObj
+open YAMLicious.YAMLiciousTypes
 
 type SchemaSaladString =
     | Literal of string
@@ -31,128 +32,384 @@ module SchemaSaladString =
 
     let toDirectiveString (saladString: SchemaSaladString) = saladString.AsDirectiveString
 
-type FileInstance () =
+type FileInstance (
+    ?location: string,
+    ?path: string,
+    ?basename: string,
+    ?dirname: string,
+    ?nameroot: string,
+    ?nameext: string,
+    ?checksum: string,
+    ?size: int64,
+    ?secondaryFiles: YAMLElement,
+    ?format: string,
+    ?contents: string
+) =
     inherit DynamicObj ()
 
+    let mutable _location = location
+    let mutable _path = path
+    let mutable _basename = basename
+    let mutable _dirname = dirname
+    let mutable _nameroot = nameroot
+    let mutable _nameext = nameext
+    let mutable _checksum = checksum
+    let mutable _size = size
+    let mutable _secondaryFiles = secondaryFiles
+    let mutable _format = format
+    let mutable _contents = contents
+
+    member this.Location
+        with get() = _location
+        and set(value) = _location <- value
+
+    member this.Path
+        with get() = _path
+        and set(value) = _path <- value
+
+    member this.Basename
+        with get() = _basename
+        and set(value) = _basename <- value
+
+    member this.Dirname
+        with get() = _dirname
+        and set(value) = _dirname <- value
+
+    member this.Nameroot
+        with get() = _nameroot
+        and set(value) = _nameroot <- value
+
+    member this.Nameext
+        with get() = _nameext
+        and set(value) = _nameext <- value
+
+    member this.Checksum
+        with get() = _checksum
+        and set(value) = _checksum <- value
+
+    member this.Size
+        with get() = _size
+        and set(value) = _size <- value
+
+    member this.SecondaryFiles
+        with get() = _secondaryFiles
+        and set(value) = _secondaryFiles <- value
+
+    member this.Format
+        with get() = _format
+        and set(value) = _format <- value
+
+    member this.Contents
+        with get() = _contents
+        and set(value) = _contents <- value
+
+    static member KnownFieldNames =
+        ResizeArray [|
+            "class"
+            "type"
+            "location"
+            "path"
+            "basename"
+            "dirname"
+            "nameroot"
+            "nameext"
+            "checksum"
+            "size"
+            "secondaryFiles"
+            "format"
+            "contents"
+        |]
+
     override this.GetHashCode (): int =
-        this.DeepCopyProperties().GetHashCode()
+        hash (
+            this.Location,
+            this.Path,
+            this.Basename,
+            this.Dirname,
+            this.Nameroot,
+            this.Nameext,
+            this.Checksum,
+            this.Size,
+            this.SecondaryFiles,
+            this.Format,
+            this.Contents,
+            HashHelpers.hashDynamicProperties this
+        )
 
     override this.Equals (o: obj): bool =
         match o with
         | :? FileInstance as o ->
-            this.StructurallyEquals o
+            this.Location = o.Location &&
+            this.Path = o.Path &&
+            this.Basename = o.Basename &&
+            this.Dirname = o.Dirname &&
+            this.Nameroot = o.Nameroot &&
+            this.Nameext = o.Nameext &&
+            this.Checksum = o.Checksum &&
+            this.Size = o.Size &&
+            this.SecondaryFiles = o.SecondaryFiles &&
+            this.Format = o.Format &&
+            this.Contents = o.Contents &&
+            HashHelpers.dynamicPropertiesEqual this o
         | _ -> false
 
-type DirectoryInstance () =
+type DirectoryInstance (
+    ?location: string,
+    ?path: string,
+    ?basename: string,
+    ?listing: YAMLElement
+) =
     inherit DynamicObj ()
+
+    let mutable _location = location
+    let mutable _path = path
+    let mutable _basename = basename
+    let mutable _listing = listing
+
+    member this.Location
+        with get() = _location
+        and set(value) = _location <- value
+
+    member this.Path
+        with get() = _path
+        and set(value) = _path <- value
+
+    member this.Basename
+        with get() = _basename
+        and set(value) = _basename <- value
+
+    member this.Listing
+        with get() = _listing
+        and set(value) = _listing <- value
+
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "type"; "location"; "path"; "basename"; "listing" |]
 
     override this.Equals (o: obj): bool =
         match o with
         | :? DirectoryInstance as o ->
-            this.StructurallyEquals o
+            this.Location = o.Location &&
+            this.Path = o.Path &&
+            this.Basename = o.Basename &&
+            this.Listing = o.Listing &&
+            HashHelpers.dynamicPropertiesEqual this o
         | _ -> false
 
     override this.GetHashCode (): int = 
-        this.DeepCopyProperties().GetHashCode()
+        hash (this.Location, this.Path, this.Basename, this.Listing, HashHelpers.hashDynamicProperties this)
 
-type DirentInstance = {
-    // can be string or expression, but expression is string as well
-    Entry: SchemaSaladString
-    Entryname: SchemaSaladString option
-    Writable: bool option
-}
+type DirentInstance (entry: SchemaSaladString, ?entryname: SchemaSaladString, ?writable: bool) =
+    inherit DynamicObj ()
+
+    let mutable _entry = entry
+    let mutable _entryname = entryname
+    let mutable _writable = writable
+
+    member this.Entry
+        with get() = _entry
+        and set(value) = _entry <- value
+
+    member this.Entryname
+        with get() = _entryname
+        and set(value) = _entryname <- value
+
+    member this.Writable
+        with get() = _writable
+        and set(value) = _writable <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? DirentInstance as other ->
+            this.Entry = other.Entry &&
+            this.Entryname = other.Entryname &&
+            this.Writable = other.Writable &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.Entry, this.Entryname, this.Writable, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "entry"; "entryname"; "writable" |]
 
 /// Represents an enumeration type with a defined set of valid symbol values.
 /// Per the CWL specification, symbol order is semantically significant and preserved during serialization.
-[<CustomEquality; NoComparison>]
-type InputEnumSchema = {
-    Symbols: ResizeArray<string>
-    Label: string option
-    Doc: string option
-    Name: string option
-}
-    with
-        /// Equality comparison that treats symbol order as significant.
-        /// Two enums are equal only if their symbols appear in the same order.
-        /// This follows the CWL specification where enum symbol order matters.
-        override this.Equals(o: obj): bool =
-            match o with
-            | :? InputEnumSchema as other ->
-                this.Label = other.Label &&
-                this.Doc = other.Doc &&
-                this.Name = other.Name &&
-                this.Symbols.Count = other.Symbols.Count &&
-                Seq.forall2 (=) this.Symbols other.Symbols
-            | _ -> false
+type InputEnumSchema (symbols: ResizeArray<string>, ?label: string, ?doc: string, ?name: string) =
+    inherit DynamicObj ()
 
-        override this.GetHashCode(): int =
-            hash (this.Symbols |> Seq.toList, this.Label, this.Doc, this.Name)
+    let mutable _symbols = symbols
+    let mutable _label = label
+    let mutable _doc = doc
+    let mutable _name = name
+
+    member this.Symbols
+        with get() = _symbols
+        and set(value) = _symbols <- value
+
+    member this.Label
+        with get() = _label
+        and set(value) = _label <- value
+
+    member this.Doc
+        with get() = _doc
+        and set(value) = _doc <- value
+
+    member this.Name
+        with get() = _name
+        and set(value) = _name <- value
+
+    /// Equality comparison that treats symbol order as significant.
+    /// Two enums are equal only if their symbols appear in the same order.
+    /// This follows the CWL specification where enum symbol order matters.
+    override this.Equals(o: obj): bool =
+        match o with
+        | :? InputEnumSchema as other ->
+            this.Label = other.Label &&
+            this.Doc = other.Doc &&
+            this.Name = other.Name &&
+            this.Symbols.Count = other.Symbols.Count &&
+            Seq.forall2 (=) this.Symbols other.Symbols &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode(): int =
+        hash (this.Symbols |> Seq.toList, this.Label, this.Doc, this.Name, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "type"; "symbols"; "label"; "doc"; "name" |]
 
 /// Represents a field in an InputRecordSchema
-[<CustomEquality; NoComparison>]
-type InputRecordField = {
-    Name: string
-    Type: CWLType
-    Doc: string option
-    Label: string option
-}
-    with
-        override this.Equals(o: obj): bool =
-            match o with
-            | :? InputRecordField as other ->
-                this.Name = other.Name &&
-                this.Type.Equals(other.Type) &&
-                this.Doc = other.Doc &&
-                this.Label = other.Label
-            | _ -> false
+type InputRecordField (name: string, type_: CWLType, ?doc: string, ?label: string) =
+    inherit DynamicObj ()
 
-        override this.GetHashCode(): int =
-            hash (this.Name, this.Type, this.Doc, this.Label)
+    let mutable _name = name
+    let mutable _type = type_
+    let mutable _doc = doc
+    let mutable _label = label
+
+    member this.Name
+        with get() = _name
+        and set(value) = _name <- value
+
+    member this.Type
+        with get() = _type
+        and set(value) = _type <- value
+
+    member this.Doc
+        with get() = _doc
+        and set(value) = _doc <- value
+
+    member this.Label
+        with get() = _label
+        and set(value) = _label <- value
+
+    override this.Equals(o: obj): bool =
+        match o with
+        | :? InputRecordField as other ->
+            this.Name = other.Name &&
+            this.Type.Equals(other.Type) &&
+            this.Doc = other.Doc &&
+            this.Label = other.Label &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode(): int =
+        hash (this.Name, this.Type, this.Doc, this.Label, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "name"; "type"; "doc"; "label" |]
 
 /// Represents a record schema for workflow input parameters
-and [<CustomEquality; NoComparison>] InputRecordSchema = {
-    Fields: ResizeArray<InputRecordField> option
-    Label: string option
-    Doc: string option
-    Name: string option
-}
-    with
-        override this.Equals(o: obj): bool =
-            match o with
-            | :? InputRecordSchema as other ->
-                this.Label = other.Label &&
-                this.Doc = other.Doc &&
-                this.Name = other.Name &&
+and InputRecordSchema (?fields: ResizeArray<InputRecordField>, ?label: string, ?doc: string, ?name: string) =
+    inherit DynamicObj ()
+
+    let mutable _fields = fields
+    let mutable _label = label
+    let mutable _doc = doc
+    let mutable _name = name
+
+    member this.Fields
+        with get() = _fields
+        and set(value) = _fields <- value
+
+    member this.Label
+        with get() = _label
+        and set(value) = _label <- value
+
+    member this.Doc
+        with get() = _doc
+        and set(value) = _doc <- value
+
+    member this.Name
+        with get() = _name
+        and set(value) = _name <- value
+
+    override this.Equals(o: obj): bool =
+        match o with
+        | :? InputRecordSchema as other ->
+            this.Label = other.Label &&
+            this.Doc = other.Doc &&
+            this.Name = other.Name &&
+            (
                 match this.Fields, other.Fields with
                 | None, None -> true
-                | Some f1, Some f2 -> 
-                    f1.Count = f2.Count && 
+                | Some f1, Some f2 ->
+                    f1.Count = f2.Count &&
                     Seq.forall2 (fun (a: InputRecordField) (b: InputRecordField) -> a.Equals(b)) f1 f2
                 | _ -> false
-            | _ -> false
+            ) &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
 
-        override this.GetHashCode(): int =
-            hash (this.Fields, this.Label, this.Doc, this.Name)
+    override this.GetHashCode(): int =
+        let fieldsHash =
+            this.Fields
+            |> Option.map (Seq.map (fun field -> field.GetHashCode()) >> Seq.toList)
+        hash (fieldsHash, this.Label, this.Doc, this.Name, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "type"; "fields"; "label"; "doc"; "name" |]
 
 /// Represents an array schema for workflow input parameters
-and [<CustomEquality; NoComparison>] InputArraySchema = {
-    Items: CWLType
-    Label: string option
-    Doc: string option
-    Name: string option
-}
-    with
-        override this.Equals(o: obj): bool =
-            match o with
-            | :? InputArraySchema as other ->
-                this.Items.Equals(other.Items) &&
-                this.Label = other.Label &&
-                this.Doc = other.Doc &&
-                this.Name = other.Name
-            | _ -> false
+and InputArraySchema (items: CWLType, ?label: string, ?doc: string, ?name: string) =
+    inherit DynamicObj ()
 
-        override this.GetHashCode(): int =
-            hash (this.Items, this.Label, this.Doc, this.Name)
+    let mutable _items = items
+    let mutable _label = label
+    let mutable _doc = doc
+    let mutable _name = name
+
+    member this.Items
+        with get() = _items
+        and set(value) = _items <- value
+
+    member this.Label
+        with get() = _label
+        and set(value) = _label <- value
+
+    member this.Doc
+        with get() = _doc
+        and set(value) = _doc <- value
+
+    member this.Name
+        with get() = _name
+        and set(value) = _name <- value
+
+    override this.Equals(o: obj): bool =
+        match o with
+        | :? InputArraySchema as other ->
+            this.Items.Equals(other.Items) &&
+            this.Label = other.Label &&
+            this.Doc = other.Doc &&
+            this.Name = other.Name &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode(): int =
+        hash (this.Items, this.Label, this.Doc, this.Name, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "type"; "items"; "label"; "doc"; "name" |]
 
 /// Primitive types with the concept of a file and directory as a builtin type.
 and [<CustomEquality; NoComparison>] CWLType =
@@ -223,13 +480,64 @@ and [<CustomEquality; NoComparison>] CWLType =
 
     static member directory() = Directory(DirectoryInstance())
 
-type SchemaDefRequirementType = {
-    Name: string
-    Type_: CWLType
-}
+type SchemaDefRequirementType (name: string, type_: CWLType) =
+    inherit DynamicObj ()
 
-type SoftwarePackage = {
-    Package: string
-    Version: ResizeArray<string> option
-    Specs: ResizeArray<string> option
-}
+    let mutable _name = name
+    let mutable _type = type_
+
+    member this.Name
+        with get() = _name
+        and set(value) = _name <- value
+
+    member this.Type_
+        with get() = _type
+        and set(value) = _type <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? SchemaDefRequirementType as other ->
+            this.Name = other.Name &&
+            this.Type_.Equals(other.Type_) &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.Name, this.Type_, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "name"; "type" |]
+
+type SoftwarePackage (package: string, ?version: ResizeArray<string>, ?specs: ResizeArray<string>) =
+    inherit DynamicObj ()
+
+    let mutable _package = package
+    let mutable _version = version
+    let mutable _specs = specs
+
+    member this.Package
+        with get() = _package
+        and set(value) = _package <- value
+
+    member this.Version
+        with get() = _version
+        and set(value) = _version <- value
+
+    member this.Specs
+        with get() = _specs
+        and set(value) = _specs <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? SoftwarePackage as other ->
+            this.Package = other.Package &&
+            this.Version = other.Version &&
+            this.Specs = other.Specs &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.Package, this.Version, this.Specs, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "package"; "version"; "specs" |]

--- a/src/CWL/CWLTypes.fs
+++ b/src/CWL/CWLTypes.fs
@@ -1,6 +1,7 @@
 namespace ARCtrl.CWL
 
 open DynamicObj
+open Fable.Core
 open YAMLicious.YAMLiciousTypes
 
 type SchemaSaladString =
@@ -32,6 +33,7 @@ module SchemaSaladString =
 
     let toDirectiveString (saladString: SchemaSaladString) = saladString.AsDirectiveString
 
+[<AttachMembers>]
 type FileInstance (
     ?location: string,
     ?path: string,
@@ -133,7 +135,7 @@ type FileInstance (
             this.SecondaryFiles,
             this.Format,
             this.Contents,
-            HashHelpers.hashDynamicProperties this
+            DynamicObjHelpers.hashDynamicProperties this
         )
 
     override this.Equals (o: obj): bool =
@@ -150,9 +152,10 @@ type FileInstance (
             this.SecondaryFiles = o.SecondaryFiles &&
             this.Format = o.Format &&
             this.Contents = o.Contents &&
-            HashHelpers.dynamicPropertiesEqual this o
+            DynamicObjHelpers.dynamicPropertiesEqual this o
         | _ -> false
 
+[<AttachMembers>]
 type DirectoryInstance (
     ?location: string,
     ?path: string,
@@ -192,12 +195,13 @@ type DirectoryInstance (
             this.Path = o.Path &&
             this.Basename = o.Basename &&
             this.Listing = o.Listing &&
-            HashHelpers.dynamicPropertiesEqual this o
+            DynamicObjHelpers.dynamicPropertiesEqual this o
         | _ -> false
 
     override this.GetHashCode (): int = 
-        hash (this.Location, this.Path, this.Basename, this.Listing, HashHelpers.hashDynamicProperties this)
+        hash (this.Location, this.Path, this.Basename, this.Listing, DynamicObjHelpers.hashDynamicProperties this)
 
+[<AttachMembers>]
 type DirentInstance (entry: SchemaSaladString, ?entryname: SchemaSaladString, ?writable: bool) =
     inherit DynamicObj ()
 
@@ -223,17 +227,18 @@ type DirentInstance (entry: SchemaSaladString, ?entryname: SchemaSaladString, ?w
             this.Entry = other.Entry &&
             this.Entryname = other.Entryname &&
             this.Writable = other.Writable &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.Entry, this.Entryname, this.Writable, HashHelpers.hashDynamicProperties this)
+        hash (this.Entry, this.Entryname, this.Writable, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "entry"; "entryname"; "writable" |]
 
 /// Represents an enumeration type with a defined set of valid symbol values.
 /// Per the CWL specification, symbol order is semantically significant and preserved during serialization.
+[<AttachMembers>]
 type InputEnumSchema (symbols: ResizeArray<string>, ?label: string, ?doc: string, ?name: string) =
     inherit DynamicObj ()
 
@@ -269,16 +274,17 @@ type InputEnumSchema (symbols: ResizeArray<string>, ?label: string, ?doc: string
             this.Name = other.Name &&
             this.Symbols.Count = other.Symbols.Count &&
             Seq.forall2 (=) this.Symbols other.Symbols &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode(): int =
-        hash (this.Symbols |> Seq.toList, this.Label, this.Doc, this.Name, HashHelpers.hashDynamicProperties this)
+        hash (this.Symbols |> Seq.toList, this.Label, this.Doc, this.Name, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "type"; "symbols"; "label"; "doc"; "name" |]
 
 /// Represents a field in an InputRecordSchema
+[<AttachMembers>]
 type InputRecordField (name: string, type_: CWLType, ?doc: string, ?label: string) =
     inherit DynamicObj ()
 
@@ -310,17 +316,17 @@ type InputRecordField (name: string, type_: CWLType, ?doc: string, ?label: strin
             this.Type.Equals(other.Type) &&
             this.Doc = other.Doc &&
             this.Label = other.Label &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode(): int =
-        hash (this.Name, this.Type, this.Doc, this.Label, HashHelpers.hashDynamicProperties this)
+        hash (this.Name, this.Type, this.Doc, this.Label, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "name"; "type"; "doc"; "label" |]
 
 /// Represents a record schema for workflow input parameters
-and InputRecordSchema (?fields: ResizeArray<InputRecordField>, ?label: string, ?doc: string, ?name: string) =
+and [<AttachMembers>] InputRecordSchema (?fields: ResizeArray<InputRecordField>, ?label: string, ?doc: string, ?name: string) =
     inherit DynamicObj ()
 
     let mutable _fields = fields
@@ -358,20 +364,20 @@ and InputRecordSchema (?fields: ResizeArray<InputRecordField>, ?label: string, ?
                     Seq.forall2 (fun (a: InputRecordField) (b: InputRecordField) -> a.Equals(b)) f1 f2
                 | _ -> false
             ) &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode(): int =
         let fieldsHash =
             this.Fields
             |> Option.map (Seq.map (fun field -> field.GetHashCode()) >> Seq.toList)
-        hash (fieldsHash, this.Label, this.Doc, this.Name, HashHelpers.hashDynamicProperties this)
+        hash (fieldsHash, this.Label, this.Doc, this.Name, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "type"; "fields"; "label"; "doc"; "name" |]
 
 /// Represents an array schema for workflow input parameters
-and InputArraySchema (items: CWLType, ?label: string, ?doc: string, ?name: string) =
+and [<AttachMembers>] InputArraySchema (items: CWLType, ?label: string, ?doc: string, ?name: string) =
     inherit DynamicObj ()
 
     let mutable _items = items
@@ -402,11 +408,11 @@ and InputArraySchema (items: CWLType, ?label: string, ?doc: string, ?name: strin
             this.Label = other.Label &&
             this.Doc = other.Doc &&
             this.Name = other.Name &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode(): int =
-        hash (this.Items, this.Label, this.Doc, this.Name, HashHelpers.hashDynamicProperties this)
+        hash (this.Items, this.Label, this.Doc, this.Name, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "type"; "items"; "label"; "doc"; "name" |]
@@ -480,6 +486,7 @@ and [<CustomEquality; NoComparison>] CWLType =
 
     static member directory() = Directory(DirectoryInstance())
 
+[<AttachMembers>]
 type SchemaDefRequirementType (name: string, type_: CWLType) =
     inherit DynamicObj ()
 
@@ -499,15 +506,16 @@ type SchemaDefRequirementType (name: string, type_: CWLType) =
         | :? SchemaDefRequirementType as other ->
             this.Name = other.Name &&
             this.Type_.Equals(other.Type_) &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.Name, this.Type_, HashHelpers.hashDynamicProperties this)
+        hash (this.Name, this.Type_, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "name"; "type" |]
 
+[<AttachMembers>]
 type SoftwarePackage (package: string, ?version: ResizeArray<string>, ?specs: ResizeArray<string>) =
     inherit DynamicObj ()
 
@@ -533,11 +541,11 @@ type SoftwarePackage (package: string, ?version: ResizeArray<string>, ?specs: Re
             this.Package = other.Package &&
             this.Version = other.Version &&
             this.Specs = other.Specs &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.Package, this.Version, this.Specs, HashHelpers.hashDynamicProperties this)
+        hash (this.Package, this.Version, this.Specs, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "package"; "version"; "specs" |]

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -25,9 +25,9 @@ module Decode =
         Warnings: ResizeArray<DecodeWarning>
     }
 
-    type private WarningSink = ResizeArray<DecodeWarning> option
+    type WarningSink = ResizeArray<DecodeWarning> option
 
-    let private addWarning (warnings: WarningSink) (path: string) (message: string) (raw: YAMLElement option) =
+    let addWarning (warnings: WarningSink) (path: string) (message: string) (raw: YAMLElement option) =
         match warnings with
         | Some warningList ->
             warningList.Add({
@@ -85,7 +85,7 @@ module Decode =
         |> Decode.read
         |> removeYamlComments
 
-    let private boxOverflowInt64 (value: int64) : obj =
+    let boxOverflowInt64 (value: int64) : obj =
 #if FABLE_COMPILER_PYTHON
         Fable.Core.PyInterop.emitPyExpr value "int64($0)"
 #else
@@ -135,13 +135,13 @@ module Decode =
             DynObj.setProperty e.Key (decodeOverflowValue e.Value) dynObj
         dynObj
 
-    let private isIgnorableYamlNoise (value: YAMLElement) =
+    let isIgnorableYamlNoise (value: YAMLElement) =
         match value with
         | YAMLElement.Comment _ -> true
         | YAMLElement.Object [] -> true
         | _ -> false
 
-    let private tryGetPresentField (fieldName: string) (decoder: YAMLElement -> 'T) (value: YAMLElement) : 'T option =
+    let tryGetPresentField (fieldName: string) (decoder: YAMLElement -> 'T) (value: YAMLElement) : 'T option =
         match value with
         | YAMLElement.Object fields
             when fields
@@ -152,19 +152,19 @@ module Decode =
         | _ ->
             None
 
-    let private tryGetStringField (fieldName: string) (value: YAMLElement) =
+    let tryGetStringField (fieldName: string) (value: YAMLElement) =
         tryGetPresentField fieldName Decode.string value
 
-    let private tryGetBoolField (fieldName: string) (value: YAMLElement) =
+    let tryGetBoolField (fieldName: string) (value: YAMLElement) =
         tryGetPresentField fieldName Decode.bool value
 
-    let private tryGetYamlField (fieldName: string) (value: YAMLElement) =
+    let tryGetYamlField (fieldName: string) (value: YAMLElement) =
         tryGetPresentField fieldName id value
 
-    let private tryGetIntArrayField (fieldName: string) (value: YAMLElement) =
+    let tryGetIntArrayField (fieldName: string) (value: YAMLElement) =
         tryGetPresentField fieldName (Decode.resizearray Decode.int) value
 
-    let private tryGetInt64Field (fieldName: string) (value: YAMLElement) =
+    let tryGetInt64Field (fieldName: string) (value: YAMLElement) =
         let decodeInt64 = function
             | YAMLElement.Value scalar
             | YAMLElement.Object [YAMLElement.Value scalar] ->
@@ -174,7 +174,7 @@ module Decode =
             | other -> raise (System.ArgumentException($"Invalid int64 value for {fieldName}: {other}"))
         tryGetPresentField fieldName decodeInt64 value
 
-    let private tryGetLoadListingField (fieldName: string) (value: YAMLElement) =
+    let tryGetLoadListingField (fieldName: string) (value: YAMLElement) =
         tryGetStringField fieldName value
         |> Option.map (fun loadListingValue ->
             match LoadListingEnum.tryParse loadListingValue with
@@ -191,7 +191,7 @@ module Decode =
             ()
         dynObj
 
-    let private decodeFileInstanceFields (element: YAMLElement) =
+    let decodeFileInstanceFields (element: YAMLElement) =
         let file =
             FileInstance(
                 ?location = tryGetStringField "location" element,
@@ -209,7 +209,7 @@ module Decode =
         overflowIntoDynamicObj file (FileInstance.KnownFieldNames |> Seq.toList) element |> ignore
         file
 
-    let private decodeDirectoryInstanceFields (element: YAMLElement) =
+    let decodeDirectoryInstanceFields (element: YAMLElement) =
         let directory =
             DirectoryInstance(
                 ?location = tryGetStringField "location" element,
@@ -610,7 +610,7 @@ module Decode =
                 cwlType, false
         )
 
-    let private decodeNamedOutput (name: string) (value: YAMLElement) =
+    let decodeNamedOutput (name: string) (value: YAMLElement) =
         let outputBinding = outputBindingDecoder value
         let outputSourceValues = outputSourceDecoder value
         let cwlType =
@@ -635,7 +635,7 @@ module Decode =
         overflowIntoDynamicObj output (CWLOutput.KnownFieldNames |> Seq.toList) value |> ignore
         output
 
-    let private decodeOutputSequenceItem (warnings: WarningSink) (path: string) (index: int) (item: YAMLElement) =
+    let decodeOutputSequenceItem (warnings: WarningSink) (path: string) (index: int) (item: YAMLElement) =
         match tryGetStringField "id" item with
         | Some id -> Some (decodeNamedOutput id item)
         | None when isIgnorableYamlNoise item -> None
@@ -960,7 +960,7 @@ module Decode =
         | "StepInputExpressionRequirement" -> StepInputExpressionRequirement
         | _ -> raise (System.ArgumentException($"Invalid or unsupported requirement class: {cls}"))
 
-    let private addRequirementPayloadOverflow (element: YAMLElement) (requirement: Requirement) =
+    let addRequirementPayloadOverflow (element: YAMLElement) (requirement: Requirement) =
         let knownWithClass knownFields = "class" :: (knownFields |> Seq.toList)
         match requirement with
         | InlineJavascriptRequirement value ->
@@ -1131,7 +1131,7 @@ module Decode =
             outputBinding
         )
 
-    let private decodeNamedInput (name: string) (value: YAMLElement) =
+    let decodeNamedInput (name: string) (value: YAMLElement) =
         let inputBinding = inputBindingDecoder value
         let cwlType, optional =
             match value with
@@ -1155,7 +1155,7 @@ module Decode =
         overflowIntoDynamicObj input (CWLInput.KnownFieldNames |> Seq.toList) value |> ignore
         input
 
-    let private decodeInputSequenceItem (warnings: WarningSink) (path: string) (index: int) (item: YAMLElement) =
+    let decodeInputSequenceItem (warnings: WarningSink) (path: string) (index: int) (item: YAMLElement) =
         match tryGetStringField "id" item with
         | Some id -> Some (decodeNamedInput id item)
         | None when isIgnorableYamlNoise item -> None

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -85,6 +85,13 @@ module Decode =
         |> Decode.read
         |> removeYamlComments
 
+    let private boxOverflowInt64 (value: int64) : obj =
+#if FABLE_COMPILER_PYTHON
+        Fable.Core.PyInterop.emitPyExpr value "int64($0)"
+#else
+        box value
+#endif
+
     /// Decode key value pairs into a dynamic object, while preserving their tree structure.
     let rec overflowDecoder (dynObj: DynamicObj) (dict: System.Collections.Generic.Dictionary<string,YAMLElement>) =
         let decodeOverflowScalar (value: YAMLContent) : obj =
@@ -98,7 +105,7 @@ module Decode =
                 | true, parsed -> box parsed
                 | _ ->
                     match System.Int64.TryParse(value.Value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture) with
-                    | true, parsed -> box parsed
+                    | true, parsed -> boxOverflowInt64 parsed
                     | _ ->
                         match System.Double.TryParse(value.Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture) with
                         | true, parsed -> box parsed

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -456,6 +456,8 @@ module Decode =
         fun value ->
         Decode.object (fun get ->
             let symbols = get.Required.Field "symbols" (Decode.resizearray Decode.string)
+            if symbols.Count = 0 then
+                raise (System.ArgumentException("CWL enum schema must define at least one symbol."))
             
             let schema =
                 InputEnumSchema(

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -118,14 +118,10 @@ module Decode =
                 decodeOverflowScalar v
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
-                let decodedItems =
-                    items
-                    |> List.map decodeOverflowValue
-                    |> ResizeArray
-                if decodedItems.Count = 1 then
-                    decodedItems.[0]
-                else
-                    box decodedItems
+                items
+                |> List.map decodeOverflowValue
+                |> ResizeArray
+                |> box
             | YAMLElement.Object _ ->
                 let nested = DynamicObj()
                 value
@@ -145,29 +141,28 @@ module Decode =
         | YAMLElement.Object [] -> true
         | _ -> false
 
-    let private tryGetStringField (fieldName: string) (value: YAMLElement) =
-        try
-            Decode.object (fun get -> get.Optional.Field fieldName Decode.string) value
-        with ex when isRecoverableDecodingError ex ->
+    let private tryGetPresentField (fieldName: string) (decoder: YAMLElement -> 'T) (value: YAMLElement) : 'T option =
+        match value with
+        | YAMLElement.Object fields
+            when fields
+                 |> List.exists (function
+                     | YAMLElement.Mapping (key, _) when key.Value = fieldName -> true
+                     | _ -> false) ->
+            Decode.object (fun get -> get.Optional.Field fieldName decoder) value
+        | _ ->
             None
+
+    let private tryGetStringField (fieldName: string) (value: YAMLElement) =
+        tryGetPresentField fieldName Decode.string value
 
     let private tryGetBoolField (fieldName: string) (value: YAMLElement) =
-        try
-            Decode.object (fun get -> get.Optional.Field fieldName Decode.bool) value
-        with ex when isRecoverableDecodingError ex ->
-            None
+        tryGetPresentField fieldName Decode.bool value
 
     let private tryGetYamlField (fieldName: string) (value: YAMLElement) =
-        try
-            Decode.object (fun get -> get.Optional.Field fieldName id) value
-        with ex when isRecoverableDecodingError ex ->
-            None
+        tryGetPresentField fieldName id value
 
     let private tryGetIntArrayField (fieldName: string) (value: YAMLElement) =
-        try
-            Decode.object (fun get -> get.Optional.Field fieldName (Decode.resizearray Decode.int)) value
-        with ex when isRecoverableDecodingError ex ->
-            None
+        tryGetPresentField fieldName (Decode.resizearray Decode.int) value
 
     let private tryGetInt64Field (fieldName: string) (value: YAMLElement) =
         let decodeInt64 = function
@@ -177,10 +172,7 @@ module Decode =
                 | true, parsed -> parsed
                 | false, _ -> raise (System.ArgumentException($"Invalid int64 value for {fieldName}: {scalar.Value}"))
             | other -> raise (System.ArgumentException($"Invalid int64 value for {fieldName}: {other}"))
-        try
-            Decode.object (fun get -> get.Optional.Field fieldName decodeInt64) value
-        with ex when isRecoverableDecodingError ex ->
-            None
+        tryGetPresentField fieldName decodeInt64 value
 
     let private tryGetLoadListingField (fieldName: string) (value: YAMLElement) =
         tryGetStringField fieldName value

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -38,83 +38,6 @@ module Decode =
         | None ->
             ()
 
-    let countLeadingSpaces (line: string) =
-        line |> Seq.takeWhile (fun c -> c = ' ') |> Seq.length
-
-    let isBlankLine (line: string) =
-        line.Trim().Length = 0
-
-    let normalizeLineEndings (yaml: string) =
-        if isNull yaml then "" else yaml.Replace("\r\n", "\n")
-
-    let stripLeadingShebang (yaml: string) =
-        let normalized = normalizeLineEndings yaml
-        let lines = normalized.Split('\n')
-        if lines.Length > 0 && lines.[0].StartsWith("#!") then
-            lines.[1..] |> String.concat "\n"
-        else
-            normalized
-
-    let tryParseBlockScalarHeader (line: string) : int option =
-        if isBlankLine line then
-            None
-        else
-            let trimmed = line.TrimEnd()
-            // Match common block scalar headers:
-            //   key: |
-            //   key: >-
-            //   - |
-            //   - >+
-            // and preserve surrounding comments.
-            let isBlockScalarHeader =
-                System.Text.RegularExpressions.Regex.IsMatch(
-                    trimmed,
-                    @"^(?:.+:\s*[|>][1-9]?[+-]?\s*(?:#.*)?|-\s*[|>][1-9]?[+-]?\s*(?:#.*)?)$"
-                )
-            if isBlockScalarHeader then Some (countLeadingSpaces line) else None
-
-    let normalizeYamlInput (yaml: string) =
-        let normalized = stripLeadingShebang yaml
-        let lines = normalized.Split('\n')
-
-        let filtered = ResizeArray<string>()
-        let mutable blockScalarIndent : int option = None
-
-        let rec processLine (line: string) =
-            match blockScalarIndent with
-            | Some indent ->
-                if isBlankLine line then
-                    // Preserve whitespace-only blank content lines in block scalars.
-                    filtered.Add line
-                else
-                    let currentIndent = countLeadingSpaces line
-                    if currentIndent > indent then
-                        filtered.Add line
-                    else
-                        // End of block scalar; re-process this line in normal mode.
-                        blockScalarIndent <- None
-                        processLine line
-            | None ->
-                match tryParseBlockScalarHeader line with
-                | Some indent ->
-                    blockScalarIndent <- Some indent
-                    filtered.Add line
-                | None ->
-                    if line = "" || line.Trim().Length > 0 then
-                        filtered.Add line
-
-        lines |> Array.iter processLine
-
-        filtered
-        |> Seq.toArray
-        |> String.concat "\n"
-        |> fun text -> text.TrimEnd()
-
-    let removeFullLineComments (yaml: string) =
-        yaml.Split('\n')
-        |> Array.filter (fun line -> line.TrimStart().StartsWith("#") |> not)
-        |> String.concat "\n"
-
     let rec removeYamlComments (yamlElement: YAMLElement) : YAMLElement =
         match yamlElement with
         | YAMLElement.Object elements ->
@@ -158,21 +81,9 @@ module Decode =
         | _ -> false
 
     let readSanitizedYaml (yaml: string) =
-        let prepared = stripLeadingShebang yaml
-        let tryRead text =
-            text
-            |> Decode.read
-            |> removeYamlComments
-        try
-            tryRead prepared
-        with ex when isRecoverableDecodingError ex ->
-            let normalized = normalizeYamlInput prepared
-            try
-                tryRead normalized
-            with ex2 when isRecoverableDecodingError ex2 ->
-                normalized
-                |> removeFullLineComments
-                |> tryRead
+        yaml
+        |> Decode.read
+        |> removeYamlComments
 
     /// Decode key value pairs into a dynamic object, while preserving their tree structure.
     let rec overflowDecoder (dynObj: DynamicObj) (dict: System.Collections.Generic.Dictionary<string,YAMLElement>) =

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -87,11 +87,28 @@ module Decode =
 
     /// Decode key value pairs into a dynamic object, while preserving their tree structure.
     let rec overflowDecoder (dynObj: DynamicObj) (dict: System.Collections.Generic.Dictionary<string,YAMLElement>) =
+        let decodeOverflowScalar (value: YAMLContent) : obj =
+            match value.Style with
+            | Some ScalarStyle.SingleQuoted
+            | Some ScalarStyle.DoubleQuoted
+            | Some (ScalarStyle.Block _) ->
+                box value.Value
+            | _ ->
+                match System.Boolean.TryParse value.Value with
+                | true, parsed -> box parsed
+                | _ ->
+                    match System.Int64.TryParse(value.Value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture) with
+                    | true, parsed -> box parsed
+                    | _ ->
+                        match System.Double.TryParse(value.Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture) with
+                        | true, parsed -> box parsed
+                        | _ -> box value.Value
+
         let rec decodeOverflowValue (value: YAMLElement) : obj =
             match value with
             | YAMLElement.Value v
             | YAMLElement.Object [YAMLElement.Value v] ->
-                box v.Value
+                decodeOverflowScalar v
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
                 let decodedItems =

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -14,6 +14,30 @@ module ResizeArray =
 
 module Decode =
 
+    type DecodeWarning = {
+        Path: string
+        Message: string
+        Raw: string option
+    }
+
+    type DecodeResult<'T> = {
+        Value: 'T
+        Warnings: ResizeArray<DecodeWarning>
+    }
+
+    type private WarningSink = ResizeArray<DecodeWarning> option
+
+    let private addWarning (warnings: WarningSink) (path: string) (message: string) (raw: YAMLElement option) =
+        match warnings with
+        | Some warningList ->
+            warningList.Add({
+                Path = path
+                Message = message
+                Raw = raw |> Option.map (sprintf "%A")
+            })
+        | None ->
+            ()
+
     let countLeadingSpaces (line: string) =
         line |> Seq.takeWhile (fun c -> c = ' ') |> Seq.length
 
@@ -150,23 +174,124 @@ module Decode =
                 |> removeFullLineComments
                 |> tryRead
 
-    /// Decode key value pairs into a dynamic object, while preserving their tree structure
+    /// Decode key value pairs into a dynamic object, while preserving their tree structure.
     let rec overflowDecoder (dynObj: DynamicObj) (dict: System.Collections.Generic.Dictionary<string,YAMLElement>) =
+        let rec decodeOverflowValue (value: YAMLElement) : obj =
+            match value with
+            | YAMLElement.Value v
+            | YAMLElement.Object [YAMLElement.Value v] ->
+                box v.Value
+            | YAMLElement.Object [YAMLElement.Sequence items]
+            | YAMLElement.Sequence items ->
+                let decodedItems =
+                    items
+                    |> List.map decodeOverflowValue
+                    |> ResizeArray
+                if decodedItems.Count = 1 then
+                    decodedItems.[0]
+                else
+                    box decodedItems
+            | YAMLElement.Object _ ->
+                let nested = DynamicObj()
+                value
+                |> Decode.object (fun get -> get.Overflow.FieldList [])
+                |> overflowDecoder nested
+                |> box
+            | other ->
+                box other
+
         for e in dict do
-            match e.Value with
-            | YAMLElement.Object [YAMLElement.Value v] -> 
-                DynObj.setProperty e.Key v.Value dynObj
-            | YAMLElement.Object [YAMLElement.Sequence s] ->
-                let newDynObj = new DynamicObj ()
-                (s |> List.map ((Decode.object (fun get ->  (get.Overflow.FieldList []))) >> overflowDecoder newDynObj))
-                |> List.iter (fun x ->
-                    DynObj.setProperty
-                        e.Key
-                        x
-                        dynObj
-                )
-            | _ -> DynObj.setProperty e.Key e.Value dynObj
+            DynObj.setProperty e.Key (decodeOverflowValue e.Value) dynObj
         dynObj
+
+    let private isIgnorableYamlNoise (value: YAMLElement) =
+        match value with
+        | YAMLElement.Comment _ -> true
+        | YAMLElement.Object [] -> true
+        | _ -> false
+
+    let private tryGetStringField (fieldName: string) (value: YAMLElement) =
+        try
+            Decode.object (fun get -> get.Optional.Field fieldName Decode.string) value
+        with ex when isRecoverableDecodingError ex ->
+            None
+
+    let private tryGetBoolField (fieldName: string) (value: YAMLElement) =
+        try
+            Decode.object (fun get -> get.Optional.Field fieldName Decode.bool) value
+        with ex when isRecoverableDecodingError ex ->
+            None
+
+    let private tryGetYamlField (fieldName: string) (value: YAMLElement) =
+        try
+            Decode.object (fun get -> get.Optional.Field fieldName id) value
+        with ex when isRecoverableDecodingError ex ->
+            None
+
+    let private tryGetIntArrayField (fieldName: string) (value: YAMLElement) =
+        try
+            Decode.object (fun get -> get.Optional.Field fieldName (Decode.resizearray Decode.int)) value
+        with ex when isRecoverableDecodingError ex ->
+            None
+
+    let private tryGetInt64Field (fieldName: string) (value: YAMLElement) =
+        let decodeInt64 = function
+            | YAMLElement.Value scalar
+            | YAMLElement.Object [YAMLElement.Value scalar] ->
+                match System.Int64.TryParse(scalar.Value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture) with
+                | true, parsed -> parsed
+                | false, _ -> raise (System.ArgumentException($"Invalid int64 value for {fieldName}: {scalar.Value}"))
+            | other -> raise (System.ArgumentException($"Invalid int64 value for {fieldName}: {other}"))
+        try
+            Decode.object (fun get -> get.Optional.Field fieldName decodeInt64) value
+        with ex when isRecoverableDecodingError ex ->
+            None
+
+    let private tryGetLoadListingField (fieldName: string) (value: YAMLElement) =
+        tryGetStringField fieldName value
+        |> Option.map (fun loadListingValue ->
+            match LoadListingEnum.tryParse loadListingValue with
+            | Some parsed -> parsed
+            | None -> raise (System.ArgumentException($"Invalid loadListing value '{loadListingValue}'. Expected one of: no_listing, shallow_listing, deep_listing.")))
+
+    let overflowIntoDynamicObj (dynObj: DynamicObj) (knownFields: string list) (value: YAMLElement) =
+        match value with
+        | YAMLElement.Object _ ->
+            value
+            |> Decode.object (fun get -> overflowDecoder dynObj (get.Overflow.FieldList knownFields))
+            |> ignore
+        | _ ->
+            ()
+        dynObj
+
+    let private decodeFileInstanceFields (element: YAMLElement) =
+        let file =
+            FileInstance(
+                ?location = tryGetStringField "location" element,
+                ?path = tryGetStringField "path" element,
+                ?basename = tryGetStringField "basename" element,
+                ?dirname = tryGetStringField "dirname" element,
+                ?nameroot = tryGetStringField "nameroot" element,
+                ?nameext = tryGetStringField "nameext" element,
+                ?checksum = tryGetStringField "checksum" element,
+                ?size = tryGetInt64Field "size" element,
+                ?secondaryFiles = tryGetYamlField "secondaryFiles" element,
+                ?format = tryGetStringField "format" element,
+                ?contents = tryGetStringField "contents" element
+            )
+        overflowIntoDynamicObj file (FileInstance.KnownFieldNames |> Seq.toList) element |> ignore
+        file
+
+    let private decodeDirectoryInstanceFields (element: YAMLElement) =
+        let directory =
+            DirectoryInstance(
+                ?location = tryGetStringField "location" element,
+                ?path = tryGetStringField "path" element,
+                ?basename = tryGetStringField "basename" element,
+                ?listing = tryGetYamlField "listing" element
+            )
+        overflowIntoDynamicObj directory (DirectoryInstance.KnownFieldNames |> Seq.toList) element |> ignore
+        directory
 
     /// Decode scalar schema-salad string fields.
     /// Recognized directive wrappers are `$include` and `$import`.
@@ -192,10 +317,19 @@ module Decode =
 
     /// Decode a YAMLElement into a glob search pattern for output binding
     let outputBindingGlobDecoder: (YAMLiciousTypes.YAMLElement -> OutputBinding) =
-        Decode.object (fun get ->
-            let glob = get.Optional.Field "glob" Decode.string
-            { Glob = glob }
-        )
+        fun value ->
+            Decode.object (fun get ->
+                let glob = get.Optional.Field "glob" Decode.string
+                let binding =
+                    OutputBinding(
+                        ?glob = glob,
+                        ?loadContents = get.Optional.Field "loadContents" Decode.bool,
+                        ?loadListing = tryGetLoadListingField "loadListing" value,
+                        ?outputEval = get.Optional.Field "outputEval" Decode.string
+                    )
+                overflowIntoDynamicObj binding (OutputBinding.KnownFieldNames |> Seq.toList) value |> ignore
+                binding
+            ) value
 
     /// Decode a YAMLElement into an OutputBinding
     let outputBindingDecoder: (YAMLiciousTypes.YAMLElement -> OutputBinding option) =
@@ -221,36 +355,27 @@ module Decode =
 
     /// Decode a YAMLElement into a Dirent
     let direntDecoder: (YAMLiciousTypes.YAMLElement -> CWLType) =
-        Decode.object (fun get ->
-            Dirent
-                {
-                    Entry = get.Required.Field "entry" decodeSchemaSaladString
-                    Entryname = get.Optional.Field "entryname" decodeSchemaSaladString
-                    Writable = get.Optional.Field "writable" Decode.bool
-                }
-        )
+        fun value ->
+            Decode.object (fun get ->
+                let dirent =
+                    DirentInstance(
+                        get.Required.Field "entry" decodeSchemaSaladString,
+                        ?entryname = get.Optional.Field "entryname" decodeSchemaSaladString,
+                        ?writable = get.Optional.Field "writable" Decode.bool
+                    )
+                overflowIntoDynamicObj dirent (DirentInstance.KnownFieldNames |> Seq.toList) value |> ignore
+                Dirent dirent
+            ) value
 
     /// Decode a listing entry of InitialWorkDirRequirement.
     /// Supports both Dirent object form and string/expression form.
     let initialWorkDirEntryDecoder: (YAMLiciousTypes.YAMLElement -> InitialWorkDirEntry) =
         fun value ->
             let decodeFileInstance (element: YAMLElement) =
-                let fileInstance = FileInstance()
-                element
-                |> Decode.object (fun get ->
-                    overflowDecoder fileInstance (get.Overflow.FieldList [])
-                )
-                |> ignore
-                fileInstance
+                decodeFileInstanceFields element
 
             let decodeDirectoryInstance (element: YAMLElement) =
-                let directoryInstance = DirectoryInstance()
-                element
-                |> Decode.object (fun get ->
-                    overflowDecoder directoryInstance (get.Overflow.FieldList [])
-                )
-                |> ignore
-                directoryInstance
+                decodeDirectoryInstanceFields element
 
             match value with
             | YAMLElement.Object mappings ->
@@ -310,32 +435,37 @@ module Decode =
             match parseArrayShorthand innerType with
             | Some innerCwlType ->
                 // Nested array
-                Some (Array { Items = innerCwlType; Label = None; Doc = None; Name = None })
+                Some (Array (InputArraySchema(innerCwlType)))
             | None ->
                 // Base type with array suffix
                 try
                     let baseType = cwlSimpleTypeFromString innerType
-                    Some (Array { Items = baseType; Label = None; Doc = None; Name = None })
+                    Some (Array (InputArraySchema(baseType)))
                 with ex when isRecoverableDecodingError ex -> None
         else
             None
 
     /// Decode an InputArraySchema from a YAMLElement
     let rec inputArraySchemaDecoder: (YAMLiciousTypes.YAMLElement -> InputArraySchema) =
+        fun value ->
         Decode.object (fun get ->
             // Decode items - can be string or complex type
             let itemsValue = get.Required.Field "items" id
             let decodedItems = cwlTypeDecoder' itemsValue
             
-            {
-                Items = decodedItems
-                Label = get.Optional.Field "label" Decode.string
-                Doc = get.Optional.Field "doc" Decode.string
-                Name = get.Optional.Field "name" Decode.string
-            }
-        )
+            let schema =
+                InputArraySchema(
+                    decodedItems,
+                    ?label = get.Optional.Field "label" Decode.string,
+                    ?doc = get.Optional.Field "doc" Decode.string,
+                    ?name = get.Optional.Field "name" Decode.string
+                )
+            overflowIntoDynamicObj schema (InputArraySchema.KnownFieldNames |> Seq.toList) value |> ignore
+            schema
+        ) value
     /// Decode an InputRecordField from a YAMLElement
     and inputRecordFieldDecoder: (YAMLiciousTypes.YAMLElement -> InputRecordField) =
+        fun value ->
         Decode.object (fun get ->
             let name = get.Required.Field "name" Decode.string
             
@@ -343,13 +473,16 @@ module Decode =
             let typeValue = get.Required.Field "type" id
             let decodedType = cwlTypeDecoder' typeValue
             
-            {
-                Name = name
-                Type = decodedType
-                Doc = get.Optional.Field "doc" Decode.string
-                Label = get.Optional.Field "label" Decode.string
-            }
-        )
+            let field =
+                InputRecordField(
+                    name,
+                    decodedType,
+                    ?doc = get.Optional.Field "doc" Decode.string,
+                    ?label = get.Optional.Field "label" Decode.string
+                )
+            overflowIntoDynamicObj field (InputRecordField.KnownFieldNames |> Seq.toList) value |> ignore
+            field
+        ) value
 
     /// Attempt to decode fields as flow-style array: [{name: x, type: y}]
     and tryDecodeFieldsAsArray (element: YAMLElement) : ResizeArray<InputRecordField> option =
@@ -364,17 +497,21 @@ module Decode =
             let fields = ResizeArray<InputRecordField>()
             for kvp in dict do
                 let fieldType = cwlTypeDecoder' kvp.Value
-                fields.Add({
-                    Name = kvp.Key
-                    Type = fieldType
-                    Doc = None
-                    Label = None
-                })
+                let field =
+                    InputRecordField(
+                        kvp.Key,
+                        fieldType,
+                        ?doc = tryGetStringField "doc" kvp.Value,
+                        ?label = tryGetStringField "label" kvp.Value
+                    )
+                overflowIntoDynamicObj field (InputRecordField.KnownFieldNames |> Seq.toList) kvp.Value |> ignore
+                fields.Add(field)
             Some fields
         with ex when isRecoverableDecodingError ex -> None
 
     /// Decode an InputRecordSchema from a YAMLElement
     and inputRecordSchemaDecoder: (YAMLiciousTypes.YAMLElement -> InputRecordSchema) =
+        fun value ->
         Decode.object (fun get ->
             // Try to decode fields as an array (flow-style) or as a map (block-style)
             let decodedFields =
@@ -392,26 +529,33 @@ module Decode =
                     | None -> tryDecodeFieldsAsMap element
                 | None -> None
             
-            {
-                Fields = decodedFields
-                Label = get.Optional.Field "label" Decode.string
-                Doc = get.Optional.Field "doc" Decode.string
-                Name = get.Optional.Field "name" Decode.string
-            }
-        )
+            let schema =
+                InputRecordSchema(
+                    ?fields = decodedFields,
+                    ?label = get.Optional.Field "label" Decode.string,
+                    ?doc = get.Optional.Field "doc" Decode.string,
+                    ?name = get.Optional.Field "name" Decode.string
+                )
+            overflowIntoDynamicObj schema (InputRecordSchema.KnownFieldNames |> Seq.toList) value |> ignore
+            schema
+        ) value
 
     /// Decode an InputEnumSchema from a YAMLElement
     and inputEnumSchemaDecoder: (YAMLiciousTypes.YAMLElement -> InputEnumSchema) =
+        fun value ->
         Decode.object (fun get ->
             let symbols = get.Required.Field "symbols" (Decode.resizearray Decode.string)
             
-            {
-                Symbols = symbols
-                Label = get.Optional.Field "label" Decode.string
-                Doc = get.Optional.Field "doc" Decode.string
-                Name = get.Optional.Field "name" Decode.string
-            }
-        )
+            let schema =
+                InputEnumSchema(
+                    symbols,
+                    ?label = get.Optional.Field "label" Decode.string,
+                    ?doc = get.Optional.Field "doc" Decode.string,
+                    ?name = get.Optional.Field "name" Decode.string
+                )
+            overflowIntoDynamicObj schema (InputEnumSchema.KnownFieldNames |> Seq.toList) value |> ignore
+            schema
+        ) value
 
     /// Decode a CWLType from a YAMLElement (handles all types including complex schemas)
     and cwlTypeDecoder' (element: YAMLiciousTypes.YAMLElement): CWLType =
@@ -434,6 +578,24 @@ module Decode =
                 Union (ResizeArray [Null; baseType])
             else
                 baseType
+
+        let parseTypeObjectString (typeStr: string) =
+            let stripped, isOptional =
+                if typeStr.EndsWith("?") then
+                    typeStr.Replace("?", ""), true
+                else
+                    typeStr, false
+
+            match stripped with
+            | "File" ->
+                let file = decodeFileInstanceFields element
+                let baseType = File file
+                if isOptional then Union (ResizeArray [Null; baseType]) else baseType
+            | "Directory" ->
+                let directory = decodeDirectoryInstanceFields element
+                let baseType = Directory directory
+                if isOptional then Union (ResizeArray [Null; baseType]) else baseType
+            | _ -> parseTypeString typeStr
         
         match element with
         | YAMLElement.Value v | YAMLElement.Object [YAMLElement.Value v] ->
@@ -454,7 +616,7 @@ module Decode =
                     | "record" -> Record (inputRecordSchemaDecoder element)
                     | "enum" -> Enum (inputEnumSchemaDecoder element)
                     | "array" -> Array (inputArraySchemaDecoder element)
-                    | simpleType -> parseTypeString simpleType
+                    | simpleType -> parseTypeObjectString simpleType
                 | Some (YAMLElement.Object _) ->
                     // Nested complex type
                     cwlTypeDecoder' (get.Required.Field "type" id)
@@ -519,37 +681,64 @@ module Decode =
                 cwlType, false
         )
 
+    let private decodeNamedOutput (name: string) (value: YAMLElement) =
+        let outputBinding = outputBindingDecoder value
+        let outputSourceValues = outputSourceDecoder value
+        let cwlType =
+            match value with
+            | YAMLElement.Object [YAMLElement.Value v] -> cwlTypeStringMatcher v.Value (Unchecked.defaultof<Decode.IGetters>) |> fst
+            | _ -> cwlTypeDecoder value |> fst
+        let output =
+            CWLOutput(
+                name,
+                cwlType,
+                ?label = tryGetStringField "label" value,
+                ?secondaryFiles = tryGetYamlField "secondaryFiles" value,
+                ?streamable = tryGetBoolField "streamable" value,
+                ?doc = tryGetStringField "doc" value,
+                ?format = tryGetStringField "format" value
+            )
+        output.OutputBinding <- outputBinding
+        match outputSourceValues with
+        | Some values when values.Count > 1 -> output.OutputSource <- Some (OutputSource.Multiple values)
+        | Some values when values.Count = 1 -> output.OutputSource <- Some (OutputSource.Single values.[0])
+        | _ -> ()
+        overflowIntoDynamicObj output (CWLOutput.KnownFieldNames |> Seq.toList) value |> ignore
+        output
+
+    let private decodeOutputSequenceItem (warnings: WarningSink) (path: string) (index: int) (item: YAMLElement) =
+        match tryGetStringField "id" item with
+        | Some id -> Some (decodeNamedOutput id item)
+        | None when isIgnorableYamlNoise item -> None
+        | None ->
+            addWarning warnings $"{path}[{index}]" "Skipped malformed unnamed CWL output entry." (Some item)
+            None
+
     /// Decode a YAMLElement into an Output Array
+    let outputArrayDecoderWithWarnings (warnings: WarningSink) (path: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLOutput>) =
+        fun value ->
+            match value with
+            | YAMLElement.Object [YAMLElement.Sequence items]
+            | YAMLElement.Sequence items ->
+                items
+                |> List.mapi (decodeOutputSequenceItem warnings path)
+                |> List.choose id
+                |> ResizeArray
+            | _ ->
+                let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
+                [| for key in dict.Keys do decodeNamedOutput key dict.[key] |] |> ResizeArray
+
     let outputArrayDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLOutput>) =
-        Decode.object (fun get ->
-            let dict = get.Overflow.FieldList []
-            [|
-                for key in dict.Keys do
-                    let value = dict.[key]
-                    let outputBinding = outputBindingDecoder value
-                    let outputSourceValues = outputSourceDecoder value
-                    let cwlType =
-                        match value with
-                        | YAMLElement.Object [YAMLElement.Value v] -> cwlTypeStringMatcher v.Value get |> fst
-                        | _ -> cwlTypeDecoder value |> fst
-                    let output = CWLOutput(key, cwlType)
-                    if outputBinding.IsSome then DynObj.setOptionalProperty "outputBinding" outputBinding output
-                    match outputSourceValues with
-                    | Some values when values.Count > 1 ->
-                        output.OutputSource <- Some (OutputSource.Multiple values)
-                    | Some values when values.Count = 1 ->
-                        output.OutputSource <- Some (OutputSource.Single values.[0])
-                    | _ ->
-                        ()
-                    output
-            |] |> ResizeArray)
+        outputArrayDecoderWithWarnings None "outputs"
 
     /// Access the outputs field and decode a YAMLElement into an Output Array
-    let outputsDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLOutput>) =
+    let outputsDecoderWithWarnings (warnings: WarningSink) : (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLOutput>) =
         Decode.object (fun get ->
-            let outputs = get.Required.Field "outputs" outputArrayDecoder
-            outputs
+            get.Required.Field "outputs" (outputArrayDecoderWithWarnings warnings "outputs")
         )
+
+    let outputsDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLOutput>) =
+        outputsDecoderWithWarnings None
 
     /// Decode a YAMLElement into a DockerRequirement
     let dockerRequirementDecoder (get: Decode.IGetters): DockerRequirement =
@@ -587,21 +776,22 @@ module Decode =
         match envDefElement with
         | YAMLElement.Sequence _ ->
             Decode.resizearray
-                (Decode.object (fun get2 ->
-                    {
-                        EnvName = get2.Required.Field "envName" Decode.string
-                        EnvValue = get2.Required.Field "envValue" Decode.string
-                    }
-                ))
+                (fun value ->
+                    Decode.object (fun get2 ->
+                        let env =
+                            EnvironmentDef(
+                                get2.Required.Field "envName" Decode.string,
+                                get2.Required.Field "envValue" Decode.string
+                            )
+                        overflowIntoDynamicObj env (EnvironmentDef.KnownFieldNames |> Seq.toList) value |> ignore
+                        env
+                    ) value)
                 envDefElement
         | YAMLElement.Object mappings ->
             mappings
             |> List.choose (function
                 | YAMLElement.Mapping (key, value) ->
-                    Some {
-                        EnvName = key.Value
-                        EnvValue = decodeEnvValue value
-                    }
+                    Some (EnvironmentDef(key.Value, decodeEnvValue value))
                 | _ -> None)
             |> ResizeArray
         | _ ->
@@ -625,17 +815,9 @@ module Decode =
             let normalizedPackageValue = normalizeCollectionElement packageValue
             match normalizedPackageValue with
             | YAMLElement.Object [] ->
-                {
-                    Package = packageName
-                    Version = None
-                    Specs = None
-                }
+                SoftwarePackage(packageName)
             | YAMLElement.Sequence _ ->
-                {
-                    Package = packageName
-                    Version = None
-                    Specs = Some (decodeSpecsArray normalizedPackageValue)
-                }
+                SoftwarePackage(packageName, specs = decodeSpecsArray normalizedPackageValue)
             | YAMLElement.Object mappings ->
                 let version =
                     mappings
@@ -647,28 +829,26 @@ module Decode =
                     |> List.tryPick (function
                         | YAMLElement.Mapping (k, v) when k.Value = "specs" -> Some (decodeSpecsArray v)
                         | _ -> None)
-                {
-                    Package = packageName
-                    Version = version
-                    Specs = specs
-                }
+                let package = SoftwarePackage(packageName, ?version = version, ?specs = specs)
+                overflowIntoDynamicObj package (SoftwarePackage.KnownFieldNames |> Seq.toList) normalizedPackageValue |> ignore
+                package
             | _ ->
-                {
-                    Package = packageName
-                    Version = None
-                    Specs = Some (ResizeArray [| decodeStringOrExpression packageValue |])
-                }
+                SoftwarePackage(packageName, specs = ResizeArray [| decodeStringOrExpression packageValue |])
 
         match packagesElement with
         | YAMLElement.Sequence _ ->
             Decode.resizearray
-                (Decode.object (fun get2 ->
-                    {
-                        Package = get2.Required.Field "package" Decode.string
-                        Version = get2.Optional.Field "version" (Decode.resizearray Decode.string)
-                        Specs = get2.Optional.Field "specs" (Decode.resizearray Decode.string)
-                    }
-                ))
+                (fun value ->
+                    Decode.object (fun get2 ->
+                        let package =
+                            SoftwarePackage(
+                                get2.Required.Field "package" Decode.string,
+                                ?version = get2.Optional.Field "version" (Decode.resizearray Decode.string),
+                                ?specs = get2.Optional.Field "specs" (Decode.resizearray Decode.string)
+                            )
+                        overflowIntoDynamicObj package (SoftwarePackage.KnownFieldNames |> Seq.toList) value |> ignore
+                        package
+                    ) value)
                 packagesElement
         | YAMLElement.Object mappings ->
             mappings
@@ -698,7 +878,7 @@ module Decode =
             match LoadListingEnum.tryParse loadListingValue with
             | Some parsed -> parsed
             | None -> raise (System.ArgumentException($"Invalid loadListing value '{loadListingValue}'. Expected one of: no_listing, shallow_listing, deep_listing."))
-        { LoadListing = loadListing }
+        LoadListingRequirementValue(loadListing)
 
     let decodeResourceScalar (element: YAMLElement) : obj =
         let tryGetScalarString = function
@@ -726,31 +906,38 @@ module Decode =
     /// Decode a YAMLElement into a ResourceRequirementInstance
     let resourceRequirementDecoder (get: Decode.IGetters): ResourceRequirementInstance =
         ResourceRequirementInstance(
-            optionalResourceField get "coresMin",
-            optionalResourceField get "coresMax",
-            optionalResourceField get "ramMin",
-            optionalResourceField get "ramMax",
-            optionalResourceField get "tmpdirMin",
-            optionalResourceField get "tmpdirMax",
-            optionalResourceField get "outdirMin",
-            optionalResourceField get "outdirMax"
+            ?coresMin = optionalResourceField get "coresMin",
+            ?coresMax = optionalResourceField get "coresMax",
+            ?ramMin = optionalResourceField get "ramMin",
+            ?ramMax = optionalResourceField get "ramMax",
+            ?tmpdirMin = optionalResourceField get "tmpdirMin",
+            ?tmpdirMax = optionalResourceField get "tmpdirMax",
+            ?outdirMin = optionalResourceField get "outdirMin",
+            ?outdirMax = optionalResourceField get "outdirMax"
         )
         
     let schemaDefRequirementTypeDecoder (value: YAMLElement) : SchemaDefRequirementType =
         let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
+        let schemaDefKnownFields =
+            [
+                yield! SchemaDefRequirementType.KnownFieldNames
+                yield! InputRecordSchema.KnownFieldNames
+                yield! InputArraySchema.KnownFieldNames
+                yield! InputEnumSchema.KnownFieldNames
+            ]
+            |> Seq.distinct
+            |> Seq.toList
         if dict.ContainsKey "name" then
-            {
-                Name = decodeStringOrExpression dict.["name"]
-                Type_ = cwlTypeDecoder' value
-            }
+            let schema = SchemaDefRequirementType(decodeStringOrExpression dict.["name"], cwlTypeDecoder' value)
+            overflowIntoDynamicObj schema schemaDefKnownFields value |> ignore
+            schema
         else
             if dict.Count = 0 then
                 raise (System.ArgumentException("SchemaDefRequirement entry cannot be empty."))
             let kv = dict |> Seq.head
-            {
-                Name = kv.Key
-                Type_ = cwlTypeDecoder' kv.Value
-            }
+            let schema = SchemaDefRequirementType(kv.Key, cwlTypeDecoder' kv.Value)
+            overflowIntoDynamicObj schema (kv.Key :: schemaDefKnownFields) value |> ignore
+            schema
 
     /// Decode a YAMLElement into a SchemaDefRequirementType array
     let schemaDefRequirementDecoder (get: Decode.IGetters): ResizeArray<SchemaDefRequirementType> =
@@ -770,31 +957,30 @@ module Decode =
     let workReuseRequirementDecoder (get: Decode.IGetters): Requirement =
         match get.Optional.Field "enableReuse" id with
         | None ->
-            WorkReuseRequirement { EnableReuse = true }
+            WorkReuseRequirement (WorkReuseRequirementValue(true))
         | Some value ->
             match tryDecodeBoolScalar value with
             | Some boolValue ->
-                WorkReuseRequirement { EnableReuse = boolValue }
+                WorkReuseRequirement (WorkReuseRequirementValue(boolValue))
             | None ->
                 WorkReuseExpressionRequirement (decodeStringOrExpression value)
 
     let networkAccessRequirementDecoder (get: Decode.IGetters): Requirement =
         match get.Optional.Field "networkAccess" id with
         | None ->
-            NetworkAccessRequirement { NetworkAccess = true }
+            NetworkAccessRequirement (NetworkAccessRequirementValue(true))
         | Some value ->
             match tryDecodeBoolScalar value with
             | Some boolValue ->
-                NetworkAccessRequirement { NetworkAccess = boolValue }
+                NetworkAccessRequirement (NetworkAccessRequirementValue(boolValue))
             | None ->
                 NetworkAccessExpressionRequirement (decodeStringOrExpression value)
 
     let inplaceUpdateRequirementDecoder (get: Decode.IGetters): InplaceUpdateRequirementValue =
-        {
-            InplaceUpdate =
-                get.Optional.Field "inplaceUpdate" Decode.bool
-                |> Option.defaultValue true
-        }
+        InplaceUpdateRequirementValue(
+            get.Optional.Field "inplaceUpdate" Decode.bool
+            |> Option.defaultValue true
+        )
 
     /// Decode a YAMLElement into a ToolTimeLimitRequirement value
     let toolTimeLimitRequirementDecoder (get: Decode.IGetters): ToolTimeLimitValue =
@@ -817,9 +1003,7 @@ module Decode =
             ToolTimeLimitExpression (decodeStringOrExpression timeLimitElement)
 
     let inlineJavascriptRequirementDecoder (get: Decode.IGetters): InlineJavascriptRequirementValue =
-        {
-            ExpressionLib = get.Optional.Field "expressionLib" decodeStringArrayOrScalar
-        }
+        InlineJavascriptRequirementValue(?expressionLib = get.Optional.Field "expressionLib" decodeStringArrayOrScalar)
 
     /// Decode all YAMLElements matching the Requirement type into a ResizeArray of Requirement
     let requirementFromTypeName cls get =
@@ -847,6 +1031,31 @@ module Decode =
         | "StepInputExpressionRequirement" -> StepInputExpressionRequirement
         | _ -> raise (System.ArgumentException($"Invalid or unsupported requirement class: {cls}"))
 
+    let private addRequirementPayloadOverflow (element: YAMLElement) (requirement: Requirement) =
+        let knownWithClass knownFields = "class" :: (knownFields |> Seq.toList)
+        match requirement with
+        | InlineJavascriptRequirement value ->
+            overflowIntoDynamicObj value (knownWithClass InlineJavascriptRequirementValue.KnownFieldNames) element |> ignore
+        | DockerRequirement value ->
+            overflowIntoDynamicObj value (knownWithClass DockerRequirement.KnownFieldNames) element |> ignore
+        | LoadListingRequirement value ->
+            overflowIntoDynamicObj value (knownWithClass LoadListingRequirementValue.KnownFieldNames) element |> ignore
+        | EnvVarRequirement _ ->
+            ()
+        | SoftwareRequirement _ ->
+            ()
+        | ResourceRequirement value ->
+            overflowIntoDynamicObj value (knownWithClass ResourceRequirementInstance.KnownFieldNames) element |> ignore
+        | WorkReuseRequirement value ->
+            overflowIntoDynamicObj value (knownWithClass WorkReuseRequirementValue.KnownFieldNames) element |> ignore
+        | NetworkAccessRequirement value ->
+            overflowIntoDynamicObj value (knownWithClass NetworkAccessRequirementValue.KnownFieldNames) element |> ignore
+        | InplaceUpdateRequirement value ->
+            overflowIntoDynamicObj value (knownWithClass InplaceUpdateRequirementValue.KnownFieldNames) element |> ignore
+        | _ ->
+            ()
+        requirement
+
     let requirementArrayDecoder : YAMLElement -> ResizeArray<Requirement> =
         fun yEle ->
             // helper: decode a single requirement object that contain 'class' field
@@ -854,6 +1063,7 @@ module Decode =
                 Decode.object (fun get ->
                     let cls = get.Required.Field "class" Decode.string
                     requirementFromTypeName cls get
+                    |> addRequirementPayloadOverflow ele
                 ) ele
 
             match yEle with
@@ -873,6 +1083,7 @@ module Decode =
                     get.Overflow.FieldList []
                     |> Seq.map (fun kv ->
                         Decode.object (requirementFromTypeName kv.Key) kv.Value
+                        |> addRequirementPayloadOverflow kv.Value
                     )
                     |> ResizeArray
                 ) yEle
@@ -884,6 +1095,7 @@ module Decode =
             Some (Decode.object (fun get ->
                 let cls = get.Required.Field "class" Decode.string
                 requirementFromTypeName cls get
+                |> addRequirementPayloadOverflow element
             ) element)
         with ex ->
             let hintClass =
@@ -907,7 +1119,7 @@ module Decode =
                     Decode.object (fun get -> get.Optional.Field "class" Decode.string) element
                 with _ ->
                     None
-            UnknownHint { Class = hintClass; Raw = element }
+            UnknownHint (HintUnknownValue(hintClass, element))
 
     let hintArrayDecoder : YAMLElement -> ResizeArray<HintEntry> =
         fun yEle ->
@@ -971,66 +1183,82 @@ module Decode =
                 get.Optional.Field 
                     "inputBinding" 
                     (
-                        Decode.object (fun get' ->
-                            {
-                                Prefix = get'.Optional.Field "prefix" Decode.string
-                                Position = get'.Optional.Field "position" Decode.int
-                                ItemSeparator = get'.Optional.Field "itemSeparator" Decode.string
-                                Separate = get'.Optional.Field "separate" Decode.bool
-                            }
-                        )         
+                        fun value ->
+                            Decode.object (fun get' ->
+                                let binding =
+                                    InputBinding(
+                                        ?prefix = get'.Optional.Field "prefix" Decode.string,
+                                        ?position = get'.Optional.Field "position" Decode.int,
+                                        ?itemSeparator = get'.Optional.Field "itemSeparator" Decode.string,
+                                        ?separate = get'.Optional.Field "separate" Decode.bool,
+                                        ?loadContents = get'.Optional.Field "loadContents" Decode.bool,
+                                        ?valueFrom = get'.Optional.Field "valueFrom" Decode.string,
+                                        ?shellQuote = get'.Optional.Field "shellQuote" Decode.bool
+                                    )
+                                overflowIntoDynamicObj binding (InputBinding.KnownFieldNames |> Seq.toList) value |> ignore
+                                binding
+                            ) value
                     )
             outputBinding
         )
 
+    let private decodeNamedInput (name: string) (value: YAMLElement) =
+        let inputBinding = inputBindingDecoder value
+        let cwlType, optional =
+            match value with
+            | YAMLElement.Object [YAMLElement.Value v] -> cwlTypeStringMatcher v.Value (Unchecked.defaultof<Decode.IGetters>)
+            | _ -> cwlTypeDecoder value
+        let input =
+            CWLInput(
+                name,
+                cwlType,
+                ?label = tryGetStringField "label" value,
+                ?secondaryFiles = tryGetYamlField "secondaryFiles" value,
+                ?streamable = tryGetBoolField "streamable" value,
+                ?doc = tryGetStringField "doc" value,
+                ?format = tryGetStringField "format" value,
+                ?loadContents = tryGetBoolField "loadContents" value,
+                ?loadListing = tryGetLoadListingField "loadListing" value,
+                ?defaultValue = tryGetYamlField "default" value
+            )
+        if optional then input.Optional <- Some true
+        input.InputBinding <- inputBinding
+        overflowIntoDynamicObj input (CWLInput.KnownFieldNames |> Seq.toList) value |> ignore
+        input
+
+    let private decodeInputSequenceItem (warnings: WarningSink) (path: string) (index: int) (item: YAMLElement) =
+        match tryGetStringField "id" item with
+        | Some id -> Some (decodeNamedInput id item)
+        | None when isIgnorableYamlNoise item -> None
+        | None ->
+            addWarning warnings $"{path}[{index}]" "Skipped malformed unnamed CWL input entry." (Some item)
+            None
+
     /// Decode a YAMLElement into an Input array
+    let inputArrayDecoderWithWarnings (warnings: WarningSink) (path: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLInput>) =
+        fun value ->
+            match value with
+            | YAMLElement.Object [YAMLElement.Sequence items]
+            | YAMLElement.Sequence items ->
+                items
+                |> List.mapi (decodeInputSequenceItem warnings path)
+                |> List.choose id
+                |> ResizeArray
+            | _ ->
+                let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
+                [| for key in dict.Keys do decodeNamedInput key dict.[key] |] |> ResizeArray
+
     let inputArrayDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLInput>) =
-        Decode.object (fun get ->
-            let dict = get.Overflow.FieldList []
-            [|
-                for key in dict.Keys do
-                    let value = dict.[key]
-                    let inputBinding = inputBindingDecoder value
-                    
-                    // Decode using unified cwlTypeDecoder'
-                    let cwlType, optional = 
-                        match value with
-                        | YAMLElement.Object [YAMLElement.Value v] -> 
-                            cwlTypeStringMatcher v.Value get
-                        | YAMLElement.Object mappings ->
-                            // Check if this has a "type" field
-                            let hasTypeField =
-                                mappings |> List.exists (fun m ->
-                                    match m with
-                                    | YAMLElement.Mapping (k, _) when k.Value = "type" -> true
-                                    | _ -> false
-                                )
-                            if hasTypeField then
-                                cwlTypeDecoder value
-                            else
-                                // No type field, treat as type string
-                                match value with
-                                | YAMLElement.Object [YAMLElement.Value v] -> cwlTypeStringMatcher v.Value get
-                                | _ -> raise (System.ArgumentException("Unexpected input format without type field"))
-                        | _ -> raise (System.ArgumentException("Unexpected input format in inputArrayDecoder"))
-                    
-                    let input = CWLInput(key, cwlType)
-                    if optional then
-                        DynObj.setOptionalProperty "optional" (Some true) input
-                    
-                    if inputBinding.IsSome then
-                        DynObj.setOptionalProperty "inputBinding" inputBinding input
-                    input
-            |]
-            |> ResizeArray
-        )
+        inputArrayDecoderWithWarnings None "inputs"
 
     /// Access the inputs field and decode the YAMLElements into an Input array
-    let inputsDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLInput> option) =
+    let inputsDecoderWithWarnings (warnings: WarningSink) : (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLInput> option) =
         Decode.object (fun get ->
-            let outputs = get.Optional.Field "inputs" inputArrayDecoder
-            outputs
+            get.Optional.Field "inputs" (inputArrayDecoderWithWarnings warnings "inputs")
         )
+
+    let inputsDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLInput> option) =
+        inputsDecoderWithWarnings None
 
     let baseCommandDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<string> option) =
         Decode.object (fun get ->
@@ -1159,18 +1387,25 @@ module Decode =
             | Some s, _ -> Some s
             | _, Some s -> Some s
             | _ -> None
-        {
-            Id = id
-            Source = source
-            DefaultValue = yamlElementOptionFieldDecoder "default" value
-            ValueFrom = stringOptionFieldDecoder "valueFrom" value
-            LinkMerge = linkMergeFieldDecoder "linkMerge" value
-            PickValue = pickValueFieldDecoder "pickValue" value
-            Doc = stringOptionFieldDecoder "doc" value
-            LoadContents = boolOptionFieldDecoder "loadContents" value
-            LoadListing = stringOptionFieldDecoder "loadListing" value
-            Label = stringOptionFieldDecoder "label" value
-        }
+        let stepInput =
+            StepInput.create(
+                id,
+                ?source = source,
+                ?defaultValue = yamlElementOptionFieldDecoder "default" value,
+                ?valueFrom = stringOptionFieldDecoder "valueFrom" value,
+                ?linkMerge = linkMergeFieldDecoder "linkMerge" value,
+                ?pickValue = pickValueFieldDecoder "pickValue" value,
+                ?doc = stringOptionFieldDecoder "doc" value,
+                ?loadContents = boolOptionFieldDecoder "loadContents" value,
+                ?loadListing = stringOptionFieldDecoder "loadListing" value,
+                ?label = stringOptionFieldDecoder "label" value
+            )
+        overflowIntoDynamicObj
+            stepInput
+            (StepInput.KnownFieldNames |> Seq.toList)
+            value
+        |> ignore
+        stepInput
 
     let decodeStepInputsFromMap (value: YAMLElement) : ResizeArray<StepInput> =
         let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
@@ -1184,19 +1419,32 @@ module Decode =
         let id = stringFieldDecoder "id" item
         decodeStepInputFromValue id item false
 
-    let decodeStepInputsFromArray (items: YAMLElement list) : ResizeArray<StepInput> =
+    let decodeStepInputsFromArrayWithWarnings (warnings: WarningSink) (path: string) (items: YAMLElement list) : ResizeArray<StepInput> =
         items
-        |> List.map decodeStepInputFromArrayItem
+        |> List.mapi (fun index item ->
+            match tryGetStringField "id" item with
+            | Some _ -> Some (decodeStepInputFromArrayItem item)
+            | None when isIgnorableYamlNoise item -> None
+            | None ->
+                addWarning warnings $"{path}[{index}]" "Skipped malformed unnamed CWL step input entry." (Some item)
+                None)
+        |> List.choose id
         |> ResizeArray
 
-    let inputStepDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<StepInput>) =
+    let decodeStepInputsFromArray (items: YAMLElement list) : ResizeArray<StepInput> =
+        decodeStepInputsFromArrayWithWarnings None "in" items
+
+    let inputStepDecoderWithWarnings (warnings: WarningSink) (path: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<StepInput>) =
         fun value ->
             match value with
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
-                decodeStepInputsFromArray items
+                decodeStepInputsFromArrayWithWarnings warnings path items
             | _ ->
                 decodeStepInputsFromMap value
+
+    let inputStepDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<StepInput>) =
+        inputStepDecoderWithWarnings None "in"
 
     let decodeStepOutputItem (value: YAMLElement) : StepOutput =
         match value with
@@ -1205,7 +1453,9 @@ module Decode =
             StepOutputString v.Value
         | _ ->
             let id = stringFieldDecoder "id" value
-            StepOutputRecord { Id = id }
+            let output = StepOutputParameter.create id
+            overflowIntoDynamicObj output (StepOutputParameter.KnownFieldNames |> Seq.toList) value |> ignore
+            StepOutputRecord output
 
     let outputStepsDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<StepOutput>) =
         Decode.object (fun get ->
@@ -1262,14 +1512,14 @@ module Decode =
         | _ ->
             yamlElement
 
-    let rec workflowStepRunDecoder (defaultCwlVersion: string) (runValue: YAMLElement) : WorkflowStepRun =
+    let rec workflowStepRunDecoder (warnings: WarningSink) (defaultCwlVersion: string) (runValue: YAMLElement) : WorkflowStepRun =
         match runValue with
         | YAMLElement.Object [YAMLElement.Value v]
         | YAMLElement.Value v ->
             RunString v.Value
         | YAMLElement.Object _ ->
             let normalizedRun = withDefaultCwlVersion defaultCwlVersion runValue
-            match decodeCWLProcessingUnitElement normalizedRun with
+            match decodeCWLProcessingUnitElementWithWarnings warnings normalizedRun with
             | CommandLineTool tool -> WorkflowStepRunOps.fromTool tool
             | Workflow workflow -> WorkflowStepRunOps.fromWorkflow workflow
             | ExpressionTool expressionTool -> WorkflowStepRunOps.fromExpressionTool expressionTool
@@ -1277,12 +1527,12 @@ module Decode =
         | _ ->
             raise (System.ArgumentException($"Unsupported run value for workflow step: %A{runValue}"))
 
-    and decodeWorkflowStepFromValueWithId (defaultCwlVersion: string) (stepId: string) (value: YAMLElement) : WorkflowStep =
+    and decodeWorkflowStepFromValueWithId (warnings: WarningSink) (defaultCwlVersion: string) (path: string) (stepId: string) (value: YAMLElement) : WorkflowStep =
         let runValue = Decode.object (fun get' -> get'.Required.Field "run" id) value
-        let run = workflowStepRunDecoder defaultCwlVersion runValue
+        let run = workflowStepRunDecoder warnings defaultCwlVersion runValue
         let inputs =
             Decode.object (fun get' ->
-                get'.Required.Field "in" inputStepDecoder
+                get'.Required.Field "in" (inputStepDecoderWithWarnings warnings $"{path}.in")
             ) value
         let outputs = outputStepsDecoder value
         let requirements = requirementsDecoder value
@@ -1308,37 +1558,51 @@ module Decode =
             wfStep.Requirements <- requirements
         if hints.IsSome then
             wfStep.Hints <- hints
+        overflowIntoDynamicObj
+            wfStep
+            (WorkflowStep.KnownFieldNames |> Seq.toList)
+            value
+        |> ignore
         wfStep
 
     and decodeWorkflowStepFromArrayItem (defaultCwlVersion: string) (item: YAMLElement) : WorkflowStep =
         let stepId = stringFieldDecoder "id" item
-        decodeWorkflowStepFromValueWithId defaultCwlVersion stepId item
+        decodeWorkflowStepFromValueWithId None defaultCwlVersion "steps[]" stepId item
 
-    and stepArrayDecoderWithVersion (defaultCwlVersion: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<WorkflowStep>) =
+    and decodeWorkflowStepFromArrayItemWithWarnings (warnings: WarningSink) (defaultCwlVersion: string) (index: int) (item: YAMLElement) =
+        match tryGetStringField "id" item with
+        | Some stepId -> Some (decodeWorkflowStepFromValueWithId warnings defaultCwlVersion $"steps[{index}]" stepId item)
+        | None when isIgnorableYamlNoise item -> None
+        | None ->
+            addWarning warnings $"steps[{index}]" "Skipped malformed unnamed CWL workflow step entry." (Some item)
+            None
+
+    and stepArrayDecoderWithVersion (warnings: WarningSink) (defaultCwlVersion: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<WorkflowStep>) =
         fun value ->
             match value with
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
                 items
-                |> List.map (decodeWorkflowStepFromArrayItem defaultCwlVersion)
+                |> List.mapi (decodeWorkflowStepFromArrayItemWithWarnings warnings defaultCwlVersion)
+                |> List.choose id
                 |> ResizeArray
             | _ ->
                 let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
                 [|
                     for key in dict.Keys do
-                        decodeWorkflowStepFromValueWithId defaultCwlVersion key dict.[key]
+                        decodeWorkflowStepFromValueWithId warnings defaultCwlVersion $"steps.{key}" key dict.[key]
                 |]
                 |> ResizeArray
 
-    and stepsDecoderWithVersion (defaultCwlVersion: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<WorkflowStep>) =
+    and stepsDecoderWithVersion (warnings: WarningSink) (defaultCwlVersion: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<WorkflowStep>) =
         Decode.object (fun get ->
-            get.Required.Field "steps" (stepArrayDecoderWithVersion defaultCwlVersion)
+            get.Required.Field "steps" (stepArrayDecoderWithVersion warnings defaultCwlVersion)
         )
 
-    and commandLineToolDecoder (yamlCWL : YAMLElement) =
+    and commandLineToolDecoder (warnings: WarningSink) (yamlCWL : YAMLElement) =
         let cwlVersion = versionDecoder yamlCWL
-        let outputs = outputsDecoder yamlCWL
-        let inputs = inputsDecoder yamlCWL
+        let outputs = outputsDecoderWithWarnings warnings yamlCWL
+        let inputs = inputsDecoderWithWarnings warnings yamlCWL
         let requirements = requirementsDecoder yamlCWL
         let hints = hintsDecoder yamlCWL
         let intent = intentDecoder yamlCWL
@@ -1349,7 +1613,14 @@ module Decode =
             CWLToolDescription(
                 outputs,
                 ?cwlVersion = Some cwlVersion,
-                ?id = idDecoder yamlCWL
+                ?id = idDecoder yamlCWL,
+                ?arguments = tryGetYamlField "arguments" yamlCWL,
+                ?stdin = tryGetStringField "stdin" yamlCWL,
+                ?stderr = tryGetStringField "stderr" yamlCWL,
+                ?stdout = tryGetStringField "stdout" yamlCWL,
+                ?successCodes = tryGetIntArrayField "successCodes" yamlCWL,
+                ?temporaryFailCodes = tryGetIntArrayField "temporaryFailCodes" yamlCWL,
+                ?permanentFailCodes = tryGetIntArrayField "permanentFailCodes" yamlCWL
             )
         let metadata =
             let md = new DynamicObj ()
@@ -1357,46 +1628,9 @@ module Decode =
             |> Decode.object (fun get ->
                 overflowDecoder
                     md
-                    (
-                        get.Overflow.FieldList [
-                            "inputs";
-                            "outputs";
-                            "class";
-                            "id";
-                            "label";
-                            "doc";
-                            "intent";
-                            "requirements";
-                            "hints";
-                            "cwlVersion";
-                            "baseCommand";
-                            "arguments";
-                            "stdin";
-                            "stderr";
-                            "stdout";
-                            "successCodes";
-                            "temporaryFailCodes";
-                            "permanentFailCodes"
-                        ]
-                    )
+                    (get.Overflow.FieldList (CWLToolDescription.KnownFieldNames |> Seq.toList))
             ) |> ignore
             md
-        yamlCWL
-        |> Decode.object (fun get ->
-            overflowDecoder
-                description
-                (
-                    get.MultipleOptional.FieldList [
-                        "arguments";
-                        "stdin";
-                        "stderr";
-                        "stdout";
-                        "successCodes";
-                        "temporaryFailCodes";
-                        "permanentFailCodes"
-                    ]
-                )
-        ) |> ignore
         if inputs.IsSome then
             description.Inputs <- inputs
         if requirements.IsSome then
@@ -1415,10 +1649,10 @@ module Decode =
             description.Metadata <- Some metadata
         description
 
-    and expressionToolDecoder (yamlCWL: YAMLElement) =
+    and expressionToolDecoder (warnings: WarningSink) (yamlCWL: YAMLElement) =
         let cwlVersion = versionDecoder yamlCWL
-        let outputs = outputsDecoder yamlCWL
-        let inputs = inputsDecoder yamlCWL
+        let outputs = outputsDecoderWithWarnings warnings yamlCWL
+        let inputs = inputsDecoderWithWarnings warnings yamlCWL
         let requirements = requirementsDecoder yamlCWL
         let hints = hintsDecoder yamlCWL
         let intent = intentDecoder yamlCWL
@@ -1439,21 +1673,7 @@ module Decode =
             |> Decode.object (fun get ->
                 overflowDecoder
                     md
-                    (
-                        get.Overflow.FieldList [
-                            "inputs";
-                            "outputs";
-                            "class";
-                            "id";
-                            "label";
-                            "doc";
-                            "intent";
-                            "requirements";
-                            "hints";
-                            "cwlVersion";
-                            "expression";
-                        ]
-                    )
+                    (get.Overflow.FieldList (CWLExpressionToolDescription.KnownFieldNames |> Seq.toList))
             ) |> ignore
             md
         if inputs.IsSome then
@@ -1472,11 +1692,11 @@ module Decode =
             description.Metadata <- Some metadata
         description
 
-    and operationDecoder (yamlCWL: YAMLElement) =
+    and operationDecoder (warnings: WarningSink) (yamlCWL: YAMLElement) =
         let cwlVersion = versionDecoder yamlCWL
-        let outputs = outputsDecoder yamlCWL
+        let outputs = outputsDecoderWithWarnings warnings yamlCWL
         let inputs =
-            match inputsDecoder yamlCWL with
+            match inputsDecoderWithWarnings warnings yamlCWL with
             | Some i -> i
             | None -> raise (System.InvalidOperationException("Inputs are required for an operation"))
         let requirements = requirementsDecoder yamlCWL
@@ -1497,20 +1717,7 @@ module Decode =
             |> Decode.object (fun get ->
                 overflowDecoder
                     md
-                    (
-                        get.Overflow.FieldList [
-                            "inputs";
-                            "outputs";
-                            "label";
-                            "doc";
-                            "intent";
-                            "class";
-                            "id";
-                            "requirements";
-                            "hints";
-                            "cwlVersion";
-                        ]
-                    )
+                    (get.Overflow.FieldList (CWLOperationDescription.KnownFieldNames |> Seq.toList))
             ) |> ignore
             md
         if requirements.IsSome then
@@ -1527,17 +1734,17 @@ module Decode =
             description.Metadata <- Some metadata
         description
 
-    and workflowDecoder (yamlCWL: YAMLElement) =
+    and workflowDecoder (warnings: WarningSink) (yamlCWL: YAMLElement) =
         let cwlVersion = versionDecoder yamlCWL
-        let outputs = outputsDecoder yamlCWL
+        let outputs = outputsDecoderWithWarnings warnings yamlCWL
         let inputs =
-            match inputsDecoder yamlCWL with
+            match inputsDecoderWithWarnings warnings yamlCWL with
             | Some i -> i
             | None -> raise (System.InvalidOperationException("Inputs are required for a workflow"))
         let requirements = requirementsDecoder yamlCWL
         let hints = hintsDecoder yamlCWL
         let intent = intentDecoder yamlCWL
-        let steps = stepsDecoderWithVersion cwlVersion yamlCWL
+        let steps = stepsDecoderWithVersion warnings cwlVersion yamlCWL
         let doc = docDecoder yamlCWL
         let label = labelDecoder yamlCWL
         let description =
@@ -1554,21 +1761,7 @@ module Decode =
             |> Decode.object (fun get ->
                 overflowDecoder
                     md
-                    (
-                        get.Overflow.FieldList [
-                            "inputs";
-                            "outputs";
-                            "label";
-                            "doc";
-                            "intent";
-                            "class";
-                            "steps";
-                            "id";
-                            "requirements";
-                            "hints";
-                            "cwlVersion";
-                        ]
-                    )
+                    (get.Overflow.FieldList (CWLWorkflowDescription.KnownFieldNames |> Seq.toList))
             ) |> ignore
             md
         if requirements.IsSome then
@@ -1585,109 +1778,165 @@ module Decode =
             description.Metadata <- Some metadata
         description
 
-    and decodeCWLProcessingUnitElement (yamlCWL: YAMLElement) =
+    and decodeCWLProcessingUnitElementWithWarnings (warnings: WarningSink) (yamlCWL: YAMLElement) =
         let cls = classDecoder yamlCWL
         match cls with
-        | "CommandLineTool" -> CommandLineTool (commandLineToolDecoder yamlCWL)
-        | "Workflow" -> Workflow (workflowDecoder yamlCWL)
-        | "ExpressionTool" -> ExpressionTool (expressionToolDecoder yamlCWL)
-        | "Operation" -> Operation (operationDecoder yamlCWL)
+        | "CommandLineTool" -> CommandLineTool (commandLineToolDecoder warnings yamlCWL)
+        | "Workflow" -> Workflow (workflowDecoder warnings yamlCWL)
+        | "ExpressionTool" -> ExpressionTool (expressionToolDecoder warnings yamlCWL)
+        | "Operation" -> Operation (operationDecoder warnings yamlCWL)
         | _ -> raise (System.ArgumentException($"Invalid or unsupported CWL class: {cls}"))
 
-    let stepArrayDecoder = stepArrayDecoderWithVersion "v1.2"
+    let decodeCWLProcessingUnitElement (yamlCWL: YAMLElement) =
+        decodeCWLProcessingUnitElementWithWarnings None yamlCWL
 
-    let stepsDecoder = stepsDecoderWithVersion "v1.2"
+    let stepArrayDecoder = stepArrayDecoderWithVersion None "v1.2"
+
+    let stepsDecoder = stepsDecoderWithVersion None "v1.2"
 
     /// Decode a CWL file string written in the YAML format into a CWLToolDescription
-    let decodeCommandLineTool (cwl: string) =
+    let decodeCommandLineToolWithWarnings (cwl: string) =
+        let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
-        commandLineToolDecoder yamlCWL
+        { Value = commandLineToolDecoder (Some warnings) yamlCWL; Warnings = warnings }
+
+    let decodeCommandLineTool (cwl: string) =
+        (decodeCommandLineToolWithWarnings cwl).Value
 
     /// Decode a CWL file string written in the YAML format into a CWLWorkflowDescription
-    let decodeWorkflow (cwl: string) =
+    let decodeWorkflowWithWarnings (cwl: string) =
+        let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
-        workflowDecoder yamlCWL
+        { Value = workflowDecoder (Some warnings) yamlCWL; Warnings = warnings }
+
+    let decodeWorkflow (cwl: string) =
+        (decodeWorkflowWithWarnings cwl).Value
 
     /// Decode a CWL file string written in the YAML format into a CWLExpressionToolDescription
-    let decodeExpressionTool (cwl: string) =
+    let decodeExpressionToolWithWarnings (cwl: string) =
+        let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
-        expressionToolDecoder yamlCWL
+        { Value = expressionToolDecoder (Some warnings) yamlCWL; Warnings = warnings }
+
+    let decodeExpressionTool (cwl: string) =
+        (decodeExpressionToolWithWarnings cwl).Value
 
     /// Decode a CWL file string written in the YAML format into a CWLOperationDescription
-    let decodeOperation (cwl: string) =
+    let decodeOperationWithWarnings (cwl: string) =
+        let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
-        operationDecoder yamlCWL
+        { Value = operationDecoder (Some warnings) yamlCWL; Warnings = warnings }
+
+    let decodeOperation (cwl: string) =
+        (decodeOperationWithWarnings cwl).Value
+
+    let decodeCWLProcessingUnitWithWarnings (cwl:string) =
+        let warnings = ResizeArray<DecodeWarning>()
+        let yamlCWL = readSanitizedYaml cwl
+        { Value = decodeCWLProcessingUnitElementWithWarnings (Some warnings) yamlCWL; Warnings = warnings }
 
     let decodeCWLProcessingUnit (cwl:string) =
-        let yamlCWL = readSanitizedYaml cwl
-        decodeCWLProcessingUnitElement yamlCWL
+        (decodeCWLProcessingUnitWithWarnings cwl).Value
 
 module DecodeParameters =
 
     let cwlParameterReferenceDecoder (get : Decode.IGetters) (key: string) (yEle: YAMLElement): CWLParameterReference =
+        let tryScalarString = function
+            | YAMLElement.Value v
+            | YAMLElement.Object [YAMLElement.Value v] -> Some v.Value
+            | _ -> None
+
+        let tryField fieldName value =
+            try
+                Decode.object (fun get -> get.Optional.Field fieldName id) value
+            with ex when Decode.isRecoverableDecodingError ex ->
+                None
+
+        let tryStringField fieldName value =
+            tryField fieldName value
+            |> Option.bind tryScalarString
+
+        let withOverflow (reference: CWLParameterReference) value =
+            Decode.overflowIntoDynamicObj reference (CWLParameterReference.KnownFieldNames |> Seq.toList) value |> ignore
+            reference
+
+        let fileOrDirectoryType className =
+            match className with
+            | "File" -> Some (CWLType.file())
+            | "Directory" -> Some (CWLType.directory())
+            | _ -> None
+
+        let pathValue value =
+            tryStringField "path" value
+            |> Option.orElseWith (fun () -> tryStringField "location" value)
+
+        let decodeObjectParameter value =
+            match tryStringField "class" value, tryStringField "type" value with
+            | Some className, _ ->
+                let cwlType = fileOrDirectoryType className
+                let values =
+                    pathValue value
+                    |> Option.map (fun p -> ResizeArray [| p |])
+                    |> Option.defaultValue (ResizeArray())
+                let reference = CWLParameterReference(key = key, values = values, ?type_ = cwlType)
+                withOverflow reference value
+            | None, Some typeName ->
+                let cwlType, _ = Decode.cwlTypeStringMatcher typeName get
+                let values =
+                    match tryField "value" value with
+                    | Some (YAMLElement.Object [YAMLElement.Sequence _] as sequenceValue)
+                    | Some (YAMLElement.Sequence _ as sequenceValue) ->
+                        Decode.resizearray Decode.string sequenceValue
+                    | Some scalarOrObject ->
+                        match tryScalarString scalarOrObject with
+                        | Some scalar -> ResizeArray [| scalar |]
+                        | None -> ResizeArray()
+                    | None -> ResizeArray()
+                let reference = CWLParameterReference(key = key, values = values, type_ = cwlType)
+                withOverflow reference value
+            | None, None ->
+                let reference = CWLParameterReference(key = key, values = ResizeArray())
+                withOverflow reference value
+
+        let decodeSequenceParameter (items: YAMLElement list) =
+            match items |> List.tryHead with
+            | Some first ->
+                match tryStringField "class" first with
+                | Some className when className = "File" || className = "Directory" ->
+                    let paths =
+                        items
+                        |> List.choose pathValue
+                        |> ResizeArray
+                    let itemType =
+                        match className with
+                        | "Directory" -> Directory (DirectoryInstance())
+                        | _ -> File (FileInstance())
+                    CWLParameterReference(
+                        key = key,
+                        values = paths,
+                        type_ = Array (InputArraySchema(itemType))
+                    )
+                | _ ->
+                    let values =
+                        items
+                        |> List.choose tryScalarString
+                        |> ResizeArray
+                    CWLParameterReference(key = key, values = values)
+            | None ->
+                CWLParameterReference(key = key, values = ResizeArray())
+
         match yEle with
-        | YAMLElement.Object[YAMLElement.Value v] ->
+        | YAMLElement.Value v
+        | YAMLElement.Object [YAMLElement.Value v] ->
             CWLParameterReference(
                 key = key,
                 values = ResizeArray [v.Value]
             )
-        | YAMLElement.Object[YAMLElement.Mapping (_,YAMLElement.Object [YAMLElement.Value v1]) ; YAMLElement.Mapping (_,YAMLElement.Object [YAMLElement.Value v2])] ->
-            let t,b = Decode.cwlTypeStringMatcher v1.Value get
-            CWLParameterReference(
-                key = key,
-                values = ResizeArray [v2.Value],
-                type_ = t
-            )
-        | YAMLElement.Object[YAMLElement.Sequence s] ->
-            // Check what type of sequence this is by examining the first element
-            match s |> List.tryHead with
-            | Some (YAMLElement.Object mappings) ->
-                // Check if mappings actually contains Mapping elements (not just Value)
-                let hasMappings = mappings |> List.exists (function
-                    | YAMLElement.Mapping _ -> true
-                    | _ -> false)
-                
-                if not hasMappings then
-                    // Not actually mappings, just wrapped values - use default decoder
-                    CWLParameterReference(
-                        key = key,
-                        values = Decode.resizearray Decode.string (YAMLElement.Sequence s)
-                    )
-                else
-                    // Check if it's a File/Directory object with a "class" field
-                    let hasClassField = mappings |> List.exists (function
-                        | YAMLElement.Mapping (k, _) when k.Value = "class" -> true
-                        | _ -> false)
-                    
-                    if hasClassField then
-                        // Sequence of File/Directory objects - extract paths
-                        let paths = ResizeArray<string>()
-                        for item in s do
-                            match item with
-                            | YAMLElement.Object itemMappings ->
-                                for mapping in itemMappings do
-                                    match mapping with
-                                    | YAMLElement.Mapping (k, YAMLElement.Object [YAMLElement.Value v]) when k.Value = "path" ->
-                                        paths.Add(v.Value)
-                                    | _ -> ()
-                            | _ -> ()
-                        // Since this is a sequence of Files, the type should be File[] (Array)
-                        CWLParameterReference(
-                            key = key,
-                            values = paths,
-                            type_ = Array { Items = File (FileInstance()); Label = None; Doc = None; Name = None }
-                        )
-                    else
-                        // Sequence of complex record objects (no "class" field)
-                        // Return empty placeholder
-                        CWLParameterReference(key = key, values = ResizeArray())
-            | _ ->
-                // Simple values sequence (strings, numbers, etc.) or empty
-                // Use original decoder logic
-                CWLParameterReference(
-                    key = key,
-                    values = Decode.resizearray Decode.string (YAMLElement.Sequence s)
-                )
+        | YAMLElement.Object [YAMLElement.Sequence s]
+        | YAMLElement.Sequence s ->
+            decodeSequenceParameter s
+        | YAMLElement.Object _ ->
+            decodeObjectParameter yEle
         | _ -> raise (System.ArgumentException($"Unexpected YAMLElement format in cwlParameterReferenceDecoder: %A{yEle}"))
 
     let cwlparameterReferenceArrayDecoder: YAMLElement -> ResizeArray<CWLParameterReference> =

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -27,8 +27,11 @@ module Decode =
 
     type WarningSink = ResizeArray<DecodeWarning> option
 
+    /// Add a recoverable decode warning only when the caller requested warning collection.
     let addWarning (warnings: WarningSink) (path: string) (message: string) (raw: YAMLElement option) =
         match warnings with
+        // Public non-warning APIs pass None, so tolerance paths can share this helper
+        // without allocating a collection or changing old call behavior.
         | Some warningList ->
             warningList.Add({
                 Path = path
@@ -38,9 +41,12 @@ module Decode =
         | None ->
             ()
 
+    /// Strip parser-level comment nodes and sequence placeholders before CWL semantic decoding.
     let rec removeYamlComments (yamlElement: YAMLElement) : YAMLElement =
         match yamlElement with
         | YAMLElement.Object elements ->
+            // Object children can contain comments directly beside mapping nodes.
+            // They should not be visible to CWL field decoders.
             elements
             |> List.choose (fun element ->
                 match element with
@@ -49,6 +55,8 @@ module Decode =
             )
             |> YAMLElement.Object
         | YAMLElement.Sequence elements ->
+            // Sequences need recursive cleanup because comments may appear as child
+            // comments or as empty object placeholders after YAMLicious parsing.
             elements
             |> List.choose (fun element ->
                 match removeYamlComments element with
@@ -80,11 +88,13 @@ module Decode =
         // All other exceptions (including system-critical) should propagate
         | _ -> false
 
+    /// Read YAML and normalize comment nodes that CWL decoders intentionally ignore.
     let readSanitizedYaml (yaml: string) =
         yaml
         |> Decode.read
         |> removeYamlComments
 
+    /// Box int64 values in a way that preserves 64-bit numeric intent across Fable targets.
     let boxOverflowInt64 (value: int64) : obj =
 #if FABLE_COMPILER_PYTHON
         Fable.Core.PyInterop.emitPyExpr value "int64($0)"
@@ -96,11 +106,15 @@ module Decode =
     let rec overflowDecoder (dynObj: DynamicObj) (dict: System.Collections.Generic.Dictionary<string,YAMLElement>) =
         let decodeOverflowScalar (value: YAMLContent) : obj =
             match value.Style with
+            // Quoted and block scalars are intentionally strings even when their text
+            // looks like a bool or number.
             | Some ScalarStyle.SingleQuoted
             | Some ScalarStyle.DoubleQuoted
             | Some (ScalarStyle.Block _) ->
                 box value.Value
             | _ ->
+                // Plain scalars follow YAML-ish coercion so extension metadata keeps
+                // useful numeric/bool shapes for roundtrips and downstream consumers.
                 match System.Boolean.TryParse value.Value with
                 | true, parsed -> box parsed
                 | _ ->
@@ -115,32 +129,43 @@ module Decode =
             match value with
             | YAMLElement.Value v
             | YAMLElement.Object [YAMLElement.Value v] ->
+                // YAMLicious often wraps scalar mapping values in Object [Value].
                 decodeOverflowScalar v
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
+                // Preserve lists recursively as ResizeArray<obj> to match the rest of
+                // the CWL object model.
                 items
                 |> List.map decodeOverflowValue
                 |> ResizeArray
                 |> box
             | YAMLElement.Object _ ->
+                // Nested mappings become nested DynamicObj instances instead of
+                // flattened string values.
                 let nested = DynamicObj()
                 value
                 |> Decode.object (fun get -> get.Overflow.FieldList [])
                 |> overflowDecoder nested
                 |> box
             | other ->
+                // Keep unsupported YAML nodes available rather than dropping them.
                 box other
 
         for e in dict do
+            // The caller already filtered known fields with FieldList, so every
+            // dictionary entry here is dynamic extension metadata.
             DynObj.setProperty e.Key (decodeOverflowValue e.Value) dynObj
         dynObj
 
+    /// Treat comment artifacts and empty placeholder objects as non-semantic collection items.
     let isIgnorableYamlNoise (value: YAMLElement) =
         match value with
         | YAMLElement.Comment _ -> true
         | YAMLElement.Object [] -> true
         | _ -> false
 
+    /// Decode an optional field only if the field is physically present, avoiding fallback
+    /// behavior that can blur absent fields with malformed field values.
     let tryGetPresentField (fieldName: string) (decoder: YAMLElement -> 'T) (value: YAMLElement) : 'T option =
         match value with
         | YAMLElement.Object fields
@@ -148,8 +173,11 @@ module Decode =
                  |> List.exists (function
                      | YAMLElement.Mapping (key, _) when key.Value = fieldName -> true
                      | _ -> false) ->
+            // Once presence is confirmed, use YAMLicious' normal optional field
+            // decoder so wrapped scalar and sequence handling remains consistent.
             Decode.object (fun get -> get.Optional.Field fieldName decoder) value
         | _ ->
+            // Missing fields and non-object shorthands are both represented as None.
             None
 
     let tryGetStringField (fieldName: string) (value: YAMLElement) =
@@ -164,6 +192,7 @@ module Decode =
     let tryGetIntArrayField (fieldName: string) (value: YAMLElement) =
         tryGetPresentField fieldName (Decode.resizearray Decode.int) value
 
+    /// Decode int64 fields explicitly so resource and File sizes do not narrow to int.
     let tryGetInt64Field (fieldName: string) (value: YAMLElement) =
         let decodeInt64 = function
             | YAMLElement.Value scalar
@@ -174,6 +203,7 @@ module Decode =
             | other -> raise (System.ArgumentException($"Invalid int64 value for {fieldName}: {other}"))
         tryGetPresentField fieldName decodeInt64 value
 
+    /// Decode and validate CWL loadListing enum fields from their YAML string form.
     let tryGetLoadListingField (fieldName: string) (value: YAMLElement) =
         tryGetStringField fieldName value
         |> Option.map (fun loadListingValue ->
@@ -181,16 +211,21 @@ module Decode =
             | Some parsed -> parsed
             | None -> raise (System.ArgumentException($"Invalid loadListing value '{loadListingValue}'. Expected one of: no_listing, shallow_listing, deep_listing.")))
 
+    /// Preserve unknown object fields on DynamicObj-backed CWL objects.
     let overflowIntoDynamicObj (dynObj: DynamicObj) (knownFields: string list) (value: YAMLElement) =
         match value with
         | YAMLElement.Object _ ->
+            // get.Overflow.FieldList removes fields consumed by the typed decoder;
+            // overflowDecoder stores the remaining fields without flattening them.
             value
             |> Decode.object (fun get -> overflowDecoder dynObj (get.Overflow.FieldList knownFields))
             |> ignore
         | _ ->
+            // Scalar shorthand has no field-level overflow to preserve.
             ()
         dynObj
 
+    /// Decode File object fields while preserving unrecognized extension metadata.
     let decodeFileInstanceFields (element: YAMLElement) =
         let file =
             FileInstance(
@@ -209,6 +244,7 @@ module Decode =
         overflowIntoDynamicObj file (FileInstance.KnownFieldNames |> Seq.toList) element |> ignore
         file
 
+    /// Decode Directory object fields while preserving unrecognized extension metadata.
     let decodeDirectoryInstanceFields (element: YAMLElement) =
         let directory =
             DirectoryInstance(
@@ -227,9 +263,12 @@ module Decode =
         match yEle with
         | YAMLElement.Value v
         | YAMLElement.Object [YAMLElement.Value v] ->
+            // Common path: plain scalar values become literal schema-salad strings.
             SchemaSaladString.Literal v.Value
         | YAMLElement.Object [YAMLElement.Mapping (c, YAMLElement.Value v)]
         | YAMLElement.Object [YAMLElement.Mapping (c, YAMLElement.Object [YAMLElement.Value v])] ->
+            // Directive forms keep their directive kind so encode can write them
+            // back as mappings instead of lossy literal text.
             match c.Value with
             | "$include" -> SchemaSaladString.Include v.Value
             | "$import" -> SchemaSaladString.Import v.Value
@@ -246,6 +285,8 @@ module Decode =
     let outputBindingGlobDecoder: (YAMLiciousTypes.YAMLElement -> OutputBinding) =
         fun value ->
             Decode.object (fun get ->
+                // Read all known outputBinding fields first; any implementation
+                // extension fields are attached below through overflowIntoDynamicObj.
                 let glob = get.Optional.Field "glob" Decode.string
                 let binding =
                     OutputBinding(
@@ -265,6 +306,7 @@ module Decode =
             outputBinding
         )
 
+    /// Decode schema-salad string-or-array fields into a uniform ResizeArray.
     let decodeStringArrayOrScalar (value: YAMLElement) : ResizeArray<string> =
         match value with
         | YAMLElement.Object [YAMLElement.Sequence items]
@@ -275,6 +317,7 @@ module Decode =
         | _ ->
             ResizeArray [| decodeStringOrExpression value |]
 
+    /// Decode CWL outputSource in either scalar or list form.
     let outputSourceDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<string> option) =
         Decode.object(fun get ->
             get.Optional.Field "outputSource" decodeStringArrayOrScalar
@@ -298,6 +341,8 @@ module Decode =
     /// Supports both Dirent object form and string/expression form.
     let initialWorkDirEntryDecoder: (YAMLiciousTypes.YAMLElement -> InitialWorkDirEntry) =
         fun value ->
+            // File and Directory object decoding is shared with CWL type decoding so
+            // listing entries preserve the same extension metadata.
             let decodeFileInstance (element: YAMLElement) =
                 decodeFileInstanceFields element
 
@@ -306,6 +351,8 @@ module Decode =
 
             match value with
             | YAMLElement.Object mappings ->
+                // Objects with entry are Dirent entries even if they also contain
+                // optional entryname/writable fields.
                 let hasEntryField =
                     mappings
                     |> List.exists (function
@@ -318,6 +365,8 @@ module Decode =
                     | Dirent dirent -> DirentEntry dirent
                     | _ -> raise (System.ArgumentException("Unexpected InitialWorkDir Dirent decoding result."))
                 else
+                    // File and Directory entries are discriminated by their class field;
+                    // all other objects are treated as schema-salad string directives.
                     let classValue =
                         mappings
                         |> List.tryPick (function
@@ -334,6 +383,8 @@ module Decode =
                         StringEntry (decodeSchemaSaladString value)
             | YAMLElement.Value _
             | YAMLElement.Object [YAMLElement.Value _] ->
+                // Scalar listing entries are allowed by CWL and represent generated
+                // file content or expressions.
                 StringEntry (decodeSchemaSaladString value)
             | _ ->
                 raise (System.ArgumentException($"Invalid InitialWorkDir listing entry: %A{value}"))
@@ -366,6 +417,8 @@ module Decode =
             | None ->
                 // Base type with array suffix
                 try
+                    // If the inner type is a simple CWL type, the current suffix
+                    // wraps it in one array layer.
                     let baseType = cwlSimpleTypeFromString innerType
                     Some (Array (InputArraySchema(baseType)))
                 with ex when isRecoverableDecodingError ex -> None
@@ -380,6 +433,8 @@ module Decode =
             let itemsValue = get.Required.Field "items" id
             let decodedItems = cwlTypeDecoder' itemsValue
             
+            // Array schema metadata is optional, but unknown fields still need to
+            // remain on the schema object for lossless roundtrips.
             let schema =
                 InputArraySchema(
                     decodedItems,
@@ -394,6 +449,7 @@ module Decode =
     and inputRecordFieldDecoder: (YAMLiciousTypes.YAMLElement -> InputRecordField) =
         fun value ->
         Decode.object (fun get ->
+            // Array-style record fields carry their own name field.
             let name = get.Required.Field "name" Decode.string
             
             // Decode the type field (can be string or complex type)
@@ -423,6 +479,7 @@ module Decode =
             let dict = Decode.object (fun get2 -> get2.Overflow.FieldList []) element
             let fields = ResizeArray<InputRecordField>()
             for kvp in dict do
+                // Map-style record fields use the mapping key as the field name.
                 let fieldType = cwlTypeDecoder' kvp.Value
                 let field =
                     InputRecordField(
@@ -456,6 +513,8 @@ module Decode =
                     | None -> tryDecodeFieldsAsMap element
                 | None -> None
             
+            // A record schema may be incomplete in some authoring contexts; keep
+            // whatever fields were available and preserve additional schema keys.
             let schema =
                 InputRecordSchema(
                     ?fields = decodedFields,
@@ -471,6 +530,8 @@ module Decode =
     and inputEnumSchemaDecoder: (YAMLiciousTypes.YAMLElement -> InputEnumSchema) =
         fun value ->
         Decode.object (fun get ->
+            // CWL enums are invalid without symbols; fail before constructing a
+            // partially meaningful enum schema.
             let symbols = get.Required.Field "symbols" (Decode.resizearray Decode.string)
             if symbols.Count = 0 then
                 raise (System.ArgumentException("CWL enum schema must define at least one symbol."))
@@ -489,7 +550,8 @@ module Decode =
     /// Decode a CWLType from a YAMLElement (handles all types including complex schemas)
     and cwlTypeDecoder' (element: YAMLiciousTypes.YAMLElement): CWLType =
         let parseTypeString (typeStr: string) =
-            // Handle optional suffix
+            // Split schema-salad shorthand like File[]? into the base type text and
+            // an optional wrapper flag before parsing the base type.
             let stripped, isOptional = 
                 if typeStr.EndsWith("?") then
                     typeStr.Replace("?", ""), true
@@ -509,6 +571,8 @@ module Decode =
                 baseType
 
         let parseTypeObjectString (typeStr: string) =
+            // Object forms such as {type: File, secondaryFiles: ...} need the
+            // surrounding object to populate File/Directory metadata.
             let stripped, isOptional =
                 if typeStr.EndsWith("?") then
                     typeStr.Replace("?", ""), true
@@ -533,6 +597,7 @@ module Decode =
         | YAMLElement.Sequence items
         | YAMLElement.Object [YAMLElement.Sequence items] ->
             // Union type. Mapping values may arrive wrapped as Object [Sequence ...].
+            // Each member can itself be shorthand, an array schema, a record, or enum.
             let types = items |> List.map cwlTypeDecoder' |> ResizeArray
             Union types
         | YAMLElement.Object _ ->
@@ -541,19 +606,23 @@ module Decode =
                 let typeField = get.Optional.Field "type" id
                 match typeField with
                 | Some (YAMLElement.Object [YAMLElement.Value v]) ->
+                    // Schema objects advertise their kind in the type field; simple
+                    // File/Directory object types are handled separately to keep metadata.
                     match v.Value with
                     | "record" -> Record (inputRecordSchemaDecoder element)
                     | "enum" -> Enum (inputEnumSchemaDecoder element)
                     | "array" -> Array (inputArraySchemaDecoder element)
                     | simpleType -> parseTypeObjectString simpleType
                 | Some (YAMLElement.Object _) ->
-                    // Nested complex type
+                    // Nested complex type, for example type: { type: array, ... }.
                     cwlTypeDecoder' (get.Required.Field "type" id)
                 | _ -> raise (System.ArgumentException("Unexpected type format in cwlTypeDecoder'"))
             ) element
         | _ -> raise (System.ArgumentException("Unexpected YAMLElement in cwlTypeDecoder'"))
     /// Match the input string to the possible CWL types and checks if it is optional
     let cwlTypeStringMatcher (t: string) (get: Decode.IGetters) =
+        // This helper is used for legacy simple type string paths that also need
+        // to report whether `?` was present for CWLInput.Optional.
         let optional, newT =
             if t.EndsWith("?") then
                 true, t.Replace("?", "")
@@ -597,6 +666,8 @@ module Decode =
                     (
                         fun value ->
                             match value with
+                            // Return Some only for scalar type fields; object and
+                            // sequence type fields are delegated to cwlTypeDecoder'.
                             | YAMLElement.Value v | YAMLElement.Object [YAMLElement.Value v] -> Some v.Value
                             | YAMLElement.Object o -> None
                             | YAMLElement.Sequence _ -> None
@@ -604,19 +675,26 @@ module Decode =
                     )
             match cwlType with
             | Some t ->
+                // Scalar type field, including shorthand such as File[]?.
                 cwlTypeStringMatcher t get
             | None -> 
+                // Complex type field, for example inline record/enum/array schema.
                 let cwlType = get.Required.Field "type" cwlTypeDecoder'
                 cwlType, false
         )
 
+    /// Decode a named output from either map shorthand or full object form.
     let decodeNamedOutput (name: string) (value: YAMLElement) =
+        // Decode dependent fields before constructing the output so both shorthand
+        // and object forms share the same object initialization path.
         let outputBinding = outputBindingDecoder value
         let outputSourceValues = outputSourceDecoder value
         let cwlType =
             match value with
             | YAMLElement.Object [YAMLElement.Value v] -> cwlTypeStringMatcher v.Value (Unchecked.defaultof<Decode.IGetters>) |> fst
             | _ -> cwlTypeDecoder value |> fst
+        // Optional presentation and behavior fields are read directly from the
+        // object form; shorthand values simply leave them absent.
         let output =
             CWLOutput(
                 name,
@@ -626,15 +704,17 @@ module Decode =
                 ?streamable = tryGetBoolField "streamable" value,
                 ?doc = tryGetStringField "doc" value,
                 ?format = tryGetStringField "format" value
-            )
+        )
         output.OutputBinding <- outputBinding
         match outputSourceValues with
+        // Preserve CWL's scalar-versus-array distinction as a discriminated union.
         | Some values when values.Count > 1 -> output.OutputSource <- Some (OutputSource.Multiple values)
         | Some values when values.Count = 1 -> output.OutputSource <- Some (OutputSource.Single values.[0])
         | _ -> ()
         overflowIntoDynamicObj output (CWLOutput.KnownFieldNames |> Seq.toList) value |> ignore
         output
 
+    /// Decode one sequence-form output, warning only for malformed unnamed entries.
     let decodeOutputSequenceItem (warnings: WarningSink) (path: string) (index: int) (item: YAMLElement) =
         match tryGetStringField "id" item with
         | Some id -> Some (decodeNamedOutput id item)
@@ -649,11 +729,14 @@ module Decode =
             match value with
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
+                // Sequence-form ports must declare id on each item. Unnamed malformed
+                // items are the tolerant path and produce warnings.
                 items
                 |> List.mapi (decodeOutputSequenceItem warnings path)
                 |> List.choose id
                 |> ResizeArray
             | _ ->
+                // Map-form ports use the map key as the port name.
                 let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
                 [| for key in dict.Keys do decodeNamedOutput key dict.[key] |] |> ResizeArray
 
@@ -671,10 +754,13 @@ module Decode =
 
     /// Decode a YAMLElement into a DockerRequirement
     let dockerRequirementDecoder (get: Decode.IGetters): DockerRequirement =
+        // dockerFile can be a plain string or schema-salad include/import directive.
         let dockerFile =
             get.Optional.Field "dockerFile" id
             |> Option.map decodeSchemaSaladString
 
+        // Constructor normalization gives dockerFileReference precedence over the
+        // legacy plain dockerFile argument.
         DockerRequirement.create(
             ?dockerPull = get.Optional.Field "dockerPull" Decode.string,
             ?dockerFileReference = dockerFile,
@@ -689,6 +775,8 @@ module Decode =
     /// Supports both array form and map shorthand form (envName -> envValue).
     let envVarRequirementDecoder (get: Decode.IGetters): ResizeArray<EnvironmentDef> =
         let normalizeCollectionElement = function
+            // YAMLicious may wrap the collection under Object; normalize before
+            // choosing array-style or map-style decoding.
             | YAMLElement.Object [YAMLElement.Sequence sequence] -> YAMLElement.Sequence sequence
             | YAMLElement.Object [YAMLElement.Object mappings] -> YAMLElement.Object mappings
             | other -> other
@@ -696,6 +784,8 @@ module Decode =
         let decodeEnvValue = function
             | YAMLElement.Value value
             | YAMLElement.Object [YAMLElement.Value value] ->
+                // Env var values are strings by CWL semantics; trim protective quotes
+                // added by the encoder around boolean-looking strings.
                 value.Value.Trim('"')
             | other ->
                 decodeStringOrExpression other
@@ -704,6 +794,7 @@ module Decode =
 
         match envDefElement with
         | YAMLElement.Sequence _ ->
+            // Standard CWL form: envDef is an array of {envName, envValue} objects.
             Decode.resizearray
                 (fun value ->
                     Decode.object (fun get2 ->
@@ -717,6 +808,7 @@ module Decode =
                     ) value)
                 envDefElement
         | YAMLElement.Object mappings ->
+            // Shorthand form: envDef is a map from variable name to value.
             mappings
             |> List.choose (function
                 | YAMLElement.Mapping (key, value) ->
@@ -730,6 +822,7 @@ module Decode =
     /// Supports both array form and map shorthand form.
     let softwareRequirementDecoder (get: Decode.IGetters): ResizeArray<SoftwarePackage> =
         let normalizeCollectionElement = function
+            // Accept wrapped sequence/object values produced by the YAML parser.
             | YAMLElement.Object [YAMLElement.Sequence sequence] -> YAMLElement.Sequence sequence
             | YAMLElement.Object [YAMLElement.Object mappings] -> YAMLElement.Object mappings
             | other -> other
@@ -737,6 +830,7 @@ module Decode =
         let packagesElement = get.Required.Field "packages" id |> normalizeCollectionElement
 
         let decodeSpecsArray (element: YAMLElement) =
+            // Version and specs can be scalar-or-array schema-salad strings.
             let normalized = normalizeCollectionElement element
             Decode.resizearray decodeStringOrExpression normalized
 
@@ -744,10 +838,13 @@ module Decode =
             let normalizedPackageValue = normalizeCollectionElement packageValue
             match normalizedPackageValue with
             | YAMLElement.Object [] ->
+                // packages: { samtools: {} }
                 SoftwarePackage(packageName)
             | YAMLElement.Sequence _ ->
+                // packages: { samtools: [spec1, spec2] } means specs shorthand.
                 SoftwarePackage(packageName, specs = decodeSpecsArray normalizedPackageValue)
             | YAMLElement.Object mappings ->
+                // Full map shorthand can include version/specs plus extension fields.
                 let version =
                     mappings
                     |> List.tryPick (function
@@ -762,10 +859,12 @@ module Decode =
                 overflowIntoDynamicObj package (SoftwarePackage.KnownFieldNames |> Seq.toList) normalizedPackageValue |> ignore
                 package
             | _ ->
+                // Scalar map value is treated as one specs entry.
                 SoftwarePackage(packageName, specs = ResizeArray [| decodeStringOrExpression packageValue |])
 
         match packagesElement with
         | YAMLElement.Sequence _ ->
+            // Standard CWL form: packages is an array of package objects.
             Decode.resizearray
                 (fun value ->
                     Decode.object (fun get2 ->
@@ -780,6 +879,7 @@ module Decode =
                     ) value)
                 packagesElement
         | YAMLElement.Object mappings ->
+            // Compact CWL form: package names are map keys.
             mappings
             |> List.choose (function
                 | YAMLElement.Mapping (key, value) -> Some (decodePackageFromMapEntry key.Value value)
@@ -795,10 +895,13 @@ module Decode =
         match listingElement with
         | YAMLElement.Object [YAMLElement.Sequence _]
         | YAMLElement.Sequence _ ->
+            // Normal case: listing is a sequence of entries.
             Decode.resizearray initialWorkDirEntryDecoder listingElement
         | _ ->
+            // CWL also permits a single listing entry without an enclosing array.
             ResizeArray [| initialWorkDirEntryDecoder listingElement |]
 
+    /// Decode LoadListingRequirement, applying CWL's default no_listing behavior.
     let loadListingRequirementDecoder (get: Decode.IGetters): LoadListingRequirementValue =
         let loadListingValue =
             get.Optional.Field "loadListing" Decode.string
@@ -809,6 +912,7 @@ module Decode =
             | None -> raise (System.ArgumentException($"Invalid loadListing value '{loadListingValue}'. Expected one of: no_listing, shallow_listing, deep_listing."))
         LoadListingRequirementValue(loadListing)
 
+    /// Decode resource scalar fields as int64, float, or expression string without losing numeric shape.
     let decodeResourceScalar (element: YAMLElement) : obj =
         let tryGetScalarString = function
             | YAMLElement.Value value
@@ -828,12 +932,15 @@ module Decode =
         | None ->
             box (decodeStringOrExpression element)
 
+    /// Decode an optional resource field through the resource scalar coercion rules.
     let optionalResourceField (get: Decode.IGetters) (fieldName: string) : obj option =
         get.Optional.Field fieldName id
         |> Option.map decodeResourceScalar
 
     /// Decode a YAMLElement into a ResourceRequirementInstance
     let resourceRequirementDecoder (get: Decode.IGetters): ResourceRequirementInstance =
+        // Resource fields may be integer, float, or expression string. Keep them as
+        // obj so the original scalar category can be re-encoded.
         ResourceRequirementInstance(
             ?coresMin = optionalResourceField get "coresMin",
             ?coresMax = optionalResourceField get "coresMax",
@@ -845,9 +952,12 @@ module Decode =
             ?outdirMax = optionalResourceField get "outdirMax"
         )
         
+    /// Decode schema definition entries in either named object or map-entry shorthand form.
     let schemaDefRequirementTypeDecoder (value: YAMLElement) : SchemaDefRequirementType =
         let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
         let schemaDefKnownFields =
+            // SchemaDefRequirement entries combine the wrapper fields with the
+            // schema fields of the referenced record/array/enum definition.
             Set.unionMany
                 [
                     SchemaDefRequirementType.KnownFieldNames
@@ -857,12 +967,14 @@ module Decode =
                 ]
             |> Seq.toList
         if dict.ContainsKey "name" then
+            // Explicit object form: {name: X, type: ...}
             let schema = SchemaDefRequirementType(decodeStringOrExpression dict.["name"], cwlTypeDecoder' value)
             overflowIntoDynamicObj schema schemaDefKnownFields value |> ignore
             schema
         else
             if dict.Count = 0 then
                 raise (System.ArgumentException("SchemaDefRequirement entry cannot be empty."))
+            // Map shorthand form: {X: {type: record, ...}}
             let kv = dict |> Seq.head
             let schema = SchemaDefRequirementType(kv.Key, cwlTypeDecoder' kv.Value)
             overflowIntoDynamicObj schema (kv.Key :: schemaDefKnownFields) value |> ignore
@@ -872,6 +984,7 @@ module Decode =
     let schemaDefRequirementDecoder (get: Decode.IGetters): ResizeArray<SchemaDefRequirementType> =
         get.Required.Field "types" (Decode.resizearray schemaDefRequirementTypeDecoder)
 
+    /// Decode only literal boolean scalars, leaving expressions for requirement-specific handling.
     let tryDecodeBoolScalar (element: YAMLElement) : bool option =
         match element with
         | YAMLElement.Value value
@@ -883,6 +996,7 @@ module Decode =
         | _ ->
             None
 
+    /// Decode WorkReuse as either a concrete bool requirement or an expression payload.
     let workReuseRequirementDecoder (get: Decode.IGetters): Requirement =
         match get.Optional.Field "enableReuse" id with
         | None ->
@@ -894,6 +1008,7 @@ module Decode =
             | None ->
                 WorkReuseExpressionRequirement (decodeStringOrExpression value)
 
+    /// Decode NetworkAccess as either a concrete bool requirement or an expression payload.
     let networkAccessRequirementDecoder (get: Decode.IGetters): Requirement =
         match get.Optional.Field "networkAccess" id with
         | None ->
@@ -905,6 +1020,7 @@ module Decode =
             | None ->
                 NetworkAccessExpressionRequirement (decodeStringOrExpression value)
 
+    /// Decode InplaceUpdateRequirement, defaulting missing inplaceUpdate to true.
     let inplaceUpdateRequirementDecoder (get: Decode.IGetters): InplaceUpdateRequirementValue =
         InplaceUpdateRequirementValue(
             get.Optional.Field "inplaceUpdate" Decode.bool
@@ -915,6 +1031,8 @@ module Decode =
     let toolTimeLimitRequirementDecoder (get: Decode.IGetters): ToolTimeLimitValue =
         let timeLimitElement = get.Required.Field "timelimit" id
         let tryGetScalarString =
+            // Numeric timelimits and expression timelimits both arrive as scalars;
+            // parsing decides the typed union case below.
             match timeLimitElement with
             | YAMLElement.Value value
             | YAMLElement.Object [YAMLElement.Value value] ->
@@ -929,12 +1047,14 @@ module Decode =
             | true, _ -> raise (System.ArgumentException("ToolTimeLimit timelimit must be non-negative."))
             | false, _ -> ToolTimeLimitExpression (decodeStringOrExpression timeLimitElement)
         | None ->
+            // Non-scalar values can only be represented as expression-like strings here.
             ToolTimeLimitExpression (decodeStringOrExpression timeLimitElement)
 
+    /// Decode InlineJavascriptRequirement expressionLib in scalar or array form.
     let inlineJavascriptRequirementDecoder (get: Decode.IGetters): InlineJavascriptRequirementValue =
         InlineJavascriptRequirementValue(?expressionLib = get.Optional.Field "expressionLib" decodeStringArrayOrScalar)
 
-    /// Decode all YAMLElements matching the Requirement type into a ResizeArray of Requirement
+    /// Dispatch a known CWL requirement class to its typed decoder.
     let requirementFromTypeName cls get =
         match cls with
         | "InlineJavascriptRequirement" -> InlineJavascriptRequirement (inlineJavascriptRequirementDecoder get)
@@ -960,9 +1080,12 @@ module Decode =
         | "StepInputExpressionRequirement" -> StepInputExpressionRequirement
         | _ -> raise (System.ArgumentException($"Invalid or unsupported requirement class: {cls}"))
 
+    /// Attach unknown payload fields to DynamicObj-backed requirement values after class dispatch.
     let addRequirementPayloadOverflow (element: YAMLElement) (requirement: Requirement) =
         let knownWithClass knownFields = "class" :: (knownFields |> Seq.toList)
         match requirement with
+        // Only payload records/classes that inherit DynamicObj can receive overflow.
+        // Collection requirements preserve overflow at each item decoder instead.
         | InlineJavascriptRequirement value ->
             overflowIntoDynamicObj value (knownWithClass InlineJavascriptRequirementValue.KnownFieldNames) element |> ignore
         | DockerRequirement value ->
@@ -985,11 +1108,13 @@ module Decode =
             ()
         requirement
 
+    /// Decode requirements from either sequence syntax or class-name map syntax.
     let requirementArrayDecoder : YAMLElement -> ResizeArray<Requirement> =
         fun yEle ->
             // helper: decode a single requirement object that contain 'class' field
             let decodeSingleRequirementObject (ele: YAMLElement) : Requirement =
                 Decode.object (fun get ->
+                    // Sequence syntax carries class inside each item.
                     let cls = get.Required.Field "class" Decode.string
                     requirementFromTypeName cls get
                     |> addRequirementPayloadOverflow ele
@@ -1011,6 +1136,8 @@ module Decode =
                 Decode.object (fun get ->
                     get.Overflow.FieldList []
                     |> Seq.map (fun kv ->
+                        // Map syntax uses the mapping key as the requirement class
+                        // and the mapping value as that requirement's payload.
                         Decode.object (requirementFromTypeName kv.Key) kv.Value
                         |> addRequirementPayloadOverflow kv.Value
                     )
@@ -1019,6 +1146,7 @@ module Decode =
             // INVALID CWL REQUIREMENTS  
             | other -> raise (System.ArgumentException($"Invalid CWL requirements syntax: {other}"))
 
+    /// Try known requirement decoding for hints, falling back to UnknownHint on decode failure.
     let tryDecodeKnownRequirementFromElement (element: YAMLElement) : Requirement option =
         try
             Some (Decode.object (fun get ->
@@ -1039,6 +1167,7 @@ module Decode =
                 ()
             None
 
+    /// Decode one hint as a known requirement when possible, otherwise preserve the raw hint.
     let decodeHintElement (element: YAMLElement) : HintEntry =
         match tryDecodeKnownRequirementFromElement element with
         | Some requirement -> KnownHint requirement
@@ -1050,11 +1179,14 @@ module Decode =
                     None
             UnknownHint (HintUnknownValue(hintClass, element))
 
+    /// Decode hints from sequence syntax or class-name map syntax while preserving unknown hints.
     let hintArrayDecoder : YAMLElement -> ResizeArray<HintEntry> =
         fun yEle ->
             match yEle with
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
+                // Sequence hints can be known requirement payloads or arbitrary
+                // extension hints.
                 items
                 |> List.map decodeHintElement
                 |> ResizeArray
@@ -1066,6 +1198,8 @@ module Decode =
                             match kv.Value with
                             | YAMLElement.Object mappings ->
                                 let hasClass =
+                                    // If map-style hint payload already has class,
+                                    // preserve it instead of overwriting with the key.
                                     mappings
                                     |> List.exists (function
                                         | YAMLElement.Mapping (k, _) when k.Value = "class" -> true
@@ -1073,10 +1207,14 @@ module Decode =
                                     )
                                 if hasClass then kv.Value
                                 else
+                                    // Map-style hints use the key as synthetic class
+                                    // for compatibility with sequence-form decoding.
                                     let clsKey = YAMLContent.create "class"
                                     let clsValue = YAMLElement.Object [YAMLElement.Value (YAMLContent.create kv.Key)]
                                     YAMLElement.Object (YAMLElement.Mapping (clsKey, clsValue) :: mappings)
                             | other ->
+                                // Scalar map-style hints are wrapped as {class, value}
+                                // so decodeHintElement can still classify them.
                                 let clsKey = YAMLContent.create "class"
                                 let clsValue = YAMLElement.Object [YAMLElement.Value (YAMLContent.create kv.Key)]
                                 let valueKey = YAMLContent.create "value"
@@ -1114,6 +1252,8 @@ module Decode =
                     (
                         fun value ->
                             Decode.object (fun get' ->
+                                // InputBinding has several optional command-line
+                                // behavior fields; absent fields remain None.
                                 let binding =
                                     InputBinding(
                                         ?prefix = get'.Optional.Field "prefix" Decode.string,
@@ -1131,12 +1271,17 @@ module Decode =
             outputBinding
         )
 
+    /// Decode a named input from map shorthand or full object form, preserving optionality and extensions.
     let decodeNamedInput (name: string) (value: YAMLElement) =
+        // inputBinding is nested and decoded separately so both shorthand and object
+        // input definitions can share the same construction flow.
         let inputBinding = inputBindingDecoder value
         let cwlType, optional =
             match value with
             | YAMLElement.Object [YAMLElement.Value v] -> cwlTypeStringMatcher v.Value (Unchecked.defaultof<Decode.IGetters>)
             | _ -> cwlTypeDecoder value
+        // Known optional fields are copied into typed properties; unrecognized fields
+        // are attached below as DynamicObj overflow.
         let input =
             CWLInput(
                 name,
@@ -1155,6 +1300,7 @@ module Decode =
         overflowIntoDynamicObj input (CWLInput.KnownFieldNames |> Seq.toList) value |> ignore
         input
 
+    /// Decode one sequence-form input, warning only for malformed unnamed entries.
     let decodeInputSequenceItem (warnings: WarningSink) (path: string) (index: int) (item: YAMLElement) =
         match tryGetStringField "id" item with
         | Some id -> Some (decodeNamedInput id item)
@@ -1169,11 +1315,13 @@ module Decode =
             match value with
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
+                // Sequence-form inputs must carry an id on each object item.
                 items
                 |> List.mapi (decodeInputSequenceItem warnings path)
                 |> List.choose id
                 |> ResizeArray
             | _ ->
+                // Map-form inputs use the map key as the input name.
                 let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
                 [| for key in dict.Keys do decodeNamedInput key dict.[key] |] |> ResizeArray
 
@@ -1189,6 +1337,7 @@ module Decode =
     let inputsDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<CWLInput> option) =
         inputsDecoderWithWarnings None
 
+    /// Decode baseCommand from CWL's scalar or array forms.
     let baseCommandDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<string> option) =
         Decode.object (fun get ->
             let baseCommandField = get.Optional.Field "baseCommand" id
@@ -1206,7 +1355,10 @@ module Decode =
                 // Array of strings unwrapped
                 Some (Decode.resizearray Decode.string (YAMLElement.Sequence s))
             | None -> None
-            | _ -> None
+            | _ ->
+                // Malformed baseCommand is ignored for backward compatibility with
+                // the previous permissive decoder.
+                None
         )
 
     let versionDecoder: (YAMLiciousTypes.YAMLElement -> string) =
@@ -1245,9 +1397,11 @@ module Decode =
         match value with
         | YAMLElement.Object [YAMLElement.Value v]
         | YAMLElement.Value v ->
+            // CWL shorthand: source: input_id
             Some (ResizeArray [ v.Value ])
         | YAMLElement.Object [YAMLElement.Sequence s]
         | YAMLElement.Sequence s ->
+            // Full form: source: [a, b]
             Some (Decode.resizearray Decode.string (YAMLElement.Sequence s))
         | _ -> None
 
@@ -1259,6 +1413,7 @@ module Decode =
             |> Option.bind stringOrStringArrayDecoder
         )
 
+    /// Decode and validate linkMerge enum fields.
     let linkMergeFieldDecoder field : (YAMLiciousTypes.YAMLElement -> LinkMergeMethod option) =
         Decode.object(fun get ->
             let linkMergeField = get.Optional.Field field Decode.string
@@ -1270,6 +1425,7 @@ module Decode =
             | None -> None
         )
 
+    /// Decode and validate pickValue enum fields.
     let pickValueFieldDecoder field : (YAMLiciousTypes.YAMLElement -> PickValueMethod option) =
         Decode.object(fun get ->
             let pickValueField = get.Optional.Field field Decode.string
@@ -1287,6 +1443,7 @@ module Decode =
             |> Option.bind stringOrStringArrayDecoder
         )
 
+    /// Decode and validate scatterMethod enum fields.
     let scatterMethodFieldDecoder field : (YAMLiciousTypes.YAMLElement -> ScatterMethod option) =
         Decode.object(fun get ->
             let scatterMethodField = get.Optional.Field field Decode.string
@@ -1298,24 +1455,32 @@ module Decode =
             | None -> None
         )
 
+    /// Decode optional expression-like fields, including schema-salad directive wrappers.
     let expressionStringOptionFieldDecoder field : (YAMLiciousTypes.YAMLElement -> string option) =
         Decode.object(fun get ->
             get.Optional.Field field id
             |> Option.map decodeStringOrExpression
         )
 
+    /// Decode a step input from map or scalar shorthand and preserve unknown step-input fields.
     let decodeStepInputFromValue (id: string) (value: YAMLElement) (allowScalarSource: bool) : StepInput =
         let scalarSource =
             if allowScalarSource then
+                // Map-form step inputs may be `in: { target: source }`, where the
+                // value itself is the source field.
                 stringOrStringArrayDecoder value
             else
+                // Sequence-form items use explicit fields and should not treat the
+                // whole item as a source scalar.
                 None
         let fieldSource = sourceArrayFieldDecoder "source" value
         let source =
             match scalarSource, fieldSource with
+            // Prefer scalar shorthand when present; otherwise use the source field.
             | Some s, _ -> Some s
             | _, Some s -> Some s
             | _ -> None
+        // Decode all optional step-input behavior fields before preserving overflow.
         let stepInput =
             StepInput.create(
                 id,
@@ -1336,6 +1501,7 @@ module Decode =
         |> ignore
         stepInput
 
+    /// Decode map-form step inputs where the map key supplies the step input id.
     let decodeStepInputsFromMap (value: YAMLElement) : ResizeArray<StepInput> =
         let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
         [|
@@ -1344,17 +1510,21 @@ module Decode =
         |]
         |> ResizeArray
 
+    /// Decode sequence-form step inputs where the id must be present in the item.
     let decodeStepInputFromArrayItem (item: YAMLElement) : StepInput =
         let id = stringFieldDecoder "id" item
         decodeStepInputFromValue id item false
 
+    /// Decode sequence-form step inputs, warning and skipping only malformed unnamed entries.
     let decodeStepInputsFromArrayWithWarnings (warnings: WarningSink) (path: string) (items: YAMLElement list) : ResizeArray<StepInput> =
         items
         |> List.mapi (fun index item ->
             match tryGetStringField "id" item with
+            // Items with ids are considered intended CWL step inputs and decode strictly.
             | Some _ -> Some (decodeStepInputFromArrayItem item)
             | None when isIgnorableYamlNoise item -> None
             | None ->
+                // Unnamed malformed entries are public-workflow tolerance cases.
                 addWarning warnings $"{path}[{index}]" "Skipped malformed unnamed CWL step input entry." (Some item)
                 None)
         |> List.choose id
@@ -1363,6 +1533,7 @@ module Decode =
     let decodeStepInputsFromArray (items: YAMLElement list) : ResizeArray<StepInput> =
         decodeStepInputsFromArrayWithWarnings None "in" items
 
+    /// Select the step input decoder based on CWL map-form versus sequence-form syntax.
     let inputStepDecoderWithWarnings (warnings: WarningSink) (path: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<StepInput>) =
         fun value ->
             match value with
@@ -1375,6 +1546,7 @@ module Decode =
     let inputStepDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<StepInput>) =
         inputStepDecoderWithWarnings None "in"
 
+    /// Decode step outputs from scalar shorthand or record form with extension fields.
     let decodeStepOutputItem (value: YAMLElement) : StepOutput =
         match value with
         | YAMLElement.Object [YAMLElement.Value v]
@@ -1386,11 +1558,13 @@ module Decode =
             overflowIntoDynamicObj output (StepOutputParameter.KnownFieldNames |> Seq.toList) value |> ignore
             StepOutputRecord output
 
+    /// Decode workflow step out values, treating CWL empty forms as an empty output list.
     let outputStepsDecoder: (YAMLiciousTypes.YAMLElement -> ResizeArray<StepOutput>) =
         Decode.object (fun get ->
             let outField = get.Required.Field "out" id
             match outField with
             | YAMLElement.Object [] ->
+                // Empty YAML object is how an empty flow sequence can surface.
                 ResizeArray()
             | YAMLElement.Object [YAMLElement.Value v] when v.Value = "[]" ->
                 ResizeArray()
@@ -1398,10 +1572,12 @@ module Decode =
                 ResizeArray()
             | YAMLElement.Object [YAMLElement.Sequence outputs]
             | YAMLElement.Sequence outputs ->
+                // Normal multi-output sequence.
                 outputs
                 |> List.map decodeStepOutputItem
                 |> ResizeArray
             | value ->
+                // Single scalar or single record output.
                 ResizeArray [ decodeStepOutputItem value ]
         )
 
@@ -1420,6 +1596,7 @@ module Decode =
             |> Option.bind stringOrStringArrayDecoder
         )
     
+    /// Test object mappings for an explicit field without invoking a typed decoder.
     let hasField (fieldName: string) (yamlElement: YAMLElement) : bool =
         match yamlElement with
         | YAMLElement.Object fields ->
@@ -1430,24 +1607,33 @@ module Decode =
             )
         | _ -> false
 
+    /// Inject the parent workflow cwlVersion into inline run objects that omit it.
     let withDefaultCwlVersion (defaultCwlVersion: string) (yamlElement: YAMLElement) : YAMLElement =
         match yamlElement with
         | YAMLElement.Object fields when hasField "cwlVersion" yamlElement ->
+            // Inline tools can declare their own version; do not override it.
             yamlElement
         | YAMLElement.Object fields ->
+            // Inline run objects commonly omit cwlVersion and inherit the workflow's
+            // version for decoding purposes.
             let key = YAMLContent.create "cwlVersion"
             let value = YAMLElement.Object [YAMLElement.Value (YAMLContent.create defaultCwlVersion)]
             YAMLElement.Object (YAMLElement.Mapping (key, value) :: fields)
         | _ ->
+            // Non-object run values are path strings and need no version injection.
             yamlElement
 
+    /// Decode a workflow step run as either a path string or an inline CWL processing unit.
     let rec workflowStepRunDecoder (warnings: WarningSink) (defaultCwlVersion: string) (runValue: YAMLElement) : WorkflowStepRun =
         match runValue with
         | YAMLElement.Object [YAMLElement.Value v]
         | YAMLElement.Value v ->
+            // Most workflow steps reference an external CWL file by path.
             RunString v.Value
         | YAMLElement.Object _ ->
             let normalizedRun = withDefaultCwlVersion defaultCwlVersion runValue
+            // Inline run objects are full CWL processing units and can themselves
+            // contain tolerant ports/steps, so the same warning sink is threaded in.
             match decodeCWLProcessingUnitElementWithWarnings warnings normalizedRun with
             | CommandLineTool tool -> WorkflowStepRunOps.fromTool tool
             | Workflow workflow -> WorkflowStepRunOps.fromWorkflow workflow
@@ -1456,13 +1642,17 @@ module Decode =
         | _ ->
             raise (System.ArgumentException($"Unsupported run value for workflow step: %A{runValue}"))
 
+    /// Decode a named workflow step and thread warnings into nested step inputs and inline runs.
     and decodeWorkflowStepFromValueWithId (warnings: WarningSink) (defaultCwlVersion: string) (path: string) (stepId: string) (value: YAMLElement) : WorkflowStep =
+        // Required fields are decoded strictly because the step has an explicit id.
         let runValue = Decode.object (fun get' -> get'.Required.Field "run" id) value
         let run = workflowStepRunDecoder warnings defaultCwlVersion runValue
         let inputs =
             Decode.object (fun get' ->
                 get'.Required.Field "in" (inputStepDecoderWithWarnings warnings $"{path}.in")
             ) value
+        // Optional fields are decoded independently so missing fields do not block
+        // preservation of other step metadata.
         let outputs = outputStepsDecoder value
         let requirements = requirementsDecoder value
         let hints = hintsDecoder value
@@ -1487,6 +1677,7 @@ module Decode =
             wfStep.Requirements <- requirements
         if hints.IsSome then
             wfStep.Hints <- hints
+        // Preserve step-level extension fields such as vendor-specific scheduling hints.
         overflowIntoDynamicObj
             wfStep
             (WorkflowStep.KnownFieldNames |> Seq.toList)
@@ -1498,24 +1689,31 @@ module Decode =
         let stepId = stringFieldDecoder "id" item
         decodeWorkflowStepFromValueWithId None defaultCwlVersion "steps[]" stepId item
 
+    /// Decode one sequence-form workflow step, warning only for malformed unnamed entries.
     and decodeWorkflowStepFromArrayItemWithWarnings (warnings: WarningSink) (defaultCwlVersion: string) (index: int) (item: YAMLElement) =
         match tryGetStringField "id" item with
+        // An id marks the item as an intended step, so malformed required fields
+        // should still fail instead of becoming warnings.
         | Some stepId -> Some (decodeWorkflowStepFromValueWithId warnings defaultCwlVersion $"steps[{index}]" stepId item)
         | None when isIgnorableYamlNoise item -> None
         | None ->
+            // Unnamed malformed sequence entries are skipped with location-aware warnings.
             addWarning warnings $"steps[{index}]" "Skipped malformed unnamed CWL workflow step entry." (Some item)
             None
 
+    /// Decode workflow steps from sequence-form or map-form syntax with version-aware inline runs.
     and stepArrayDecoderWithVersion (warnings: WarningSink) (defaultCwlVersion: string) : (YAMLiciousTypes.YAMLElement -> ResizeArray<WorkflowStep>) =
         fun value ->
             match value with
             | YAMLElement.Object [YAMLElement.Sequence items]
             | YAMLElement.Sequence items ->
+                // Sequence-form steps carry id in each item.
                 items
                 |> List.mapi (decodeWorkflowStepFromArrayItemWithWarnings warnings defaultCwlVersion)
                 |> List.choose id
                 |> ResizeArray
             | _ ->
+                // Map-form steps use the map key as the step id.
                 let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
                 [|
                     for key in dict.Keys do
@@ -1528,7 +1726,10 @@ module Decode =
             get.Required.Field "steps" (stepArrayDecoderWithVersion warnings defaultCwlVersion)
         )
 
+    /// Decode a CommandLineTool and preserve unknown top-level metadata fields.
     and commandLineToolDecoder (warnings: WarningSink) (yamlCWL : YAMLElement) =
+        // Decode standard sections first. Inputs are optional for CommandLineTool,
+        // outputs are required by the current model.
         let cwlVersion = versionDecoder yamlCWL
         let outputs = outputsDecoderWithWarnings warnings yamlCWL
         let inputs = inputsDecoderWithWarnings warnings yamlCWL
@@ -1538,6 +1739,8 @@ module Decode =
         let baseCommand = baseCommandDecoder yamlCWL
         let doc = docDecoder yamlCWL
         let label = labelDecoder yamlCWL
+        // Command-line execution fields are kept as typed properties because they
+        // are common CWL fields and should not fall through to metadata overflow.
         let description =
             CWLToolDescription(
                 outputs,
@@ -1552,6 +1755,7 @@ module Decode =
                 ?permanentFailCodes = tryGetIntArrayField "permanentFailCodes" yamlCWL
             )
         let metadata =
+            // Anything not in KnownFieldNames is top-level metadata/extension data.
             let md = new DynamicObj ()
             yamlCWL
             |> Decode.object (fun get ->
@@ -1560,6 +1764,7 @@ module Decode =
                     (get.Overflow.FieldList (CWLToolDescription.KnownFieldNames |> Seq.toList))
             ) |> ignore
             md
+        // Apply optional sections only when present to preserve constructor defaults.
         if inputs.IsSome then
             description.Inputs <- inputs
         if requirements.IsSome then
@@ -1578,7 +1783,10 @@ module Decode =
             description.Metadata <- Some metadata
         description
 
+    /// Decode an ExpressionTool and preserve unknown top-level metadata fields.
     and expressionToolDecoder (warnings: WarningSink) (yamlCWL: YAMLElement) =
+        // ExpressionTool shares port/requirement metadata decoding with other
+        // processing units, then decodes its required expression body.
         let cwlVersion = versionDecoder yamlCWL
         let outputs = outputsDecoderWithWarnings warnings yamlCWL
         let inputs = inputsDecoderWithWarnings warnings yamlCWL
@@ -1597,6 +1805,7 @@ module Decode =
                 ?id = idDecoder yamlCWL
             )
         let metadata =
+            // Preserve top-level fields that are not part of the typed ExpressionTool model.
             let md = new DynamicObj ()
             yamlCWL
             |> Decode.object (fun get ->
@@ -1621,7 +1830,9 @@ module Decode =
             description.Metadata <- Some metadata
         description
 
+    /// Decode an Operation and enforce its required inputs collection.
     and operationDecoder (warnings: WarningSink) (yamlCWL: YAMLElement) =
+        // Operation inputs are required, unlike CommandLineTool and ExpressionTool.
         let cwlVersion = versionDecoder yamlCWL
         let outputs = outputsDecoderWithWarnings warnings yamlCWL
         let inputs =
@@ -1641,6 +1852,7 @@ module Decode =
                 ?id = idDecoder yamlCWL
             )
         let metadata =
+            // Preserve top-level operation extensions separately from typed fields.
             let md = new DynamicObj ()
             yamlCWL
             |> Decode.object (fun get ->
@@ -1663,7 +1875,10 @@ module Decode =
             description.Metadata <- Some metadata
         description
 
+    /// Decode a Workflow, including version-aware steps and preserved metadata fields.
     and workflowDecoder (warnings: WarningSink) (yamlCWL: YAMLElement) =
+        // Workflow inputs and steps are required by this model; outputs and steps
+        // can still use tolerant collection decoders internally.
         let cwlVersion = versionDecoder yamlCWL
         let outputs = outputsDecoderWithWarnings warnings yamlCWL
         let inputs =
@@ -1685,6 +1900,7 @@ module Decode =
                 ?id = idDecoder yamlCWL
             )
         let metadata =
+            // Preserve top-level workflow extensions after removing known workflow fields.
             let md = new DynamicObj ()
             yamlCWL
             |> Decode.object (fun get ->
@@ -1707,15 +1923,19 @@ module Decode =
             description.Metadata <- Some metadata
         description
 
+    /// Dispatch a parsed CWL document to the processing-unit decoder declared by its class field.
     and decodeCWLProcessingUnitElementWithWarnings (warnings: WarningSink) (yamlCWL: YAMLElement) =
         let cls = classDecoder yamlCWL
         match cls with
+        // The class field is the only discriminator at this layer; individual
+        // decoders handle version, ports, requirements, and metadata.
         | "CommandLineTool" -> CommandLineTool (commandLineToolDecoder warnings yamlCWL)
         | "Workflow" -> Workflow (workflowDecoder warnings yamlCWL)
         | "ExpressionTool" -> ExpressionTool (expressionToolDecoder warnings yamlCWL)
         | "Operation" -> Operation (operationDecoder warnings yamlCWL)
         | _ -> raise (System.ArgumentException($"Invalid or unsupported CWL class: {cls}"))
 
+    /// Decode an already-parsed CWL element without warning collection.
     let decodeCWLProcessingUnitElement (yamlCWL: YAMLElement) =
         decodeCWLProcessingUnitElementWithWarnings None yamlCWL
 
@@ -1723,60 +1943,70 @@ module Decode =
 
     let stepsDecoder = stepsDecoderWithVersion None "v1.2"
 
-    /// Decode a CWL file string written in the YAML format into a CWLToolDescription
+    /// Decode a CWL CommandLineTool YAML string and return recoverable warnings.
     let decodeCommandLineToolWithWarnings (cwl: string) =
         let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
         { Value = commandLineToolDecoder (Some warnings) yamlCWL; Warnings = warnings }
 
+    /// Decode a CWL CommandLineTool and discard recoverable warnings.
     let decodeCommandLineTool (cwl: string) =
         (decodeCommandLineToolWithWarnings cwl).Value
 
-    /// Decode a CWL file string written in the YAML format into a CWLWorkflowDescription
+    /// Decode a CWL Workflow YAML string and return recoverable warnings.
     let decodeWorkflowWithWarnings (cwl: string) =
         let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
         { Value = workflowDecoder (Some warnings) yamlCWL; Warnings = warnings }
 
+    /// Decode a CWL Workflow and discard recoverable warnings.
     let decodeWorkflow (cwl: string) =
         (decodeWorkflowWithWarnings cwl).Value
 
-    /// Decode a CWL file string written in the YAML format into a CWLExpressionToolDescription
+    /// Decode a CWL ExpressionTool YAML string and return recoverable warnings.
     let decodeExpressionToolWithWarnings (cwl: string) =
         let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
         { Value = expressionToolDecoder (Some warnings) yamlCWL; Warnings = warnings }
 
+    /// Decode a CWL ExpressionTool and discard recoverable warnings.
     let decodeExpressionTool (cwl: string) =
         (decodeExpressionToolWithWarnings cwl).Value
 
-    /// Decode a CWL file string written in the YAML format into a CWLOperationDescription
+    /// Decode a CWL Operation YAML string and return recoverable warnings.
     let decodeOperationWithWarnings (cwl: string) =
         let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
         { Value = operationDecoder (Some warnings) yamlCWL; Warnings = warnings }
 
+    /// Decode a CWL Operation and discard recoverable warnings.
     let decodeOperation (cwl: string) =
         (decodeOperationWithWarnings cwl).Value
 
+    /// Decode any CWL processing unit from a YAML string and return recoverable warnings.
     let decodeCWLProcessingUnitWithWarnings (cwl:string) =
         let warnings = ResizeArray<DecodeWarning>()
         let yamlCWL = readSanitizedYaml cwl
         { Value = decodeCWLProcessingUnitElementWithWarnings (Some warnings) yamlCWL; Warnings = warnings }
 
+    /// Decode any CWL processing unit and discard recoverable warnings.
     let decodeCWLProcessingUnit (cwl:string) =
         (decodeCWLProcessingUnitWithWarnings cwl).Value
 
 module DecodeParameters =
 
+    /// Decode one YAML parameter entry from scalar, object, or sequence forms.
     let cwlParameterReferenceDecoder (get : Decode.IGetters) (key: string) (yEle: YAMLElement): CWLParameterReference =
         let tryScalarString = function
+            // Parameter files commonly use plain scalar values.
             | YAMLElement.Value v
             | YAMLElement.Object [YAMLElement.Value v] -> Some v.Value
             | _ -> None
 
         let tryField fieldName value =
             try
+                // Optional field reads here are intentionally tolerant because
+                // parameter files may mix scalar and object entries.
                 Decode.object (fun get -> get.Optional.Field fieldName id) value
             with ex when Decode.isRecoverableDecodingError ex ->
                 None
@@ -1786,22 +2016,27 @@ module DecodeParameters =
             |> Option.bind tryScalarString
 
         let withOverflow (reference: CWLParameterReference) value =
+            // Preserve non-standard parameter fields beside the normalized key/value/type.
             Decode.overflowIntoDynamicObj reference (CWLParameterReference.KnownFieldNames |> Seq.toList) value |> ignore
             reference
 
         let fileOrDirectoryType className =
+            // Parameter object class values are normalized to CWL file/directory types.
             match className with
             | "File" -> Some (CWLType.file())
             | "Directory" -> Some (CWLType.directory())
             | _ -> None
 
         let pathValue value =
+            // File/Directory parameters may use either path or location for the
+            // value consumed by ARCtrl's parameter reference model.
             tryStringField "path" value
             |> Option.orElseWith (fun () -> tryStringField "location" value)
 
         let decodeObjectParameter value =
             match tryStringField "class" value, tryStringField "type" value with
             | Some className, _ ->
+                // File/Directory parameter object.
                 let cwlType = fileOrDirectoryType className
                 let values =
                     pathValue value
@@ -1810,11 +2045,13 @@ module DecodeParameters =
                 let reference = CWLParameterReference(key = key, values = values, ?type_ = cwlType)
                 withOverflow reference value
             | None, Some typeName ->
+                // Typed parameter object with an explicit value field.
                 let cwlType, _ = Decode.cwlTypeStringMatcher typeName get
                 let values =
                     match tryField "value" value with
                     | Some (YAMLElement.Object [YAMLElement.Sequence _] as sequenceValue)
                     | Some (YAMLElement.Sequence _ as sequenceValue) ->
+                        // value: [a, b]
                         Decode.resizearray Decode.string sequenceValue
                     | Some scalarOrObject ->
                         match tryScalarString scalarOrObject with
@@ -1824,6 +2061,7 @@ module DecodeParameters =
                 let reference = CWLParameterReference(key = key, values = values, type_ = cwlType)
                 withOverflow reference value
             | None, None ->
+                // Unknown object shape; keep the object as overflow with no normalized values.
                 let reference = CWLParameterReference(key = key, values = ResizeArray())
                 withOverflow reference value
 
@@ -1832,6 +2070,8 @@ module DecodeParameters =
             | Some first ->
                 match tryStringField "class" first with
                 | Some className when className = "File" || className = "Directory" ->
+                    // Sequence of File/Directory objects becomes an array type with
+                    // all available path/location values.
                     let paths =
                         items
                         |> List.choose pathValue
@@ -1846,28 +2086,34 @@ module DecodeParameters =
                         type_ = Array (InputArraySchema(itemType))
                     )
                 | _ ->
+                    // Sequence of scalars becomes a multi-value untyped reference.
                     let values =
                         items
                         |> List.choose tryScalarString
                         |> ResizeArray
                     CWLParameterReference(key = key, values = values)
             | None ->
+                // Empty parameter arrays are represented as empty value lists.
                 CWLParameterReference(key = key, values = ResizeArray())
 
         match yEle with
         | YAMLElement.Value v
         | YAMLElement.Object [YAMLElement.Value v] ->
+            // Scalar top-level parameter: key: value
             CWLParameterReference(
                 key = key,
                 values = ResizeArray [v.Value]
             )
         | YAMLElement.Object [YAMLElement.Sequence s]
         | YAMLElement.Sequence s ->
+            // Sequence top-level parameter.
             decodeSequenceParameter s
         | YAMLElement.Object _ ->
+            // Object top-level parameter with class/type/value metadata.
             decodeObjectParameter yEle
         | _ -> raise (System.ArgumentException($"Unexpected YAMLElement format in cwlParameterReferenceDecoder: %A{yEle}"))
 
+    /// Decode every top-level parameter entry into CWLParameterReference values.
     let cwlparameterReferenceArrayDecoder: YAMLElement -> ResizeArray<CWLParameterReference> =
         Decode.object (fun get ->
             let dict = get.Overflow.FieldList []
@@ -1878,7 +2124,7 @@ module DecodeParameters =
             |> ResizeArray
         )
 
+    /// Decode a YAML parameter file string into parameter references.
     let decodeYAMLParameterFile (yaml: string) =
         let yEle = Decode.read yaml
         cwlparameterReferenceArrayDecoder yEle
-

--- a/src/CWL/Decode.fs
+++ b/src/CWL/Decode.fs
@@ -848,13 +848,13 @@ module Decode =
     let schemaDefRequirementTypeDecoder (value: YAMLElement) : SchemaDefRequirementType =
         let dict = Decode.object (fun get -> get.Overflow.FieldList []) value
         let schemaDefKnownFields =
-            [
-                yield! SchemaDefRequirementType.KnownFieldNames
-                yield! InputRecordSchema.KnownFieldNames
-                yield! InputArraySchema.KnownFieldNames
-                yield! InputEnumSchema.KnownFieldNames
-            ]
-            |> Seq.distinct
+            Set.unionMany
+                [
+                    SchemaDefRequirementType.KnownFieldNames
+                    InputRecordSchema.KnownFieldNames
+                    InputArraySchema.KnownFieldNames
+                    InputEnumSchema.KnownFieldNames
+                ]
             |> Seq.toList
         if dict.ContainsKey "name" then
             let schema = SchemaDefRequirementType(decodeStringOrExpression dict.["name"], cwlTypeDecoder' value)

--- a/src/CWL/DynamicObjHelpers.fs
+++ b/src/CWL/DynamicObjHelpers.fs
@@ -3,7 +3,7 @@ module ARCtrl.CWL.DynamicObjHelpers
 open System
 open DynamicObj
 
-let private toCompilerBackingName (propertyName: string) =
+let toCompilerBackingName (propertyName: string) =
     let propertyName =
         if String.IsNullOrEmpty propertyName then
             propertyName
@@ -26,7 +26,7 @@ let private toCompilerBackingName (propertyName: string) =
 
     "_" + String(chars)
 
-let private typedBackingFieldNames (dynObj: DynamicObj) =
+let typedBackingFieldNames (dynObj: DynamicObj) =
     dynObj.GetPropertyHelpers(true)
     |> Seq.filter (fun property -> not property.IsDynamic)
     |> Seq.collect (fun property ->

--- a/src/CWL/DynamicObjHelpers.fs
+++ b/src/CWL/DynamicObjHelpers.fs
@@ -3,6 +3,8 @@ module ARCtrl.CWL.DynamicObjHelpers
 open System
 open DynamicObj
 
+/// Convert a public F# property name to the private backing-field name that
+/// DynamicObj exposes for typed members compiled by Fable or .NET.
 let toCompilerBackingName (propertyName: string) =
     let propertyName =
         if String.IsNullOrEmpty propertyName then
@@ -26,6 +28,8 @@ let toCompilerBackingName (propertyName: string) =
 
     "_" + String(chars)
 
+/// Return both common backing-field spellings for all typed properties so they
+/// can be excluded from dynamic CWL extension fields.
 let typedBackingFieldNames (dynObj: DynamicObj) =
     dynObj.GetPropertyHelpers(true)
     |> Seq.filter (fun property -> not property.IsDynamic)
@@ -36,6 +40,8 @@ let typedBackingFieldNames (dynObj: DynamicObj) =
         })
     |> Set.ofSeq
 
+/// Enumerate only true dynamic properties, excluding known CWL fields and
+/// compiler-generated storage for typed members.
 let dynamicPropertiesExcept (knownFieldNames: Set<string>) (dynObj: DynamicObj) =
     let typedBackingFields = typedBackingFieldNames dynObj
     dynObj.GetProperties(false)
@@ -43,18 +49,23 @@ let dynamicPropertiesExcept (knownFieldNames: Set<string>) (dynObj: DynamicObj) 
         not (Set.contains kv.Key knownFieldNames) &&
         not (Set.contains kv.Key typedBackingFields))
 
+/// Create a stable, sorted dynamic-property snapshot for equality and hashing.
 let dynamicPropertiesSnapshotExcept (knownFieldNames: Set<string>) (dynObj: DynamicObj) =
     dynamicPropertiesExcept knownFieldNames dynObj
     |> Seq.map (fun kv -> kv.Key, kv.Value)
     |> Seq.sortBy fst
     |> Seq.toList
     
+/// Snapshot all dynamic extension properties on an object.
 let dynamicPropertiesSnapshot (dynObj: DynamicObj) =
     dynamicPropertiesSnapshotExcept Set.empty dynObj
 
+/// Compare only preserved dynamic extension properties between two CWL objects.
 let dynamicPropertiesEqual (left: DynamicObj) (right: DynamicObj) =
     dynamicPropertiesSnapshot left = dynamicPropertiesSnapshot right
 
+/// Hash preserved dynamic extension properties in the same stable order used
+/// by dynamicPropertiesEqual.
 let hashDynamicProperties (dynObj: DynamicObj) =
     dynamicPropertiesSnapshot dynObj
     |> Operators.hash

--- a/src/CWL/DynamicObjHelpers.fs
+++ b/src/CWL/DynamicObjHelpers.fs
@@ -36,22 +36,21 @@ let typedBackingFieldNames (dynObj: DynamicObj) =
         })
     |> Set.ofSeq
 
-let dynamicPropertiesExcept (knownFieldNames: seq<string>) (dynObj: DynamicObj) =
-    let knownFieldSet = knownFieldNames |> Set.ofSeq
+let dynamicPropertiesExcept (knownFieldNames: Set<string>) (dynObj: DynamicObj) =
     let typedBackingFields = typedBackingFieldNames dynObj
     dynObj.GetProperties(false)
     |> Seq.filter (fun kv ->
-        not (Set.contains kv.Key knownFieldSet) &&
+        not (Set.contains kv.Key knownFieldNames) &&
         not (Set.contains kv.Key typedBackingFields))
 
-let dynamicPropertiesSnapshotExcept (knownFieldNames: seq<string>) (dynObj: DynamicObj) =
+let dynamicPropertiesSnapshotExcept (knownFieldNames: Set<string>) (dynObj: DynamicObj) =
     dynamicPropertiesExcept knownFieldNames dynObj
     |> Seq.map (fun kv -> kv.Key, kv.Value)
     |> Seq.sortBy fst
     |> Seq.toList
-
+    
 let dynamicPropertiesSnapshot (dynObj: DynamicObj) =
-    dynamicPropertiesSnapshotExcept Seq.empty dynObj
+    dynamicPropertiesSnapshotExcept Set.empty dynObj
 
 let dynamicPropertiesEqual (left: DynamicObj) (right: DynamicObj) =
     dynamicPropertiesSnapshot left = dynamicPropertiesSnapshot right

--- a/src/CWL/DynamicObjHelpers.fs
+++ b/src/CWL/DynamicObjHelpers.fs
@@ -1,0 +1,61 @@
+module ARCtrl.CWL.DynamicObjHelpers
+
+open System
+open DynamicObj
+
+let private toCompilerBackingName (propertyName: string) =
+    let propertyName =
+        if String.IsNullOrEmpty propertyName then
+            propertyName
+        elif propertyName.EndsWith("_", StringComparison.Ordinal) then
+            propertyName.Substring(0, propertyName.Length - 1)
+        else
+            propertyName
+
+    let chars = propertyName.ToCharArray()
+    let mutable index = 0
+    let mutable keepLowering = true
+    while keepLowering && index < chars.Length && Char.IsUpper chars.[index] do
+        let nextIsEnd = index + 1 = chars.Length
+        let nextIsUpper = not nextIsEnd && Char.IsUpper chars.[index + 1]
+        if index = 0 || nextIsEnd || nextIsUpper then
+            chars.[index] <- Char.ToLowerInvariant chars.[index]
+            index <- index + 1
+        else
+            keepLowering <- false
+
+    "_" + String(chars)
+
+let private typedBackingFieldNames (dynObj: DynamicObj) =
+    dynObj.GetPropertyHelpers(true)
+    |> Seq.filter (fun property -> not property.IsDynamic)
+    |> Seq.collect (fun property ->
+        seq {
+            yield "_" + property.Name
+            yield toCompilerBackingName property.Name
+        })
+    |> Set.ofSeq
+
+let dynamicPropertiesExcept (knownFieldNames: seq<string>) (dynObj: DynamicObj) =
+    let knownFieldSet = knownFieldNames |> Set.ofSeq
+    let typedBackingFields = typedBackingFieldNames dynObj
+    dynObj.GetProperties(false)
+    |> Seq.filter (fun kv ->
+        not (Set.contains kv.Key knownFieldSet) &&
+        not (Set.contains kv.Key typedBackingFields))
+
+let dynamicPropertiesSnapshotExcept (knownFieldNames: seq<string>) (dynObj: DynamicObj) =
+    dynamicPropertiesExcept knownFieldNames dynObj
+    |> Seq.map (fun kv -> kv.Key, kv.Value)
+    |> Seq.sortBy fst
+    |> Seq.toList
+
+let dynamicPropertiesSnapshot (dynObj: DynamicObj) =
+    dynamicPropertiesSnapshotExcept Seq.empty dynObj
+
+let dynamicPropertiesEqual (left: DynamicObj) (right: DynamicObj) =
+    dynamicPropertiesSnapshot left = dynamicPropertiesSnapshot right
+
+let hashDynamicProperties (dynObj: DynamicObj) =
+    dynamicPropertiesSnapshot dynObj
+    |> Operators.hash

--- a/src/CWL/Encode.fs
+++ b/src/CWL/Encode.fs
@@ -93,6 +93,41 @@ module Encode =
         | Some v -> acc @ [name, encoder v]
         | None -> acc
 
+    let rec encodeDynamicValue (value: obj) =
+        match value with
+        | null -> None
+        | :? string as s -> Some (Encode.string s)
+        | :? bool as b -> Some (yBool b)
+        | :? int as i -> Some (Encode.int i)
+        | :? int64 as i -> Some (Encode.string (string i))
+        | :? float as f -> Some (Encode.float f)
+        | :? YAMLElement as y -> Some y
+        | :? DynamicObj as dynObj -> Some (encodeDynamicObj dynObj)
+        | :? System.Collections.IEnumerable as values ->
+            values
+            |> Seq.cast<obj>
+            |> Seq.choose encodeDynamicValue
+            |> Seq.toList
+            |> YAMLElement.Sequence
+            |> Some
+        | _ -> None
+
+    and encodeDynamicObj (dynObj: DynamicObj) =
+        dynObj.GetProperties(false)
+        |> Seq.choose (fun kvp -> encodeDynamicValue kvp.Value |> Option.map (fun encoded -> kvp.Key, encoded))
+        |> Seq.toList
+        |> yMap
+
+    let appendDynamicPropertiesExcept (knownFieldNames: seq<string>) (dynObj: DynamicObj) acc =
+        let knownFieldSet = knownFieldNames |> Set.ofSeq
+        dynObj.GetProperties(false)
+        |> Seq.filter (fun kvp -> not (Set.contains kvp.Key knownFieldSet))
+        |> Seq.choose (fun kvp -> encodeDynamicValue kvp.Value |> Option.map (fun encoded -> kvp.Key, encoded))
+        |> Seq.fold (fun pairs pair -> pairs @ [ pair ]) acc
+
+    let appendDynamicProperties (dynObj: DynamicObj) acc =
+        appendDynamicPropertiesExcept Seq.empty dynObj acc
+
     let normalizeDocString (doc:string) =
         doc.Replace("\r\n","\n").TrimEnd('\n').TrimEnd('\r')
 
@@ -171,14 +206,48 @@ module Encode =
     // ------------------------------
     // CWLType encoder
     // ------------------------------
+    let private encodeFilePairs discriminatorKey discriminatorValue (file: FileInstance) =
+        [ discriminatorKey, Encode.string discriminatorValue ]
+        |> appendOpt "location" Encode.string file.Location
+        |> appendOpt "path" Encode.string file.Path
+        |> appendOpt "basename" Encode.string file.Basename
+        |> appendOpt "dirname" Encode.string file.Dirname
+        |> appendOpt "nameroot" Encode.string file.Nameroot
+        |> appendOpt "nameext" Encode.string file.Nameext
+        |> appendOpt "checksum" Encode.string file.Checksum
+        |> appendOpt "size" (fun size -> YAMLElement.Value (YAMLContent.create (string size))) file.Size
+        |> appendOpt "secondaryFiles" id file.SecondaryFiles
+        |> appendOpt "format" Encode.string file.Format
+        |> appendOpt "contents" Encode.string file.Contents
+        |> appendDynamicPropertiesExcept FileInstance.KnownFieldNames file
+
+    let private encodeDirectoryPairs discriminatorKey discriminatorValue (directory: DirectoryInstance) =
+        [ discriminatorKey, Encode.string discriminatorValue ]
+        |> appendOpt "location" Encode.string directory.Location
+        |> appendOpt "path" Encode.string directory.Path
+        |> appendOpt "basename" Encode.string directory.Basename
+        |> appendOpt "listing" id directory.Listing
+        |> appendDynamicPropertiesExcept DirectoryInstance.KnownFieldNames directory
+
     let rec encodeCWLType (t:CWLType) : YAMLElement =
+        let hasFileFields (file: FileInstance) =
+            (encodeFilePairs "type" "File" file).Length > 1
+
+        let hasDirectoryFields (directory: DirectoryInstance) =
+            (encodeDirectoryPairs "type" "Directory" directory).Length > 1
+
         match t with
+        | File file when hasFileFields file ->
+            encodeFilePairs "type" "File" file |> yMap
         | File _ -> Encode.string "File"
+        | Directory directory when hasDirectoryFields directory ->
+            encodeDirectoryPairs "type" "Directory" directory |> yMap
         | Directory _ -> Encode.string "Directory"
         | Dirent d ->
             [ "entry", encodeSchemaSaladString d.Entry ]
             |> appendOpt "entryname" encodeSchemaSaladString d.Entryname
             |> appendOpt "writable" (fun b -> yBool b) d.Writable
+            |> appendDynamicPropertiesExcept DirentInstance.KnownFieldNames d
             |> yMap
         | String -> Encode.string "string"
         | Int -> Encode.string "int"
@@ -229,7 +298,12 @@ module Encode =
     // ------------------------------
 
     and encodeInputRecordField (field:InputRecordField) : (string * YAMLElement) =
-        field.Name, yMap [ "type", encodeCWLType field.Type ]
+        let pairs =
+            [ "type", encodeCWLType field.Type ]
+            |> appendOpt "doc" Encode.string field.Doc
+            |> appendOpt "label" Encode.string field.Label
+            |> appendDynamicPropertiesExcept InputRecordField.KnownFieldNames field
+        field.Name, yMap pairs
 
     and encodeInputRecordSchema (schema:InputRecordSchema) : YAMLElement =
         let fieldsElement =
@@ -238,18 +312,32 @@ module Encode =
                 let fieldPairs = fs |> Seq.map encodeInputRecordField |> Seq.toList
                 yMap fieldPairs
             | None -> yMap []
-        
-        yMap [ "type", Encode.string "record"; "fields", fieldsElement ]
+        [ "type", Encode.string "record"; "fields", fieldsElement ]
+        |> appendOpt "label" Encode.string schema.Label
+        |> appendOpt "doc" Encode.string schema.Doc
+        |> appendOpt "name" Encode.string schema.Name
+        |> appendDynamicPropertiesExcept InputRecordSchema.KnownFieldNames schema
+        |> yMap
 
     and encodeInputEnumSchema (schema:InputEnumSchema) : YAMLElement =
         let pairs =
             [ "type", Encode.string "enum" ]
             @ [ "symbols", (schema.Symbols |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) ]
-        
-        yMap pairs
+
+        pairs
+        |> appendOpt "label" Encode.string schema.Label
+        |> appendOpt "doc" Encode.string schema.Doc
+        |> appendOpt "name" Encode.string schema.Name
+        |> appendDynamicPropertiesExcept InputEnumSchema.KnownFieldNames schema
+        |> yMap
 
     and encodeInputArraySchema (schema:InputArraySchema) : YAMLElement =
-        yMap [ "type", Encode.string "array"; "items", encodeCWLType schema.Items ]
+        [ "type", Encode.string "array"; "items", encodeCWLType schema.Items ]
+        |> appendOpt "label" Encode.string schema.Label
+        |> appendOpt "doc" Encode.string schema.Doc
+        |> appendOpt "name" Encode.string schema.Name
+        |> appendDynamicPropertiesExcept InputArraySchema.KnownFieldNames schema
+        |> yMap
 
     // ------------------------------
     // Binding & Port encoders
@@ -258,6 +346,10 @@ module Encode =
     let encodeOutputBinding (ob:OutputBinding) : YAMLElement =
         [ ob.Glob |> Option.map (fun g -> "glob", Encode.string g) ]
         |> List.choose id
+        |> appendOpt "loadContents" yBool ob.LoadContents
+        |> appendOpt "loadListing" (LoadListingEnum.toCwlString >> Encode.string) ob.LoadListing
+        |> appendOpt "outputEval" Encode.string ob.OutputEval
+        |> appendDynamicPropertiesExcept OutputBinding.KnownFieldNames ob
         |> yMap
 
     let encodeStringArrayOrScalar (values: ResizeArray<string>) : YAMLElement =
@@ -322,8 +414,14 @@ module Encode =
         let pairs =
             []
             |> appendOpt "type" id typeElement
+            |> appendOpt "label" Encode.string o.Label
+            |> appendOpt "secondaryFiles" id o.SecondaryFiles
+            |> appendOpt "streamable" yBool o.Streamable
+            |> appendOpt "doc" Encode.string o.Doc
+            |> appendOpt "format" Encode.string o.Format
             |> appendOpt "outputBinding" encodeOutputBinding o.OutputBinding
             |> appendOpt "outputSource" id outputSourceElement
+            |> appendDynamicPropertiesExcept CWLOutput.KnownFieldNames o
         match pairs with
         | [ ("type", t) ] -> o.Name, t // only type specified
         | _ ->
@@ -332,10 +430,14 @@ module Encode =
 
     let encodeInputBinding (ib:InputBinding) : YAMLElement =
         []
+        |> appendOpt "loadContents" yBool ib.LoadContents
         |> appendOpt "prefix" Encode.string ib.Prefix
         |> appendOpt "position" (fun p -> Encode.int p) ib.Position
         |> appendOpt "itemSeparator" Encode.string ib.ItemSeparator
         |> appendOpt "separate" yBool ib.Separate
+        |> appendOpt "valueFrom" Encode.string ib.ValueFrom
+        |> appendOpt "shellQuote" yBool ib.ShellQuote
+        |> appendDynamicPropertiesExcept InputBinding.KnownFieldNames ib
         |> yMap
 
     let encodeCWLInput (i:CWLInput) : (string * YAMLElement) =
@@ -385,8 +487,16 @@ module Encode =
         let pairs =
             []
             |> appendOpt "type" id typeElement
+            |> appendOpt "label" Encode.string i.Label
+            |> appendOpt "secondaryFiles" id i.SecondaryFiles
+            |> appendOpt "streamable" yBool i.Streamable
+            |> appendOpt "doc" Encode.string i.Doc
+            |> appendOpt "format" Encode.string i.Format
+            |> appendOpt "loadContents" yBool i.LoadContents
+            |> appendOpt "loadListing" (LoadListingEnum.toCwlString >> Encode.string) i.LoadListing
+            |> appendOpt "default" id i.DefaultValue
             |> appendOpt "inputBinding" encodeInputBinding i.InputBinding
-            |> appendOpt "optional" yBool i.Optional
+            |> appendDynamicPropertiesExcept CWLInput.KnownFieldNames i
         match pairs with
         | [ ("type", t) ] -> i.Name, t
         | _ -> i.Name, yMap pairs
@@ -396,10 +506,12 @@ module Encode =
     // ------------------------------
 
     let encodeSchemaDefRequirementType (s:SchemaDefRequirementType) : YAMLElement =
-        yMap [
+        [
             "name", Encode.string s.Name
             "type", encodeCWLType s.Type_
         ]
+        |> appendDynamicPropertiesExcept SchemaDefRequirementType.KnownFieldNames s
+        |> yMap
 
     let encodeRequirement (r:Requirement) : YAMLElement =
         match r with
@@ -409,6 +521,7 @@ module Encode =
                 |> Option.bind (fun entries -> if entries.Count > 0 then Some entries else None)
             [ "class", Encode.string "InlineJavascriptRequirement" ]
             |> appendOpt "expressionLib" (fun entries -> entries |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) expressionLib
+            |> appendDynamicPropertiesExcept InlineJavascriptRequirementValue.KnownFieldNames value
             |> yMap
         | SchemaDefRequirement types ->
             [ "class", Encode.string "SchemaDefRequirement";
@@ -422,6 +535,7 @@ module Encode =
             |> appendOpt "dockerImport" Encode.string dr.DockerImport
             |> appendOpt "dockerOutputDirectory" Encode.string dr.DockerOutputDirectory
             |> appendOpt "cwltool:dockerRunOptions" (fun values -> values |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) dr.DockerRunOptions
+            |> appendDynamicPropertiesExcept DockerRequirement.KnownFieldNames dr
             |> yMap
         | SoftwareRequirement pkgs ->
             let encodePkg (p:SoftwarePackage) =
@@ -429,55 +543,39 @@ module Encode =
                 |> fun acc -> acc @ [ "package", Encode.string p.Package ]
                 |> appendOpt "version" (fun vs -> vs |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) p.Version
                 |> appendOpt "specs" (fun vs -> vs |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) p.Specs
+                |> appendDynamicPropertiesExcept SoftwarePackage.KnownFieldNames p
                 |> yMap
             [ "class", Encode.string "SoftwareRequirement";
               "packages", (pkgs |> Seq.map encodePkg |> List.ofSeq |> YAMLElement.Sequence) ] |> yMap
         | LoadListingRequirement loadListing ->
             [ "class", Encode.string "LoadListingRequirement"
               "loadListing", Encode.string (LoadListingEnum.toCwlString loadListing.LoadListing) ]
+            |> appendDynamicPropertiesExcept LoadListingRequirementValue.KnownFieldNames loadListing
             |> yMap
         | InitialWorkDirRequirement listing ->
-            let encodeDynamicObjWithClass (className: string) (dynObj: DynamicObj) =
-                let dynamicPairs =
-                    dynObj.GetProperties(false)
-                    |> Seq.choose (fun kvp ->
-                        match kvp.Value with
-                        | :? string as s -> Some (kvp.Key, Encode.string s)
-                        | :? bool as b -> Some (kvp.Key, yBool b)
-                        | :? int as i -> Some (kvp.Key, Encode.int i)
-                        | :? int64 as i -> Some (kvp.Key, Encode.string (string i))
-                        | :? float as f -> Some (kvp.Key, Encode.float f)
-                        | :? YAMLElement as y -> Some (kvp.Key, y)
-                        | _ -> None
-                    )
-                    |> Seq.toList
-
-                let hasClass = dynamicPairs |> List.exists (fun (k, _) -> k = "class")
-                if hasClass then
-                    yMap dynamicPairs
-                else
-                    yMap (("class", Encode.string className) :: dynamicPairs)
-
             let encodeInitialWorkDirEntry = function
                 | DirentEntry d ->
                     [ ]
                     |> appendOpt "entryname" encodeSchemaSaladString d.Entryname
                     |> fun acc -> acc @ [ "entry", encodeSchemaSaladString d.Entry ]
                     |> appendOpt "writable" yBool d.Writable
+                    |> appendDynamicPropertiesExcept DirentInstance.KnownFieldNames d
                     |> yMap
                 | StringEntry s ->
                     encodeSchemaSaladString s
                 | FileEntry file ->
-                    encodeDynamicObjWithClass "File" file
+                    encodeFilePairs "class" "File" file |> yMap
                 | DirectoryEntry directory ->
-                    encodeDynamicObjWithClass "Directory" directory
+                    encodeDirectoryPairs "class" "Directory" directory |> yMap
 
             [ "class", Encode.string "InitialWorkDirRequirement";
               "listing", (listing |> Seq.map encodeInitialWorkDirEntry |> List.ofSeq |> YAMLElement.Sequence) ] |> yMap
         | EnvVarRequirement envs ->
             let encodeEnv (e:EnvironmentDef) =
                 let v = normalizeEnvValueForEncode e.EnvValue
-                [ "envName", Encode.string e.EnvName; "envValue", Encode.string v ] |> yMap
+                [ "envName", Encode.string e.EnvName; "envValue", Encode.string v ]
+                |> appendDynamicPropertiesExcept EnvironmentDef.KnownFieldNames e
+                |> yMap
             [ "class", Encode.string "EnvVarRequirement";
               "envDef", (envs |> Seq.map encodeEnv |> List.ofSeq |> YAMLElement.Sequence) ] |> yMap
         | ShellCommandRequirement -> [ "class", Encode.string "ShellCommandRequirement" ] |> yMap
@@ -491,8 +589,19 @@ module Encode =
                 | :? bool as b -> Some (key, yBool b)
                 | _ -> None
 
+            let knownPairs =
+                rr.KnownFieldValues
+                |> List.choose (fun (key, value) ->
+                    value |> Option.bind (tryEncodeScalar key))
+
+            let knownFieldNames =
+                ResourceRequirementInstance.KnownFieldNames
+                |> Seq.map id
+                |> Set.ofSeq
+
             let dynamicPairs =
                 rr.GetProperties(false)
+                |> Seq.filter (fun kvp -> not (Set.contains kvp.Key knownFieldNames))
                 |> Seq.choose (fun kvp ->
                     match kvp.Value with
                     | :? Option<obj> as optionalValue ->
@@ -501,11 +610,12 @@ module Encode =
                     | directValue ->
                         tryEncodeScalar kvp.Key directValue)
                 |> Seq.toList
-            [ "class", Encode.string "ResourceRequirement" ] @ dynamicPairs |> yMap
+            [ "class", Encode.string "ResourceRequirement" ] @ knownPairs @ dynamicPairs |> yMap
         // Canonicalize class names to short CWL forms where applicable.
         | WorkReuseRequirement workReuse ->
             [ "class", Encode.string "WorkReuse"
               "enableReuse", yBool workReuse.EnableReuse ]
+            |> appendDynamicPropertiesExcept WorkReuseRequirementValue.KnownFieldNames workReuse
             |> yMap
         | WorkReuseExpressionRequirement expression ->
             [ "class", Encode.string "WorkReuse"
@@ -514,6 +624,7 @@ module Encode =
         | NetworkAccessRequirement networkAccess ->
             [ "class", Encode.string "NetworkAccess"
               "networkAccess", yBool networkAccess.NetworkAccess ]
+            |> appendDynamicPropertiesExcept NetworkAccessRequirementValue.KnownFieldNames networkAccess
             |> yMap
         | NetworkAccessExpressionRequirement expression ->
             [ "class", Encode.string "NetworkAccess"
@@ -522,6 +633,7 @@ module Encode =
         | InplaceUpdateRequirement inplaceUpdate ->
             [ "class", Encode.string "InplaceUpdateRequirement"
               "inplaceUpdate", yBool inplaceUpdate.InplaceUpdate ]
+            |> appendDynamicPropertiesExcept InplaceUpdateRequirementValue.KnownFieldNames inplaceUpdate
             |> yMap
         | ToolTimeLimitRequirement tl ->
             let timelimit =
@@ -575,6 +687,7 @@ module Encode =
             |> appendOpt "loadContents" yBool si.LoadContents
             |> appendOpt "loadListing" Encode.string si.LoadListing
             |> appendOpt "label" Encode.string si.Label
+            |> appendDynamicPropertiesExcept StepInput.KnownFieldNames si
         match pairs with
         | [ ("source", s) ]
             when
@@ -596,7 +709,9 @@ module Encode =
         |> yMap
 
     let encodeStepOutputParameter (so: StepOutputParameter) : YAMLElement =
-        yMap [ "id", Encode.string so.Id ]
+        [ "id", Encode.string so.Id ]
+        |> appendDynamicPropertiesExcept StepOutputParameter.KnownFieldNames so
+        |> yMap
 
     let encodeStepOutputs (outputs: ResizeArray<StepOutput>) : YAMLElement =
         outputs
@@ -660,30 +775,30 @@ module Encode =
             | Some bc when bc.Count > 0 ->
                 withRequirements @ [ "baseCommand", (bc |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) ]
             | _ -> withRequirements
+        let withCommandFields =
+            withBaseCommand
+            |> appendOpt "arguments" id td.Arguments
+            |> appendOpt "stdin" Encode.string td.Stdin
+            |> appendOpt "stderr" Encode.string td.Stderr
+            |> appendOpt "stdout" Encode.string td.Stdout
+            |> appendOpt "successCodes" (fun codes -> codes |> Seq.map Encode.int |> List.ofSeq |> YAMLElement.Sequence) td.SuccessCodes
+            |> appendOpt "temporaryFailCodes" (fun codes -> codes |> Seq.map Encode.int |> List.ofSeq |> YAMLElement.Sequence) td.TemporaryFailCodes
+            |> appendOpt "permanentFailCodes" (fun codes -> codes |> Seq.map Encode.int |> List.ofSeq |> YAMLElement.Sequence) td.PermanentFailCodes
         let withInputs =
             match td.Inputs with
             | Some i when i.Count > 0 ->
-                withBaseCommand @ [ "inputs", (i |> Seq.map encodeCWLInput |> Seq.toList |> yMap) ]
-            | _ -> withBaseCommand
+                withCommandFields @ [ "inputs", (i |> Seq.map encodeCWLInput |> Seq.toList |> yMap) ]
+            | _ -> withCommandFields
         let withOutputs =
             withInputs @ [ "outputs", (td.Outputs |> Seq.map encodeCWLOutput |> Seq.toList |> yMap) ]
         let withMetadata =
             match td.Metadata with
             | Some md ->
-                md.GetProperties(false)
-                |> Seq.fold (fun acc kvp ->
-                    let encodedValue =
-                        match kvp.Value with
-                        | :? string as s -> Encode.string s
-                        | :? bool as b -> yBool b
-                        | :? int as i -> Encode.int i
-                        | :? float as f -> Encode.float f
-                        | :? YAMLElement as y -> y
-                        | _ -> Encode.string (string kvp.Value)
-                    acc @ [ kvp.Key, encodedValue ]
-                ) withOutputs
+                appendDynamicProperties md withOutputs
             | None -> withOutputs
-        yMap withMetadata
+        withMetadata
+        |> appendDynamicPropertiesExcept CWLToolDescription.KnownFieldNames td
+        |> yMap
 
     and encodeExpressionToolDescriptionElement (et: CWLExpressionToolDescription) : YAMLElement =
         let basePairs =
@@ -715,20 +830,11 @@ module Encode =
         let withMetadata =
             match et.Metadata with
             | Some md ->
-                md.GetProperties(false)
-                |> Seq.fold (fun acc kvp ->
-                    let encodedValue =
-                        match kvp.Value with
-                        | :? string as s -> Encode.string s
-                        | :? bool as b -> yBool b
-                        | :? int as i -> Encode.int i
-                        | :? float as f -> Encode.float f
-                        | :? YAMLElement as y -> y
-                        | _ -> Encode.string (string kvp.Value)
-                    acc @ [ kvp.Key, encodedValue ]
-                ) withExpression
+                appendDynamicProperties md withExpression
             | None -> withExpression
-        yMap withMetadata
+        withMetadata
+        |> appendDynamicPropertiesExcept CWLExpressionToolDescription.KnownFieldNames et
+        |> yMap
 
     and encodeOperationDescriptionElement (op: CWLOperationDescription) : YAMLElement =
         let basePairs =
@@ -755,20 +861,11 @@ module Encode =
         let withMetadata =
             match op.Metadata with
             | Some md ->
-                md.GetProperties(false)
-                |> Seq.fold (fun acc kvp ->
-                    let encodedValue =
-                        match kvp.Value with
-                        | :? string as s -> Encode.string s
-                        | :? bool as b -> yBool b
-                        | :? int as i -> Encode.int i
-                        | :? float as f -> Encode.float f
-                        | :? YAMLElement as y -> y
-                        | _ -> Encode.string (string kvp.Value)
-                    acc @ [ kvp.Key, encodedValue ]
-                ) withOutputs
+                appendDynamicProperties md withOutputs
             | None -> withOutputs
-        yMap withMetadata
+        withMetadata
+        |> appendDynamicPropertiesExcept CWLOperationDescription.KnownFieldNames op
+        |> yMap
 
     and encodeWorkflowDescriptionElement (wd: CWLWorkflowDescription) : YAMLElement =
         let basePairs =
@@ -794,20 +891,11 @@ module Encode =
         let withMetadata =
             match wd.Metadata with
             | Some md ->
-                md.GetProperties(false)
-                |> Seq.fold (fun acc kvp ->
-                    let encodedValue =
-                        match kvp.Value with
-                        | :? string as s -> Encode.string s
-                        | :? bool as b -> yBool b
-                        | :? int as i -> Encode.int i
-                        | :? float as f -> Encode.float f
-                        | :? YAMLElement as y -> y
-                        | _ -> Encode.string (string kvp.Value)
-                    acc @ [ kvp.Key, encodedValue ]
-                ) withOutputs
+                appendDynamicProperties md withOutputs
             | None -> withOutputs
-        yMap withMetadata
+        withMetadata
+        |> appendDynamicPropertiesExcept CWLWorkflowDescription.KnownFieldNames wd
+        |> yMap
 
     and encodeWorkflowStep (ws:WorkflowStep) : (string * YAMLElement) =
         let basePairs =
@@ -819,6 +907,7 @@ module Encode =
             |> appendOpt "scatter" encodeScatter ws.Scatter
             |> appendOpt "scatterMethod" encodeScatterMethod ws.ScatterMethod
             |> appendOpt "when" Encode.string ws.When_
+            |> appendDynamicPropertiesExcept WorkflowStep.KnownFieldNames ws
         let withHints =
             match ws.Hints with
             | Some h when h.Count > 0 -> basePairs @ [ "hints", (h |> Seq.map encodeHintEntry |> List.ofSeq |> YAMLElement.Sequence) ]

--- a/src/CWL/Encode.fs
+++ b/src/CWL/Encode.fs
@@ -117,18 +117,18 @@ module Encode =
         | _ -> None
 
     and encodeDynamicObj (dynObj: DynamicObj) =
-        DynamicObjHelpers.dynamicPropertiesExcept Seq.empty dynObj
+        DynamicObjHelpers.dynamicPropertiesExcept Set.empty dynObj
         |> Seq.choose (fun kvp -> encodeDynamicValue kvp.Value |> Option.map (fun encoded -> kvp.Key, encoded))
         |> Seq.toList
         |> yMap
 
-    let appendDynamicPropertiesExcept (knownFieldNames: seq<string>) (dynObj: DynamicObj) acc =
+    let appendDynamicPropertiesExcept (knownFieldNames: Set<string>) (dynObj: DynamicObj) acc =
         DynamicObjHelpers.dynamicPropertiesExcept knownFieldNames dynObj
         |> Seq.choose (fun kvp -> encodeDynamicValue kvp.Value |> Option.map (fun encoded -> kvp.Key, encoded))
         |> Seq.fold (fun pairs pair -> pairs @ [ pair ]) acc
 
     let appendDynamicProperties (dynObj: DynamicObj) acc =
-        appendDynamicPropertiesExcept Seq.empty dynObj acc
+        appendDynamicPropertiesExcept Set.empty dynObj acc
 
     let normalizeDocString (doc:string) =
         doc.Replace("\r\n","\n").TrimEnd('\n').TrimEnd('\r')

--- a/src/CWL/Encode.fs
+++ b/src/CWL/Encode.fs
@@ -113,15 +113,13 @@ module Encode =
         | _ -> None
 
     and encodeDynamicObj (dynObj: DynamicObj) =
-        dynObj.GetProperties(false)
+        DynamicObjHelpers.dynamicPropertiesExcept Seq.empty dynObj
         |> Seq.choose (fun kvp -> encodeDynamicValue kvp.Value |> Option.map (fun encoded -> kvp.Key, encoded))
         |> Seq.toList
         |> yMap
 
     let appendDynamicPropertiesExcept (knownFieldNames: seq<string>) (dynObj: DynamicObj) acc =
-        let knownFieldSet = knownFieldNames |> Set.ofSeq
-        dynObj.GetProperties(false)
-        |> Seq.filter (fun kvp -> not (Set.contains kvp.Key knownFieldSet))
+        DynamicObjHelpers.dynamicPropertiesExcept knownFieldNames dynObj
         |> Seq.choose (fun kvp -> encodeDynamicValue kvp.Value |> Option.map (fun encoded -> kvp.Key, encoded))
         |> Seq.fold (fun pairs pair -> pairs @ [ pair ]) acc
 
@@ -600,8 +598,7 @@ module Encode =
                 |> Set.ofSeq
 
             let dynamicPairs =
-                rr.GetProperties(false)
-                |> Seq.filter (fun kvp -> not (Set.contains kvp.Key knownFieldNames))
+                DynamicObjHelpers.dynamicPropertiesExcept knownFieldNames rr
                 |> Seq.choose (fun kvp ->
                     match kvp.Value with
                     | :? Option<obj> as optionalValue ->

--- a/src/CWL/Encode.fs
+++ b/src/CWL/Encode.fs
@@ -67,6 +67,13 @@ module Encode =
     let yBool (b:bool) =
         YAMLElement.Value (YAMLContent.create (if b then "true" else "false"))
 
+    let yFloat (value: float) =
+#if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
+        YAMLElement.Value (YAMLContent.create (value.ToString()))
+#else
+        YAMLElement.Value (YAMLContent.create (value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)))
+#endif
+
     // ------------------------------
     // Helper to build YAML mappings preserving order
     // ------------------------------
@@ -94,9 +101,10 @@ module Encode =
         | null -> None
         | :? string as s -> Some (Encode.string s)
         | :? bool as b -> Some (yBool b)
+        // Fable JavaScript/TypeScript use `number` for int and float; avoid truncating decimal values through Encode.int.
+        | :? float as f -> Some (yFloat f)
         | :? int as i -> Some (Encode.int i)
         | :? int64 as i -> Some (Encode.string (string i))
-        | :? float as f -> Some (Encode.float f)
         | :? YAMLElement as y -> Some y
         | :? DynamicObj as dynObj -> Some (encodeDynamicObj dynObj)
         | :? System.Collections.IEnumerable as values ->
@@ -576,9 +584,10 @@ module Encode =
         | ResourceRequirement rr ->
             let tryEncodeScalar (key: string) (value: obj) =
                 match value with
+                // Fable JavaScript/TypeScript use `number` for int and float; preserve decimal resource values.
+                | :? float as f -> Some (key, yFloat f)
                 | :? int as i -> Some (key, Encode.int i)
                 | :? int64 as i -> Some (key, YAMLElement.Value (YAMLContent.create (string i)))
-                | :? float as f -> Some (key, Encode.float f)
                 | :? string as s -> Some (key, Encode.string s)
                 | :? bool as b -> Some (key, yBool b)
                 | _ -> None

--- a/src/CWL/Encode.fs
+++ b/src/CWL/Encode.fs
@@ -72,11 +72,7 @@ module Encode =
     // ------------------------------
     let yMap (pairs: (string * YAMLElement) list) =
         // Represent a mapping as an Object containing Mapping nodes preserving order.
-        // Preserve single wrapped scalar and alias nodes because YAMLicious alpha.7
-        // can now write them directly without collapsing style/alias information.
         let normalize = function
-            // YAMLicious emits `key:` (null) for empty object values unless we force inline `{}`.
-            | YAMLElement.Object [] -> YAMLElement.Value (YAMLContent.create "{}")
             | (YAMLElement.Object [YAMLElement.Value _]) as wrapped -> wrapped
             | (YAMLElement.Object [YAMLElement.Alias _]) as wrapped -> wrapped
             | YAMLElement.Object [single] -> single // unwrap single wrapped value (legacy helper usage)

--- a/src/CWL/Encode.fs
+++ b/src/CWL/Encode.fs
@@ -17,6 +17,8 @@ module Encode =
     /// Active pattern to classify CWL types as primitive (with shorthand) or complex (requiring full YAML)
     let rec (|PrimitiveType|ComplexType|) (t: CWLType) =
         match t with
+        // Primitive cases have a direct CWL scalar spelling and can participate
+        // in shorthand array syntax.
         | File _ -> PrimitiveType "File"
         | Directory _ -> PrimitiveType "Directory"
         | Dirent _ -> PrimitiveType "Dirent"
@@ -28,6 +30,8 @@ module Encode =
         | Boolean -> PrimitiveType "boolean"
         | Null -> PrimitiveType "null"
         | Stdout -> PrimitiveType "stdout"
+        // Schemas and general unions require structured YAML unless a later
+        // optional-union special case handles them.
         | Record _ | Enum _ | Union _ -> ComplexType
         | Array arraySchema ->
             // Arrays are primitive only if their items are primitive
@@ -67,6 +71,7 @@ module Encode =
     let yBool (b:bool) =
         YAMLElement.Value (YAMLContent.create (if b then "true" else "false"))
 
+    /// Encode floats with round-trip formatting on .NET while keeping Fable output usable.
     let yFloat (value: float) =
 #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
         YAMLElement.Value (YAMLContent.create (value.ToString()))
@@ -80,8 +85,12 @@ module Encode =
     let yMap (pairs: (string * YAMLElement) list) =
         // Represent a mapping as an Object containing Mapping nodes preserving order.
         let normalize = function
+            // Preserve wrapped scalars and aliases because YAMLicious uses these
+            // wrappers to retain style information.
             | (YAMLElement.Object [YAMLElement.Value _]) as wrapped -> wrapped
             | (YAMLElement.Object [YAMLElement.Alias _]) as wrapped -> wrapped
+            // Legacy helpers often return Object [single] for nested values; unwrap
+            // those to avoid one unnecessary object layer in emitted YAML.
             | YAMLElement.Object [single] -> single // unwrap single wrapped value (legacy helper usage)
             | other -> other
         pairs
@@ -96,18 +105,24 @@ module Encode =
         | Some v -> acc @ [name, encoder v]
         | None -> acc
 
+    /// Encode preserved DynamicObj extension values when they can be represented as YAML.
     let rec encodeDynamicValue (value: obj) =
         match value with
         | null -> None
+        // Direct scalar values map to YAML scalars.
         | :? string as s -> Some (Encode.string s)
         | :? bool as b -> Some (yBool b)
         // Fable JavaScript/TypeScript use `number` for int and float; avoid truncating decimal values through Encode.int.
         | :? float as f -> Some (yFloat f)
         | :? int as i -> Some (Encode.int i)
         | :? int64 as i -> Some (Encode.string (string i))
+        // Already-parsed YAML is written back without reinterpretation.
         | :? YAMLElement as y -> Some y
+        // Nested DynamicObj extension payloads become nested YAML mappings.
         | :? DynamicObj as dynObj -> Some (encodeDynamicObj dynObj)
         | :? System.Collections.IEnumerable as values ->
+            // Generic collections are encoded item-by-item, silently dropping values
+            // that cannot be represented as YAML.
             values
             |> Seq.cast<obj>
             |> Seq.choose encodeDynamicValue
@@ -116,20 +131,25 @@ module Encode =
             |> Some
         | _ -> None
 
+    /// Encode all dynamic extension properties on a DynamicObj as a YAML mapping.
     and encodeDynamicObj (dynObj: DynamicObj) =
         DynamicObjHelpers.dynamicPropertiesExcept Set.empty dynObj
         |> Seq.choose (fun kvp -> encodeDynamicValue kvp.Value |> Option.map (fun encoded -> kvp.Key, encoded))
         |> Seq.toList
         |> yMap
 
+    /// Append encodable dynamic extension fields while excluding typed CWL fields.
     let appendDynamicPropertiesExcept (knownFieldNames: Set<string>) (dynObj: DynamicObj) acc =
         DynamicObjHelpers.dynamicPropertiesExcept knownFieldNames dynObj
         |> Seq.choose (fun kvp -> encodeDynamicValue kvp.Value |> Option.map (fun encoded -> kvp.Key, encoded))
+        // Use a fold that appends to preserve the existing pair order before adding
+        // dynamic fields at the end of the current section.
         |> Seq.fold (fun pairs pair -> pairs @ [ pair ]) acc
 
     let appendDynamicProperties (dynObj: DynamicObj) acc =
         appendDynamicPropertiesExcept Set.empty dynObj acc
 
+    /// Normalize documentation line endings and trim only trailing newline markers.
     let normalizeDocString (doc:string) =
         doc.Replace("\r\n","\n").TrimEnd('\n').TrimEnd('\r')
 
@@ -139,28 +159,35 @@ module Encode =
     /// so trailing newlines and blank lines survive decode/encode roundtrips.
     let encodeExpressionScalar (expression: string) : YAMLElement =
         let normalized =
+            // Normalize line endings once so style selection and emitted text agree.
             if isNull expression then "" else expression.Replace("\r\n", "\n").Replace("\r", "\n")
 
         let style =
+            // Literal block style keeps multi-line JS expressions readable and avoids
+            // YAML interpreting punctuation inside expressions.
             if normalized.Contains("\n") then
                 ScalarStyle.Block(BlockScalarStyle.Literal, ChompingMode.Clip, None)
             else
+                // Single-line expressions are quoted for parser safety.
                 ScalarStyle.DoubleQuoted
 
         YAMLElement.Value (YAMLContent.create(normalized, style = style))
 
+    /// Encode schema-salad strings as literals or directive mappings.
     let encodeSchemaSaladString (value: SchemaSaladString) : YAMLElement =
         match value with
         | SchemaSaladString.Literal text -> Encode.string text
         | SchemaSaladString.Include path -> yMap [ "$include", Encode.string path ]
         | SchemaSaladString.Import path -> yMap [ "$import", Encode.string path ]
 
+    /// Quote boolean-looking EnvVar values so YAML does not coerce them on decode.
     let normalizeEnvValueForEncode (envValue: string) =
         if envValue = "true" || envValue = "false" then "\"" + envValue + "\"" else envValue
 
     /// Encode EnvVarRequirement using compact map shorthand (envName -> envValue).
     let encodeEnvVarRequirementCompactMap (envs: ResizeArray<EnvironmentDef>) : YAMLElement =
         let envDefMap =
+            // Compact map form writes env names as keys.
             envs
             |> Seq.map (fun env -> env.EnvName, Encode.string (normalizeEnvValueForEncode env.EnvValue))
             |> Seq.toList
@@ -173,9 +200,12 @@ module Encode =
     let encodeSoftwareRequirementCompactMap (packages: ResizeArray<SoftwarePackage>) : YAMLElement =
         let encodePackageValue (package: SoftwarePackage) =
             match package.Version, package.Specs with
+            // Empty object means package present with no version/specs constraints.
             | None, None -> yMap []
+            // Specs-only packages can use sequence shorthand.
             | None, Some specs -> specs |> Seq.map Encode.string |> Seq.toList |> YAMLElement.Sequence
             | _ ->
+                // Full package object keeps version and specs separate.
                 []
                 |> appendOpt "version" (fun values -> values |> Seq.map Encode.string |> Seq.toList |> YAMLElement.Sequence) package.Version
                 |> appendOpt "specs" (fun values -> values |> Seq.map Encode.string |> Seq.toList |> YAMLElement.Sequence) package.Specs
@@ -208,6 +238,7 @@ module Encode =
     // ------------------------------
     // CWLType encoder
     // ------------------------------
+    /// Encode File fields with the supplied discriminator key (`type` or `class`).
     let encodeFilePairs discriminatorKey discriminatorValue (file: FileInstance) =
         [ discriminatorKey, Encode.string discriminatorValue ]
         |> appendOpt "location" Encode.string file.Location
@@ -223,6 +254,7 @@ module Encode =
         |> appendOpt "contents" Encode.string file.Contents
         |> appendDynamicPropertiesExcept FileInstance.KnownFieldNames file
 
+    /// Encode Directory fields with the supplied discriminator key (`type` or `class`).
     let encodeDirectoryPairs discriminatorKey discriminatorValue (directory: DirectoryInstance) =
         [ discriminatorKey, Encode.string discriminatorValue ]
         |> appendOpt "location" Encode.string directory.Location
@@ -231,21 +263,29 @@ module Encode =
         |> appendOpt "listing" id directory.Listing
         |> appendDynamicPropertiesExcept DirectoryInstance.KnownFieldNames directory
 
+    /// Encode CWL types using shorthand when possible and full schema objects when required.
     let rec encodeCWLType (t:CWLType) : YAMLElement =
         let hasFileFields (file: FileInstance) =
+            // encodeFilePairs always includes the discriminator, so more than one
+            // pair means metadata is present and scalar File shorthand would lose it.
             (encodeFilePairs "type" "File" file).Length > 1
 
         let hasDirectoryFields (directory: DirectoryInstance) =
+            // Same rule as File: any metadata requires object form.
             (encodeDirectoryPairs "type" "Directory" directory).Length > 1
 
         match t with
         | File file when hasFileFields file ->
+            // Preserve File metadata such as secondaryFiles or format.
             encodeFilePairs "type" "File" file |> yMap
         | File _ -> Encode.string "File"
         | Directory directory when hasDirectoryFields directory ->
+            // Preserve Directory metadata such as listing.
             encodeDirectoryPairs "type" "Directory" directory |> yMap
         | Directory _ -> Encode.string "Directory"
         | Dirent d ->
+            // Dirent is always structured because it has required entry plus optional
+            // entryname/writable fields.
             [ "entry", encodeSchemaSaladString d.Entry ]
             |> appendOpt "entryname" encodeSchemaSaladString d.Entryname
             |> appendOpt "writable" (fun b -> yBool b) d.Writable
@@ -260,7 +300,8 @@ module Encode =
         | Stdout -> Encode.string "stdout"
         | Null -> Encode.string "null"
         | Union types ->
-            // Check if this is an optional type (union of null and one other type)
+            // Check if this is an optional type (union of null and one other type).
+            // Only those unions can use CWL's `?` shorthand.
             let typesList = types |> Seq.toList
             match typesList with
             | [Null; otherType] | [otherType; Null] ->
@@ -288,7 +329,8 @@ module Encode =
                 // General union - use array form
                 typesList |> List.map encodeCWLType |> YAMLElement.Sequence
         | Array arraySchema ->
-            // Try to use short form for arrays (handles arbitrary nesting depth recursively)
+            // Try to use short form for arrays (handles arbitrary nesting depth
+            // recursively); fall back to schema object for complex item types.
             match tryGetArrayShorthand arraySchema.Items with
             | Some shorthand -> Encode.string (shorthand + "[]")
             | None -> encodeInputArraySchema arraySchema
@@ -299,21 +341,28 @@ module Encode =
     // InputRecordSchema encoders
     // ------------------------------
 
+    /// Encode a record field as a map entry keyed by its field name.
     and encodeInputRecordField (field:InputRecordField) : (string * YAMLElement) =
         let pairs =
+            // The field name is emitted as the mapping key, so the nested value only
+            // contains field payload such as type/doc/label/extensions.
             [ "type", encodeCWLType field.Type ]
             |> appendOpt "doc" Encode.string field.Doc
             |> appendOpt "label" Encode.string field.Label
             |> appendDynamicPropertiesExcept InputRecordField.KnownFieldNames field
         field.Name, yMap pairs
 
+    /// Encode record schemas with map-form fields and preserved schema metadata.
     and encodeInputRecordSchema (schema:InputRecordSchema) : YAMLElement =
         let fieldsElement =
             match schema.Fields with
             | Some fs ->
+                // Record fields are written in map form for stable names and compact YAML.
                 let fieldPairs = fs |> Seq.map encodeInputRecordField |> Seq.toList
                 yMap fieldPairs
-            | None -> yMap []
+            | None ->
+                // Missing fields are emitted as an empty map to keep the schema object valid.
+                yMap []
         [ "type", Encode.string "record"; "fields", fieldsElement ]
         |> appendOpt "label" Encode.string schema.Label
         |> appendOpt "doc" Encode.string schema.Doc
@@ -321,8 +370,10 @@ module Encode =
         |> appendDynamicPropertiesExcept InputRecordSchema.KnownFieldNames schema
         |> yMap
 
+    /// Encode enum schemas while preserving symbol order and schema metadata.
     and encodeInputEnumSchema (schema:InputEnumSchema) : YAMLElement =
         let pairs =
+            // Symbol order is semantically significant, so emit the ResizeArray order.
             [ "type", Encode.string "enum" ]
             @ [ "symbols", (schema.Symbols |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) ]
 
@@ -333,6 +384,7 @@ module Encode =
         |> appendDynamicPropertiesExcept InputEnumSchema.KnownFieldNames schema
         |> yMap
 
+    /// Encode array schemas with their item type and preserved schema metadata.
     and encodeInputArraySchema (schema:InputArraySchema) : YAMLElement =
         [ "type", Encode.string "array"; "items", encodeCWLType schema.Items ]
         |> appendOpt "label" Encode.string schema.Label
@@ -345,6 +397,7 @@ module Encode =
     // Binding & Port encoders
     // ------------------------------
 
+    /// Encode outputBinding fields and preserved extension properties.
     let encodeOutputBinding (ob:OutputBinding) : YAMLElement =
         [ ob.Glob |> Option.map (fun g -> "glob", Encode.string g) ]
         |> List.choose id
@@ -354,6 +407,7 @@ module Encode =
         |> appendDynamicPropertiesExcept OutputBinding.KnownFieldNames ob
         |> yMap
 
+    /// Encode one source value as a scalar and multiple source values as a sequence.
     let encodeStringArrayOrScalar (values: ResizeArray<string>) : YAMLElement =
         if values.Count = 1 then
             Encode.string values.[0]
@@ -363,8 +417,11 @@ module Encode =
             |> List.ofSeq
             |> YAMLElement.Sequence
 
+    /// Encode a workflow or tool output, choosing shorthand only when type is the sole field.
     let encodeCWLOutput (o:CWLOutput) : (string * YAMLElement) =
         let typeElement = o.Type_ |> Option.map (fun t ->
+            // Output type encoding mirrors input type encoding, but wraps complex
+            // schema forms under `type` when the port itself is an object.
             match t with
             | Union types ->
                 // Check if this is a simple optional (encodeCWLType handles the short form)
@@ -408,12 +465,15 @@ module Encode =
         )
 
         let outputSourceElement =
+            // Keep scalar outputSource compact, but use a sequence when multiple
+            // upstream step outputs feed this workflow output.
             match o.OutputSource with
             | Some (OutputSource.Single value) -> Some (Encode.string value)
             | Some (OutputSource.Multiple values) when values.Count > 0 -> Some (encodeStringArrayOrScalar values)
             | _ -> None
         
         let pairs =
+            // Build object-form fields in CWL's conventional order.
             []
             |> appendOpt "type" id typeElement
             |> appendOpt "label" Encode.string o.Label
@@ -425,11 +485,14 @@ module Encode =
             |> appendOpt "outputSource" id outputSourceElement
             |> appendDynamicPropertiesExcept CWLOutput.KnownFieldNames o
         match pairs with
-        | [ ("type", t) ] -> o.Name, t // only type specified
+        | [ ("type", t) ] ->
+            // Map shorthand: outputName: File
+            o.Name, t
         | _ ->
             // Always extended form when additional fields like outputSource/outputBinding present
             o.Name, (yMap pairs)
 
+    /// Encode inputBinding fields and preserved extension properties.
     let encodeInputBinding (ib:InputBinding) : YAMLElement =
         []
         |> appendOpt "loadContents" yBool ib.LoadContents
@@ -442,8 +505,11 @@ module Encode =
         |> appendDynamicPropertiesExcept InputBinding.KnownFieldNames ib
         |> yMap
 
+    /// Encode a workflow or tool input, choosing shorthand only when type is the sole field.
     let encodeCWLInput (i:CWLInput) : (string * YAMLElement) =
         let typeElement = i.Type_ |> Option.map (fun t ->
+            // Input type object wrapping follows the same shorthand/full-schema rules
+            // as outputs to avoid losing complex schema metadata.
             match t with
             | Union types ->
                 // Check if this is a simple optional (encodeCWLType handles the short form)
@@ -487,6 +553,8 @@ module Encode =
         )
         
         let pairs =
+            // Build object-form fields in CWL's conventional order; optional is
+            // encoded through the type union shorthand rather than as a separate field.
             []
             |> appendOpt "type" id typeElement
             |> appendOpt "label" Encode.string i.Label
@@ -500,13 +568,18 @@ module Encode =
             |> appendOpt "inputBinding" encodeInputBinding i.InputBinding
             |> appendDynamicPropertiesExcept CWLInput.KnownFieldNames i
         match pairs with
-        | [ ("type", t) ] -> i.Name, t
-        | _ -> i.Name, yMap pairs
+        | [ ("type", t) ] ->
+            // Map shorthand: inputName: string
+            i.Name, t
+        | _ ->
+            // Extended form is needed whenever metadata/default/binding/extensions exist.
+            i.Name, yMap pairs
 
     // ------------------------------
     // Requirement encoder (always extended style)
     // ------------------------------
 
+    /// Encode one SchemaDefRequirement type entry and preserved schema extension fields.
     let encodeSchemaDefRequirementType (s:SchemaDefRequirementType) : YAMLElement =
         [
             "name", Encode.string s.Name
@@ -515,10 +588,13 @@ module Encode =
         |> appendDynamicPropertiesExcept SchemaDefRequirementType.KnownFieldNames s
         |> yMap
 
+    /// Encode known CWL requirements in extended form while preserving requirement extensions.
     let encodeRequirement (r:Requirement) : YAMLElement =
         match r with
         | InlineJavascriptRequirement value ->
             let expressionLib =
+                // Empty expressionLib is omitted because the requirement class alone
+                // is meaningful and matches CWL's compact style.
                 value.ExpressionLib
                 |> Option.bind (fun entries -> if entries.Count > 0 then Some entries else None)
             [ "class", Encode.string "InlineJavascriptRequirement" ]
@@ -526,9 +602,12 @@ module Encode =
             |> appendDynamicPropertiesExcept InlineJavascriptRequirementValue.KnownFieldNames value
             |> yMap
         | SchemaDefRequirement types ->
+            // SchemaDefRequirement contains schema entries that already preserve their
+            // own extension fields.
             [ "class", Encode.string "SchemaDefRequirement";
               "types", (types |> Seq.map encodeSchemaDefRequirementType |> List.ofSeq |> YAMLElement.Sequence) ] |> yMap
         | DockerRequirement dr ->
+            // Docker fields are optional and emitted only when present.
             [ "class", Encode.string "DockerRequirement" ]
             |> appendOpt "dockerPull" Encode.string dr.DockerPull
             |> appendOpt "dockerFile" encodeSchemaSaladString dr.DockerFile
@@ -541,6 +620,8 @@ module Encode =
             |> yMap
         | SoftwareRequirement pkgs ->
             let encodePkg (p:SoftwarePackage) =
+                // Extended package form is used here so version/specs/extensions all
+                // have explicit keys.
                 []
                 |> fun acc -> acc @ [ "package", Encode.string p.Package ]
                 |> appendOpt "version" (fun vs -> vs |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) p.Version
@@ -550,6 +631,7 @@ module Encode =
             [ "class", Encode.string "SoftwareRequirement";
               "packages", (pkgs |> Seq.map encodePkg |> List.ofSeq |> YAMLElement.Sequence) ] |> yMap
         | LoadListingRequirement loadListing ->
+            // Always emit the concrete loadListing value instead of relying on decoder defaults.
             [ "class", Encode.string "LoadListingRequirement"
               "loadListing", Encode.string (LoadListingEnum.toCwlString loadListing.LoadListing) ]
             |> appendDynamicPropertiesExcept LoadListingRequirementValue.KnownFieldNames loadListing
@@ -557,6 +639,7 @@ module Encode =
         | InitialWorkDirRequirement listing ->
             let encodeInitialWorkDirEntry = function
                 | DirentEntry d ->
+                    // Dirent entries use their own object form.
                     [ ]
                     |> appendOpt "entryname" encodeSchemaSaladString d.Entryname
                     |> fun acc -> acc @ [ "entry", encodeSchemaSaladString d.Entry ]
@@ -564,8 +647,10 @@ module Encode =
                     |> appendDynamicPropertiesExcept DirentInstance.KnownFieldNames d
                     |> yMap
                 | StringEntry s ->
+                    // String/expression listing entries stay scalar/directive form.
                     encodeSchemaSaladString s
                 | FileEntry file ->
+                    // File/Directory listing entries use class, not type, as discriminator.
                     encodeFilePairs "class" "File" file |> yMap
                 | DirectoryEntry directory ->
                     encodeDirectoryPairs "class" "Directory" directory |> yMap
@@ -574,6 +659,7 @@ module Encode =
               "listing", (listing |> Seq.map encodeInitialWorkDirEntry |> List.ofSeq |> YAMLElement.Sequence) ] |> yMap
         | EnvVarRequirement envs ->
             let encodeEnv (e:EnvironmentDef) =
+                // Env var values remain strings; quote boolean-looking values.
                 let v = normalizeEnvValueForEncode e.EnvValue
                 [ "envName", Encode.string e.EnvName; "envValue", Encode.string v ]
                 |> appendDynamicPropertiesExcept EnvironmentDef.KnownFieldNames e
@@ -583,6 +669,8 @@ module Encode =
         | ShellCommandRequirement -> [ "class", Encode.string "ShellCommandRequirement" ] |> yMap
         | ResourceRequirement rr ->
             let tryEncodeScalar (key: string) (value: obj) =
+                // Resource fields can be numeric, boolean, or expression strings.
+                // Only those scalar shapes are emitted from typed or dynamic fields.
                 match value with
                 // Fable JavaScript/TypeScript use `number` for int and float; preserve decimal resource values.
                 | :? float as f -> Some (key, yFloat f)
@@ -593,6 +681,7 @@ module Encode =
                 | _ -> None
 
             let knownPairs =
+                // Typed fields are emitted first in CWL field order.
                 rr.KnownFieldValues
                 |> List.choose (fun (key, value) ->
                     value |> Option.bind (tryEncodeScalar key))
@@ -603,6 +692,7 @@ module Encode =
                 |> Set.ofSeq
 
             let dynamicPairs =
+                // Then append custom resource fields that look scalar enough to encode.
                 DynamicObjHelpers.dynamicPropertiesExcept knownFieldNames rr
                 |> Seq.choose (fun kvp ->
                     match kvp.Value with
@@ -648,6 +738,7 @@ module Encode =
         | MultipleInputFeatureRequirement -> [ "class", Encode.string "MultipleInputFeatureRequirement" ] |> yMap
         | StepInputExpressionRequirement -> [ "class", Encode.string "StepInputExpressionRequirement" ] |> yMap
 
+    /// Encode known hints as requirements and unknown hints as their original raw YAML.
     let encodeHintEntry (hint: HintEntry) : YAMLElement =
         match hint with
         | KnownHint requirement -> encodeRequirement requirement
@@ -660,7 +751,9 @@ module Encode =
     /// Encode a ResizeArray<string> as either a single string or a sequence
     let encodeSourceArray (sources:ResizeArray<string>) : YAMLElement =
         match sources.Count with
-        | 1 -> Encode.string sources.[0]
+        | 1 ->
+            // CWL source shorthand: source: input_id
+            Encode.string sources.[0]
         | _ -> 
             // Wrap scalar items to keep nested `source` arrays in block-sequence form.
             sources 
@@ -677,6 +770,7 @@ module Encode =
     let encodeScatterMethod (scatterMethod: ScatterMethod) : YAMLElement =
         Encode.string scatterMethod.AsCwlString
 
+    /// Encode a step input using scalar source shorthand only when no other fields exist.
     let encodeStepInput (si:StepInput) : (string * YAMLElement) =
         let pairs =
             []
@@ -704,17 +798,20 @@ module Encode =
             si.Id, s
         | _ -> si.Id, yMap pairs
 
+    /// Encode all step inputs in map form keyed by step input id.
     let encodeStepInputs (inputs:ResizeArray<StepInput>) : YAMLElement =
         inputs
         |> Seq.map encodeStepInput
         |> Seq.toList
         |> yMap
 
+    /// Encode record-form step output parameters, including extension fields.
     let encodeStepOutputParameter (so: StepOutputParameter) : YAMLElement =
         [ "id", Encode.string so.Id ]
         |> appendDynamicPropertiesExcept StepOutputParameter.KnownFieldNames so
         |> yMap
 
+    /// Encode step outputs as either scalar ids or record-form output parameters.
     let encodeStepOutputs (outputs: ResizeArray<StepOutput>) : YAMLElement =
         outputs
         |> Seq.map (fun output ->
@@ -725,37 +822,47 @@ module Encode =
         |> List.ofSeq
         |> YAMLElement.Sequence
 
+    /// Encode scatter as scalar shorthand for one item or a sequence for multiple items.
     let encodeScatter (scatter: ResizeArray<string>) : YAMLElement =
         match scatter.Count with
         | 1 -> Encode.string scatter.[0]
         | _ -> scatter |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence
 
+    /// Encode workflow step run targets as paths or inline processing units.
     let rec encodeWorkflowStepRun (run: WorkflowStepRun) : YAMLElement =
         match run with
-        | RunString runPath -> Encode.string runPath
+        | RunString runPath ->
+            // External run reference.
+            Encode.string runPath
         | RunCommandLineTool toolObj ->
+            // Inline CommandLineTool run; validate the object payload before encoding.
             match WorkflowStepRunOps.tryGetTool run with
             | Some tool -> encodeToolDescriptionElement tool
             | None ->
                 raise (System.ArgumentException($"RunCommandLineTool must contain CWLToolDescription but got %A{toolObj}"))
         | RunWorkflow workflowObj ->
+            // Inline nested Workflow run.
             match WorkflowStepRunOps.tryGetWorkflow run with
             | Some workflow -> encodeWorkflowDescriptionElement workflow
             | None ->
                 raise (System.ArgumentException($"RunWorkflow must contain CWLWorkflowDescription but got %A{workflowObj}"))
         | RunExpressionTool expressionToolObj ->
+            // Inline ExpressionTool run.
             match WorkflowStepRunOps.tryGetExpressionTool run with
             | Some expressionTool -> encodeExpressionToolDescriptionElement expressionTool
             | None ->
                 raise (System.ArgumentException($"RunExpressionTool must contain CWLExpressionToolDescription but got %A{expressionToolObj}"))
         | RunOperation operationObj ->
+            // Inline Operation run.
             match WorkflowStepRunOps.tryGetOperation run with
             | Some operation -> encodeOperationDescriptionElement operation
             | None ->
                 raise (System.ArgumentException($"RunOperation must contain CWLOperationDescription but got %A{operationObj}"))
 
+    /// Encode a CommandLineTool element with ordered sections and preserved metadata.
     and encodeToolDescriptionElement (td: CWLToolDescription) : YAMLElement =
         let basePairs =
+            // Base identity fields stay in the first top-level section.
             [ "cwlVersion", Encode.string td.CWLVersion
               "class", Encode.string "CommandLineTool" ]
             |> appendOptPair (td.Id |> Option.map (fun id -> "id", Encode.string id))
@@ -765,19 +872,23 @@ module Encode =
         let withHints =
             match td.Hints with
             | Some h when h.Count > 0 ->
+                // Hints are emitted before requirements to match existing fixtures.
                 basePairs @ [ "hints", (h |> Seq.map encodeHintEntry |> List.ofSeq |> YAMLElement.Sequence) ]
             | _ -> basePairs
         let withRequirements =
             match td.Requirements with
             | Some r when r.Count > 0 ->
+                // Requirements are omitted when absent or empty.
                 withHints @ [ "requirements", (r |> Seq.map encodeRequirement |> List.ofSeq |> YAMLElement.Sequence) ]
             | _ -> withHints
         let withBaseCommand =
             match td.BaseCommand with
             | Some bc when bc.Count > 0 ->
+                // baseCommand is always emitted as a sequence here.
                 withRequirements @ [ "baseCommand", (bc |> Seq.map Encode.string |> List.ofSeq |> YAMLElement.Sequence) ]
             | _ -> withRequirements
         let withCommandFields =
+            // Command-line execution fields belong near baseCommand before ports.
             withBaseCommand
             |> appendOpt "arguments" id td.Arguments
             |> appendOpt "stdin" Encode.string td.Stdin
@@ -789,21 +900,27 @@ module Encode =
         let withInputs =
             match td.Inputs with
             | Some i when i.Count > 0 ->
+                // Inputs are optional for CommandLineTool.
                 withCommandFields @ [ "inputs", (i |> Seq.map encodeCWLInput |> Seq.toList |> yMap) ]
             | _ -> withCommandFields
         let withOutputs =
+            // Outputs are required by the model and always emitted.
             withInputs @ [ "outputs", (td.Outputs |> Seq.map encodeCWLOutput |> Seq.toList |> yMap) ]
         let withMetadata =
             match td.Metadata with
             | Some md ->
+                // Metadata DynamicObj is serialized as top-level extension fields.
                 appendDynamicProperties md withOutputs
             | None -> withOutputs
         withMetadata
+        // Also include dynamic fields attached directly to the tool object.
         |> appendDynamicPropertiesExcept CWLToolDescription.KnownFieldNames td
         |> yMap
 
+    /// Encode an ExpressionTool element with ordered sections and preserved metadata.
     and encodeExpressionToolDescriptionElement (et: CWLExpressionToolDescription) : YAMLElement =
         let basePairs =
+            // Base identity fields stay in the first top-level section.
             [ "cwlVersion", Encode.string et.CWLVersion
               "class", Encode.string "ExpressionTool" ]
             |> appendOptPair (et.Id |> Option.map (fun id -> "id", Encode.string id))
@@ -828,18 +945,23 @@ module Encode =
         let withOutputs =
             withInputs @ [ "outputs", (et.Outputs |> Seq.map encodeCWLOutput |> Seq.toList |> yMap) ]
         let withExpression =
+            // Expression is required and written after ports.
             withOutputs @ [ "expression", encodeExpressionScalar et.Expression ]
         let withMetadata =
             match et.Metadata with
             | Some md ->
+                // Metadata DynamicObj is serialized as top-level extension fields.
                 appendDynamicProperties md withExpression
             | None -> withExpression
         withMetadata
+        // Include dynamic fields attached directly to the expression tool object.
         |> appendDynamicPropertiesExcept CWLExpressionToolDescription.KnownFieldNames et
         |> yMap
 
+    /// Encode an Operation element with ordered sections and preserved metadata.
     and encodeOperationDescriptionElement (op: CWLOperationDescription) : YAMLElement =
         let basePairs =
+            // Base identity fields stay in the first top-level section.
             [ "cwlVersion", Encode.string op.CWLVersion
               "class", Encode.string "Operation" ]
             |> appendOptPair (op.Id |> Option.map (fun id -> "id", Encode.string id))
@@ -857,20 +979,26 @@ module Encode =
                 withHints @ [ "requirements", (r |> Seq.map encodeRequirement |> List.ofSeq |> YAMLElement.Sequence) ]
             | _ -> withHints
         let withInputs =
+            // Operation inputs are required by the model.
             withRequirements @ [ "inputs", (op.Inputs |> Seq.map encodeCWLInput |> Seq.toList |> yMap) ]
         let withOutputs =
+            // Operation outputs are required by the model.
             withInputs @ [ "outputs", (op.Outputs |> Seq.map encodeCWLOutput |> Seq.toList |> yMap) ]
         let withMetadata =
             match op.Metadata with
             | Some md ->
+                // Metadata DynamicObj is serialized as top-level extension fields.
                 appendDynamicProperties md withOutputs
             | None -> withOutputs
         withMetadata
+        // Include dynamic fields attached directly to the operation object.
         |> appendDynamicPropertiesExcept CWLOperationDescription.KnownFieldNames op
         |> yMap
 
+    /// Encode a Workflow element with ordered sections and preserved metadata.
     and encodeWorkflowDescriptionElement (wd: CWLWorkflowDescription) : YAMLElement =
         let basePairs =
+            // Base identity fields stay in the first top-level section.
             [ "cwlVersion", Encode.string wd.CWLVersion
               "class", Encode.string "Workflow" ]
             |> appendOptPair (wd.Id |> Option.map (fun id -> "id", Encode.string id))
@@ -887,20 +1015,30 @@ module Encode =
             | Some r when r.Count > 0 ->
                 withHints @ [ "requirements", (r |> Seq.map encodeRequirement |> List.ofSeq |> YAMLElement.Sequence) ]
             | _ -> withHints
-        let withInputs = withRequirements @ [ "inputs", (wd.Inputs |> Seq.map encodeCWLInput |> Seq.toList |> yMap) ]
-        let withSteps = withInputs @ [ "steps", (wd.Steps |> Seq.map encodeWorkflowStep |> Seq.toList |> yMap) ]
-        let withOutputs = withSteps @ [ "outputs", (wd.Outputs |> Seq.map encodeCWLOutput |> Seq.toList |> yMap) ]
+        let withInputs =
+            // Workflow inputs are required and emitted before steps.
+            withRequirements @ [ "inputs", (wd.Inputs |> Seq.map encodeCWLInput |> Seq.toList |> yMap) ]
+        let withSteps =
+            // Steps are map entries keyed by step id.
+            withInputs @ [ "steps", (wd.Steps |> Seq.map encodeWorkflowStep |> Seq.toList |> yMap) ]
+        let withOutputs =
+            // Outputs follow steps for scan-friendly workflow YAML.
+            withSteps @ [ "outputs", (wd.Outputs |> Seq.map encodeCWLOutput |> Seq.toList |> yMap) ]
         let withMetadata =
             match wd.Metadata with
             | Some md ->
+                // Metadata DynamicObj is serialized as top-level extension fields.
                 appendDynamicProperties md withOutputs
             | None -> withOutputs
         withMetadata
+        // Include dynamic fields attached directly to the workflow object.
         |> appendDynamicPropertiesExcept CWLWorkflowDescription.KnownFieldNames wd
         |> yMap
 
+    /// Encode one workflow step as a map entry keyed by step id.
     and encodeWorkflowStep (ws:WorkflowStep) : (string * YAMLElement) =
         let basePairs =
+            // Required step fields are emitted first.
             [ "run", encodeWorkflowStepRun ws.Run
               "in", encodeStepInputs ws.In
               "out", encodeStepOutputs ws.Out ]
@@ -912,10 +1050,12 @@ module Encode =
             |> appendDynamicPropertiesExcept WorkflowStep.KnownFieldNames ws
         let withHints =
             match ws.Hints with
+            // Step-local hints are included only when non-empty.
             | Some h when h.Count > 0 -> basePairs @ [ "hints", (h |> Seq.map encodeHintEntry |> List.ofSeq |> YAMLElement.Sequence) ]
             | _ -> basePairs
         let withReq =
             match ws.Requirements with
+            // Step-local requirements follow hints.
             | Some r when r.Count > 0 -> withHints @ [ "requirements", (r |> Seq.map encodeRequirement |> List.ofSeq |> YAMLElement.Sequence) ]
             | _ -> withHints
         ws.Id, yMap withReq
@@ -928,6 +1068,7 @@ module Encode =
         // Use whitespace=2 to match fixtures (assumed)
         YAMLicious.Writer.write element (Some (fun c -> { c with Whitespace = 2 }))
 
+    /// Extract object mappings in order, dropping non-mapping presentation nodes.
     let getObjectPairs (element: YAMLElement) : (string * YAMLElement) list =
         match element with
         | YAMLElement.Object mappings ->
@@ -938,8 +1079,11 @@ module Encode =
             )
         | _ -> []
 
+    /// Render top-level CWL sections in a stable order while keeping metadata as a final block.
     let renderTopLevelElement (baseKeys: string list) (orderedSectionKeys: string list) (element: YAMLElement) : string =
         let section (pairs:(string*YAMLElement) list) =
+            // Render each logical section independently so blank lines can separate
+            // high-level CWL sections.
             pairs
             |> yMap
             |> writeYaml
@@ -947,10 +1091,13 @@ module Encode =
 
         let pairs = getObjectPairs element
         let basePairs =
+            // Identity and description keys stay together at the top.
             pairs
             |> List.filter (fun (k, _) -> List.contains k baseKeys)
 
         let knownSections =
+            // Ordered sections are emitted one key at a time to keep large CWL blocks
+            // visually separated.
             orderedSectionKeys
             |> List.choose (fun sectionKey ->
                 pairs
@@ -960,10 +1107,12 @@ module Encode =
 
         let reservedKeys = Set.ofList (baseKeys @ orderedSectionKeys)
         let metadataPairs =
+            // Any unreserved key is extension metadata and is placed after typed sections.
             pairs
             |> List.filter (fun (k, _) -> reservedKeys.Contains k |> not)
 
         let sections =
+            // Drop empty sections, preserving the requested order for the rest.
             [
                 if basePairs.Length > 0 then
                     section basePairs
@@ -977,6 +1126,8 @@ module Encode =
         let rec merge (acc:string list) (remaining:string list) =
             match remaining with
             | a::b::rest when a.Trim() = "-" && b.TrimStart().Contains(":") ->
+                // YAMLicious can render a sequence item marker on its own line before
+                // a mapping; merge it to the conventional `- key: value` form.
                 let merged = a + " " + b.Trim()
                 merge (merged::acc) rest
             | l::rest -> merge (l::acc) rest
@@ -984,23 +1135,28 @@ module Encode =
         merge [] lines |> String.concat "\r\n"
 
     let encodeToolDescription (td:CWLToolDescription) : string =
+        // Tool top-level layout places command fields before ports.
         encodeToolDescriptionElement td
         |> renderTopLevelElement ["cwlVersion"; "class"; "id"; "label"; "doc"; "intent"] ["hints"; "requirements"; "baseCommand"; "inputs"; "outputs"]
 
     let encodeWorkflowDescription (wd:CWLWorkflowDescription) : string =
+        // Workflow layout keeps inputs, steps, and outputs as separate scan blocks.
         encodeWorkflowDescriptionElement wd
         |> renderTopLevelElement ["cwlVersion"; "class"; "id"; "label"; "doc"; "intent"] ["hints"; "requirements"; "inputs"; "steps"; "outputs"]
 
     let encodeExpressionToolDescription (et:CWLExpressionToolDescription) : string =
+        // ExpressionTool layout writes expression after ports.
         encodeExpressionToolDescriptionElement et
         |> renderTopLevelElement ["cwlVersion"; "class"; "id"; "label"; "doc"; "intent"] ["hints"; "requirements"; "inputs"; "outputs"; "expression"]
 
     let encodeOperationDescription (op: CWLOperationDescription) : string =
+        // Operation layout mirrors workflow/tool metadata and port ordering.
         encodeOperationDescriptionElement op
         |> renderTopLevelElement ["cwlVersion"; "class"; "id"; "label"; "doc"; "intent"] ["hints"; "requirements"; "inputs"; "outputs"]
 
     let encodeProcessingUnit (pu : CWLProcessingUnit) :string =
         match pu with
+        // Preserve the public processing-unit wrapper dispatch at the string level.
         | CommandLineTool td -> encodeToolDescription td
         | Workflow wd -> encodeWorkflowDescription wd
         | ExpressionTool et -> encodeExpressionToolDescription et
@@ -1018,6 +1174,7 @@ module Encode =
                 |> String.concat ", "
             "[" + encodedTypes + "]"
         | Array arraySchema ->
+            // Inline schema rendering is used for compact serialization contexts.
             encodeInputArraySchemaYaml arraySchema
         | Record recordSchema -> encodeInputRecordSchemaYaml recordSchema
         | Enum enumSchema -> encodeInputEnumSchemaYaml enumSchema
@@ -1030,6 +1187,7 @@ module Encode =
             yamlForm.Trim()
 
     and encodeInputRecordFieldYaml (field: InputRecordField) : string =
+        // Flow-style helper used only for single-line type serialization.
         let typeYaml = encodeCWLTypeYaml field.Type
         $"{{name: {field.Name}, type: {typeYaml}}}"
 
@@ -1037,23 +1195,27 @@ module Encode =
         let fieldsYaml =
             match schema.Fields with
             | Some fs when fs.Count > 0 -> 
+                // Preserve field order from the schema's ResizeArray.
                 fs 
                 |> Seq.map encodeInputRecordFieldYaml
                 |> String.concat ", "
             | _ -> ""
         
         if fieldsYaml = "" then
+            // Empty records still need an explicit fields array in flow form.
             "{type: record, fields: []}"
         else
             $"{{type: record, fields: [{fieldsYaml}]}}"
 
     and encodeInputEnumSchemaYaml (schema: InputEnumSchema) : string =
+        // Symbols are emitted in stored order.
         let symbolsYaml = 
             schema.Symbols 
             |> String.concat ", "
         $"{{type: enum, symbols: [{symbolsYaml}]}}"
 
     and encodeInputArraySchemaYaml (schema: InputArraySchema) : string =
+        // Array flow form delegates recursively for nested or complex item types.
         let itemsYaml = encodeCWLTypeYaml schema.Items
         $"{{type: array, items: {itemsYaml}}}"
 

--- a/src/CWL/Encode.fs
+++ b/src/CWL/Encode.fs
@@ -208,7 +208,7 @@ module Encode =
     // ------------------------------
     // CWLType encoder
     // ------------------------------
-    let private encodeFilePairs discriminatorKey discriminatorValue (file: FileInstance) =
+    let encodeFilePairs discriminatorKey discriminatorValue (file: FileInstance) =
         [ discriminatorKey, Encode.string discriminatorValue ]
         |> appendOpt "location" Encode.string file.Location
         |> appendOpt "path" Encode.string file.Path
@@ -223,7 +223,7 @@ module Encode =
         |> appendOpt "contents" Encode.string file.Contents
         |> appendDynamicPropertiesExcept FileInstance.KnownFieldNames file
 
-    let private encodeDirectoryPairs discriminatorKey discriminatorValue (directory: DirectoryInstance) =
+    let encodeDirectoryPairs discriminatorKey discriminatorValue (directory: DirectoryInstance) =
         [ discriminatorKey, Encode.string discriminatorValue ]
         |> appendOpt "location" Encode.string directory.Location
         |> appendOpt "path" Encode.string directory.Path

--- a/src/CWL/ExpressionToolDescription.fs
+++ b/src/CWL/ExpressionToolDescription.fs
@@ -76,7 +76,7 @@ type CWLExpressionToolDescription (
         and set(doc) = _doc <- doc
 
     static member KnownFieldNames =
-        ResizeArray [|
+        Set [|
             "inputs"
             "outputs"
             "class"

--- a/src/CWL/ExpressionToolDescription.fs
+++ b/src/CWL/ExpressionToolDescription.fs
@@ -75,6 +75,21 @@ type CWLExpressionToolDescription (
         with get() = _doc
         and set(doc) = _doc <- doc
 
+    static member KnownFieldNames =
+        ResizeArray [|
+            "inputs"
+            "outputs"
+            "class"
+            "id"
+            "label"
+            "doc"
+            "intent"
+            "requirements"
+            "hints"
+            "cwlVersion"
+            "expression"
+        |]
+
     /// Returns the expression tool's inputs or an empty ResizeArray if None.
     static member getInputsOrEmpty (tool: CWLExpressionToolDescription) =
         tool.Inputs |> Option.defaultValue (ResizeArray())

--- a/src/CWL/HashHelpers.fs
+++ b/src/CWL/HashHelpers.fs
@@ -1,5 +1,7 @@
 module ARCtrl.CWL.HashHelpers
 
+open DynamicObj
+
 let mergeHashes (hash1 : int) (hash2 : int) : int =
     0x9e3779b9 + hash2 + (hash1 <<< 6) + (hash1 >>> 2)
 
@@ -36,3 +38,16 @@ let boxHashSeq (a: seq<'a>) : obj =
         hash o
         |> mergeHashes acc) 0
     |> box
+
+let dynamicPropertiesSnapshot (dynObj: DynamicObj) =
+    dynObj.GetProperties(false)
+    |> Seq.map (fun kv -> kv.Key, kv.Value)
+    |> Seq.sortBy fst
+    |> Seq.toList
+
+let dynamicPropertiesEqual (left: DynamicObj) (right: DynamicObj) =
+    dynamicPropertiesSnapshot left = dynamicPropertiesSnapshot right
+
+let hashDynamicProperties (dynObj: DynamicObj) =
+    dynamicPropertiesSnapshot dynObj
+    |> Operators.hash

--- a/src/CWL/HashHelpers.fs
+++ b/src/CWL/HashHelpers.fs
@@ -1,7 +1,5 @@
 module ARCtrl.CWL.HashHelpers
 
-open DynamicObj
-
 let mergeHashes (hash1 : int) (hash2 : int) : int =
     0x9e3779b9 + hash2 + (hash1 <<< 6) + (hash1 >>> 2)
 
@@ -38,16 +36,3 @@ let boxHashSeq (a: seq<'a>) : obj =
         hash o
         |> mergeHashes acc) 0
     |> box
-
-let dynamicPropertiesSnapshot (dynObj: DynamicObj) =
-    dynObj.GetProperties(false)
-    |> Seq.map (fun kv -> kv.Key, kv.Value)
-    |> Seq.sortBy fst
-    |> Seq.toList
-
-let dynamicPropertiesEqual (left: DynamicObj) (right: DynamicObj) =
-    dynamicPropertiesSnapshot left = dynamicPropertiesSnapshot right
-
-let hashDynamicProperties (dynObj: DynamicObj) =
-    dynamicPropertiesSnapshot dynObj
-    |> Operators.hash

--- a/src/CWL/Inputs.fs
+++ b/src/CWL/Inputs.fs
@@ -2,29 +2,95 @@ namespace ARCtrl.CWL
 
 open DynamicObj
 open Fable.Core
+open YAMLicious.YAMLiciousTypes
 
-type InputBinding = {
-    Prefix: string option
-    Position: int option
-    ItemSeparator: string option
-    Separate: bool option
-    }
+[<AttachMembers>]
+type InputBinding (
+    ?prefix: string,
+    ?position: int,
+    ?itemSeparator: string,
+    ?separate: bool,
+    ?loadContents: bool,
+    ?valueFrom: string,
+    ?shellQuote: bool
+) =
+    inherit DynamicObj ()
 
-    with
+    let mutable _prefix = prefix
+    let mutable _position = position
+    let mutable _itemSeparator = itemSeparator
+    let mutable _separate = separate
+    let mutable _loadContents = loadContents
+    let mutable _valueFrom = valueFrom
+    let mutable _shellQuote = shellQuote
+
+    member this.Prefix
+        with get() = _prefix
+        and set(value) = _prefix <- value
+
+    member this.Position
+        with get() = _position
+        and set(value) = _position <- value
+
+    member this.ItemSeparator
+        with get() = _itemSeparator
+        and set(value) = _itemSeparator <- value
+
+    member this.Separate
+        with get() = _separate
+        and set(value) = _separate <- value
+
+    member this.LoadContents
+        with get() = _loadContents
+        and set(value) = _loadContents <- value
+
+    member this.ValueFrom
+        with get() = _valueFrom
+        and set(value) = _valueFrom <- value
+
+    member this.ShellQuote
+        with get() = _shellQuote
+        and set(value) = _shellQuote <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? InputBinding as other ->
+            this.Prefix = other.Prefix &&
+            this.Position = other.Position &&
+            this.ItemSeparator = other.ItemSeparator &&
+            this.Separate = other.Separate &&
+            this.LoadContents = other.LoadContents &&
+            this.ValueFrom = other.ValueFrom &&
+            this.ShellQuote = other.ShellQuote &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (
+            this.Prefix,
+            this.Position,
+            this.ItemSeparator,
+            this.Separate,
+            this.LoadContents,
+            this.ValueFrom,
+            this.ShellQuote,
+            HashHelpers.hashDynamicProperties this
+        )
+
+    static member KnownFieldNames =
+        ResizeArray [| "loadContents"; "position"; "prefix"; "separate"; "itemSeparator"; "valueFrom"; "shellQuote" |]
 
     static member create
         (
             ?prefix: string,
             ?position: int,
             ?itemSeparator: string,
-            ?separate: bool
+            ?separate: bool,
+            ?loadContents: bool,
+            ?valueFrom: string,
+            ?shellQuote: bool
         ) =
-        {
-            Prefix = prefix
-            Position = position
-            ItemSeparator = itemSeparator
-            Separate = separate
-        }
+        InputBinding(?prefix = prefix, ?position = position, ?itemSeparator = itemSeparator, ?separate = separate, ?loadContents = loadContents, ?valueFrom = valueFrom, ?shellQuote = shellQuote)
 
 
 [<AttachMembers>]
@@ -32,29 +98,113 @@ type CWLInput (
     name: string,
     ?type_: CWLType,
     ?inputBinding: InputBinding,
-    ?optional: bool
-) as this =
+    ?optional: bool,
+    ?label: string,
+    ?secondaryFiles: YAMLElement,
+    ?streamable: bool,
+    ?doc: string,
+    ?format: string,
+    ?loadContents: bool,
+    ?loadListing: LoadListingEnum,
+    ?defaultValue: YAMLElement
+) =
     inherit DynamicObj ()
-    do
-        DynObj.setOptionalProperty ("type") type_ this
-        DynObj.setOptionalProperty ("inputBinding") inputBinding this
-        DynObj.setOptionalProperty ("optional") optional this
-    member this.Name = name
+
+    let mutable _name = name
+    let mutable _type = type_
+    let mutable _inputBinding = inputBinding
+    let mutable _optional = optional
+    let mutable _label = label
+    let mutable _secondaryFiles = secondaryFiles
+    let mutable _streamable = streamable
+    let mutable _doc = doc
+    let mutable _format = format
+    let mutable _loadContents = loadContents
+    let mutable _loadListing = loadListing
+    let mutable _defaultValue = defaultValue
+
+    member this.Name
+        with get() = _name
+        and set(value) = _name <- value
+
     member this.Type_
-        with get() = DynObj.tryGetTypedPropertyValue<CWLType> ("type") this
-        and set(value: CWLType option) =
-            match value with
-            | Some v -> DynObj.setProperty "type" v this
-            | None -> DynObj.removeProperty "type" this
+        with get() = _type
+        and set(value) = _type <- value
+
     member this.InputBinding
-        with get() = DynObj.tryGetTypedPropertyValue<InputBinding> ("inputBinding") this
-        and set(value: InputBinding option) =
-            match value with
-            | Some v -> DynObj.setProperty "inputBinding" v this
-            | None -> DynObj.removeProperty "inputBinding" this
+        with get() = _inputBinding
+        and set(value) = _inputBinding <- value
+
     member this.Optional
-        with get() = DynObj.tryGetTypedPropertyValue<bool> ("optional") this
-        and set(value: bool option) =
-            match value with
-            | Some v -> DynObj.setProperty "optional" v this
-            | None -> DynObj.removeProperty "optional" this
+        with get() = _optional
+        and set(value) = _optional <- value
+
+    member this.Label
+        with get() = _label
+        and set(value) = _label <- value
+
+    member this.SecondaryFiles
+        with get() = _secondaryFiles
+        and set(value) = _secondaryFiles <- value
+
+    member this.Streamable
+        with get() = _streamable
+        and set(value) = _streamable <- value
+
+    member this.Doc
+        with get() = _doc
+        and set(value) = _doc <- value
+
+    member this.Format
+        with get() = _format
+        and set(value) = _format <- value
+
+    member this.LoadContents
+        with get() = _loadContents
+        and set(value) = _loadContents <- value
+
+    member this.LoadListing
+        with get() = _loadListing
+        and set(value) = _loadListing <- value
+
+    member this.DefaultValue
+        with get() = _defaultValue
+        and set(value) = _defaultValue <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? CWLInput as other ->
+            this.Name = other.Name &&
+            this.Type_ = other.Type_ &&
+            this.InputBinding = other.InputBinding &&
+            this.Optional = other.Optional &&
+            this.Label = other.Label &&
+            this.SecondaryFiles = other.SecondaryFiles &&
+            this.Streamable = other.Streamable &&
+            this.Doc = other.Doc &&
+            this.Format = other.Format &&
+            this.LoadContents = other.LoadContents &&
+            this.LoadListing = other.LoadListing &&
+            this.DefaultValue = other.DefaultValue &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (
+            this.Name,
+            this.Type_,
+            this.InputBinding,
+            this.Optional,
+            this.Label,
+            this.SecondaryFiles,
+            this.Streamable,
+            this.Doc,
+            this.Format,
+            this.LoadContents,
+            this.LoadListing,
+            this.DefaultValue,
+            HashHelpers.hashDynamicProperties this
+        )
+
+    static member KnownFieldNames =
+        ResizeArray [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "loadContents"; "loadListing"; "default"; "inputBinding" |]

--- a/src/CWL/Inputs.fs
+++ b/src/CWL/Inputs.fs
@@ -84,7 +84,7 @@ type InputBinding (
         )
 
     static member KnownFieldNames =
-        ResizeArray [| "loadContents"; "position"; "prefix"; "separate"; "itemSeparator"; "valueFrom"; "shellQuote" |]
+        Set [| "loadContents"; "position"; "prefix"; "separate"; "itemSeparator"; "valueFrom"; "shellQuote" |]
 
     static member create
         (
@@ -213,4 +213,4 @@ type CWLInput (
         )
 
     static member KnownFieldNames =
-        ResizeArray [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "loadContents"; "loadListing"; "default"; "inputBinding" |]
+        Set [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "loadContents"; "loadListing"; "default"; "inputBinding" |]

--- a/src/CWL/Inputs.fs
+++ b/src/CWL/Inputs.fs
@@ -28,9 +28,15 @@ type InputBinding (
         with get() = _prefix
         and set(value) = _prefix <- value
 
+    #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
+    member this.Position
+        with [<EmitProperty("_position")>] get() = _position
+        and set(value) = _position <- value
+    #else
     member this.Position
         with get() = _position
         and set(value) = _position <- value
+    #endif
 
     member this.ItemSeparator
         with get() = _itemSeparator
@@ -62,7 +68,7 @@ type InputBinding (
             this.LoadContents = other.LoadContents &&
             this.ValueFrom = other.ValueFrom &&
             this.ShellQuote = other.ShellQuote &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
@@ -74,7 +80,7 @@ type InputBinding (
             this.LoadContents,
             this.ValueFrom,
             this.ShellQuote,
-            HashHelpers.hashDynamicProperties this
+            DynamicObjHelpers.hashDynamicProperties this
         )
 
     static member KnownFieldNames =
@@ -186,7 +192,7 @@ type CWLInput (
             this.LoadContents = other.LoadContents &&
             this.LoadListing = other.LoadListing &&
             this.DefaultValue = other.DefaultValue &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
@@ -203,7 +209,7 @@ type CWLInput (
             this.LoadContents,
             this.LoadListing,
             this.DefaultValue,
-            HashHelpers.hashDynamicProperties this
+            DynamicObjHelpers.hashDynamicProperties this
         )
 
     static member KnownFieldNames =

--- a/src/CWL/OperationDescription.fs
+++ b/src/CWL/OperationDescription.fs
@@ -69,6 +69,20 @@ type CWLOperationDescription(
         with get() = _doc
         and set(value) = _doc <- value
 
+    static member KnownFieldNames =
+        ResizeArray [|
+            "inputs"
+            "outputs"
+            "label"
+            "doc"
+            "intent"
+            "class"
+            "id"
+            "requirements"
+            "hints"
+            "cwlVersion"
+        |]
+
     static member getInputs (operation: CWLOperationDescription) =
         operation.Inputs
 

--- a/src/CWL/OperationDescription.fs
+++ b/src/CWL/OperationDescription.fs
@@ -70,7 +70,7 @@ type CWLOperationDescription(
         and set(value) = _doc <- value
 
     static member KnownFieldNames =
-        ResizeArray [|
+        Set [|
             "inputs"
             "outputs"
             "label"

--- a/src/CWL/Outputs.fs
+++ b/src/CWL/Outputs.fs
@@ -2,12 +2,51 @@ namespace ARCtrl.CWL
 
 open DynamicObj
 open Fable.Core
+open YAMLicious.YAMLiciousTypes
 
-type OutputBinding = {
-    Glob: string option
-    }
+[<AttachMembers>]
+type OutputBinding (?glob: string, ?loadContents: bool, ?loadListing: LoadListingEnum, ?outputEval: string) =
+    inherit DynamicObj ()
 
-    with static member create(?glob) = {Glob = glob}
+    let mutable _glob = glob
+    let mutable _loadContents = loadContents
+    let mutable _loadListing = loadListing
+    let mutable _outputEval = outputEval
+
+    member this.Glob
+        with get() = _glob
+        and set(value) = _glob <- value
+
+    member this.LoadContents
+        with get() = _loadContents
+        and set(value) = _loadContents <- value
+
+    member this.LoadListing
+        with get() = _loadListing
+        and set(value) = _loadListing <- value
+
+    member this.OutputEval
+        with get() = _outputEval
+        and set(value) = _outputEval <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? OutputBinding as other ->
+            this.Glob = other.Glob &&
+            this.LoadContents = other.LoadContents &&
+            this.LoadListing = other.LoadListing &&
+            this.OutputEval = other.OutputEval &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.Glob, this.LoadContents, this.LoadListing, this.OutputEval, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "loadContents"; "loadListing"; "glob"; "outputEval" |]
+
+    static member create(?glob: string, ?loadContents: bool, ?loadListing: LoadListingEnum, ?outputEval: string) =
+        OutputBinding(?glob = glob, ?loadContents = loadContents, ?loadListing = loadListing, ?outputEval = outputEval)
 
 [<AttachMembers>]
 type OutputSource =
@@ -24,36 +63,100 @@ type CWLOutput (
     name: string,
     ?type_: CWLType,
     ?outputBinding: OutputBinding,
-    ?outputSource: OutputSource
-) as this =
+    ?outputSource: OutputSource,
+    ?label: string,
+    ?secondaryFiles: YAMLElement,
+    ?streamable: bool,
+    ?doc: string,
+    ?format: string
+) =
     inherit DynamicObj ()
-    do
-        DynObj.setOptionalProperty ("type") type_ this
-        DynObj.setOptionalProperty ("outputBinding") outputBinding this
-        DynObj.setOptionalProperty ("outputSource") outputSource this
-    member this.Name = name
+
+    let normalizeOutputSource = function
+        | Some (Multiple values) when values.Count = 0 -> None
+        | value -> value
+
+    let mutable _name = name
+    let mutable _type = type_
+    let mutable _outputBinding = outputBinding
+    let mutable _outputSource = normalizeOutputSource outputSource
+    let mutable _label = label
+    let mutable _secondaryFiles = secondaryFiles
+    let mutable _streamable = streamable
+    let mutable _doc = doc
+    let mutable _format = format
+
+    member this.Name
+        with get() = _name
+        and set(value) = _name <- value
+
     member this.Type_
-        with get() = DynObj.tryGetTypedPropertyValue<CWLType> ("type") this
-        and set(value: CWLType option) =
-            match value with
-            | Some v -> DynObj.setProperty "type" v this
-            | None -> DynObj.removeProperty "type" this
+        with get() = _type
+        and set(value) = _type <- value
+
     member this.OutputBinding
-        with get() = DynObj.tryGetTypedPropertyValue<OutputBinding> ("outputBinding") this
-        and set(value: OutputBinding option) =
-            match value with
-            | Some v -> DynObj.setProperty "outputBinding" v this
-            | None -> DynObj.removeProperty "outputBinding" this
+        with get() = _outputBinding
+        and set(value) = _outputBinding <- value
+
     member this.OutputSource
-        with get() = DynObj.tryGetTypedPropertyValue<OutputSource> ("outputSource") this
-        and set(value: OutputSource option) =
-            match value with
-            | Some (Multiple values) when values.Count = 0 -> DynObj.removeProperty "outputSource" this
-            | Some v -> DynObj.setProperty "outputSource" v this
-            | None -> DynObj.removeProperty "outputSource" this
+        with get() = _outputSource
+        and set(value) =
+            _outputSource <- normalizeOutputSource value
+
+    member this.Label
+        with get() = _label
+        and set(value) = _label <- value
+
+    member this.SecondaryFiles
+        with get() = _secondaryFiles
+        and set(value) = _secondaryFiles <- value
+
+    member this.Streamable
+        with get() = _streamable
+        and set(value) = _streamable <- value
+
+    member this.Doc
+        with get() = _doc
+        and set(value) = _doc <- value
+
+    member this.Format
+        with get() = _format
+        and set(value) = _format <- value
 
     member this.GetOutputSources() =
         match this.OutputSource with
         | Some outputSource -> outputSource.AsValues()
         | _ ->
             ResizeArray()
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? CWLOutput as other ->
+            this.Name = other.Name &&
+            this.Type_ = other.Type_ &&
+            this.OutputBinding = other.OutputBinding &&
+            this.OutputSource = other.OutputSource &&
+            this.Label = other.Label &&
+            this.SecondaryFiles = other.SecondaryFiles &&
+            this.Streamable = other.Streamable &&
+            this.Doc = other.Doc &&
+            this.Format = other.Format &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (
+            this.Name,
+            this.Type_,
+            this.OutputBinding,
+            this.OutputSource,
+            this.Label,
+            this.SecondaryFiles,
+            this.Streamable,
+            this.Doc,
+            this.Format,
+            HashHelpers.hashDynamicProperties this
+        )
+
+    static member KnownFieldNames =
+        ResizeArray [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "outputBinding"; "outputSource" |]

--- a/src/CWL/Outputs.fs
+++ b/src/CWL/Outputs.fs
@@ -36,11 +36,11 @@ type OutputBinding (?glob: string, ?loadContents: bool, ?loadListing: LoadListin
             this.LoadContents = other.LoadContents &&
             this.LoadListing = other.LoadListing &&
             this.OutputEval = other.OutputEval &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.Glob, this.LoadContents, this.LoadListing, this.OutputEval, HashHelpers.hashDynamicProperties this)
+        hash (this.Glob, this.LoadContents, this.LoadListing, this.OutputEval, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "loadContents"; "loadListing"; "glob"; "outputEval" |]
@@ -141,7 +141,7 @@ type CWLOutput (
             this.Streamable = other.Streamable &&
             this.Doc = other.Doc &&
             this.Format = other.Format &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
@@ -155,7 +155,7 @@ type CWLOutput (
             this.Streamable,
             this.Doc,
             this.Format,
-            HashHelpers.hashDynamicProperties this
+            DynamicObjHelpers.hashDynamicProperties this
         )
 
     static member KnownFieldNames =

--- a/src/CWL/Outputs.fs
+++ b/src/CWL/Outputs.fs
@@ -43,7 +43,7 @@ type OutputBinding (?glob: string, ?loadContents: bool, ?loadListing: LoadListin
         hash (this.Glob, this.LoadContents, this.LoadListing, this.OutputEval, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "loadContents"; "loadListing"; "glob"; "outputEval" |]
+        Set [| "loadContents"; "loadListing"; "glob"; "outputEval" |]
 
     static member create(?glob: string, ?loadContents: bool, ?loadListing: LoadListingEnum, ?outputEval: string) =
         OutputBinding(?glob = glob, ?loadContents = loadContents, ?loadListing = loadListing, ?outputEval = outputEval)
@@ -159,4 +159,4 @@ type CWLOutput (
         )
 
     static member KnownFieldNames =
-        ResizeArray [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "outputBinding"; "outputSource" |]
+        Set [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "outputBinding"; "outputSource" |]

--- a/src/CWL/ParameterReference.fs
+++ b/src/CWL/ParameterReference.fs
@@ -1,10 +1,13 @@
 namespace ARCtrl.CWL
 
+open DynamicObj
 open Fable.Core
 open System
 
 [<AttachMembers>]
 type CWLParameterReference(key : string, ?values: string ResizeArray, ?type_: CWLType) =
+    inherit DynamicObj ()
+
     let mutable _key = key
     let mutable _values = defaultArg values (ResizeArray<string>())
     let mutable _type = type_
@@ -26,15 +29,25 @@ type CWLParameterReference(key : string, ?values: string ResizeArray, ?type_: CW
             HashHelpers.boxHashSeq this.Values
             HashHelpers.hash this.Key
             HashHelpers.boxHashOption this.Type
+            HashHelpers.hashDynamicProperties this
         |]
         |> HashHelpers.boxHashArray
         |> fun x -> x :?> int
 
     override this.Equals (obj: obj) : bool = 
-        this.StructurallyEquals (obj :?> CWLParameterReference)
+        match obj with
+        | :? CWLParameterReference as other -> this.StructurallyEquals other
+        | _ -> false
 
     member this.StructurallyEquals (other: CWLParameterReference) : bool =
-        this.GetHashCode() = other.GetHashCode()
+        this.Key = other.Key &&
+        this.Values.Count = other.Values.Count &&
+        Seq.forall2 (=) this.Values other.Values &&
+        this.Type = other.Type &&
+        HashHelpers.dynamicPropertiesEqual this other
 
     member this.ReferenceEquals (other: CWLParameterReference) : bool =
         System.Object.ReferenceEquals(this,other)
+
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "path"; "location"; "type"; "value" |]

--- a/src/CWL/ParameterReference.fs
+++ b/src/CWL/ParameterReference.fs
@@ -50,4 +50,4 @@ type CWLParameterReference(key : string, ?values: string ResizeArray, ?type_: CW
         System.Object.ReferenceEquals(this,other)
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "path"; "location"; "type"; "value" |]
+        Set [| "class"; "path"; "location"; "type"; "value" |]

--- a/src/CWL/ParameterReference.fs
+++ b/src/CWL/ParameterReference.fs
@@ -29,7 +29,7 @@ type CWLParameterReference(key : string, ?values: string ResizeArray, ?type_: CW
             HashHelpers.boxHashSeq this.Values
             HashHelpers.hash this.Key
             HashHelpers.boxHashOption this.Type
-            HashHelpers.hashDynamicProperties this
+            DynamicObjHelpers.hashDynamicProperties this
         |]
         |> HashHelpers.boxHashArray
         |> fun x -> x :?> int
@@ -44,7 +44,7 @@ type CWLParameterReference(key : string, ?values: string ResizeArray, ?type_: CW
         this.Values.Count = other.Values.Count &&
         Seq.forall2 (=) this.Values other.Values &&
         this.Type = other.Type &&
-        HashHelpers.dynamicPropertiesEqual this other
+        DynamicObjHelpers.dynamicPropertiesEqual this other
 
     member this.ReferenceEquals (other: CWLParameterReference) : bool =
         System.Object.ReferenceEquals(this,other)

--- a/src/CWL/Requirements.fs
+++ b/src/CWL/Requirements.fs
@@ -3,16 +3,78 @@ namespace ARCtrl.CWL
 open DynamicObj
 open YAMLicious.YAMLiciousTypes
 
-type DockerRequirement = {
-        DockerPull: string option
-        DockerFile: SchemaSaladString option
-        DockerImageId: string option
-        DockerLoad: string option
-        DockerImport: string option
-        DockerOutputDirectory: string option
-        DockerRunOptions: ResizeArray<string> option
-    }
-    with 
+type DockerRequirement (
+    ?dockerPull: string,
+    ?dockerFile: SchemaSaladString,
+    ?dockerImageId: string,
+    ?dockerLoad: string,
+    ?dockerImport: string,
+    ?dockerOutputDirectory: string,
+    ?dockerRunOptions: ResizeArray<string>
+) =
+    inherit DynamicObj ()
+
+    let mutable _dockerPull = dockerPull
+    let mutable _dockerFile = dockerFile
+    let mutable _dockerImageId = dockerImageId
+    let mutable _dockerLoad = dockerLoad
+    let mutable _dockerImport = dockerImport
+    let mutable _dockerOutputDirectory = dockerOutputDirectory
+    let mutable _dockerRunOptions = dockerRunOptions
+
+    member this.DockerPull
+        with get() = _dockerPull
+        and set(value) = _dockerPull <- value
+
+    member this.DockerFile
+        with get() = _dockerFile
+        and set(value) = _dockerFile <- value
+
+    member this.DockerImageId
+        with get() = _dockerImageId
+        and set(value) = _dockerImageId <- value
+
+    member this.DockerLoad
+        with get() = _dockerLoad
+        and set(value) = _dockerLoad <- value
+
+    member this.DockerImport
+        with get() = _dockerImport
+        and set(value) = _dockerImport <- value
+
+    member this.DockerOutputDirectory
+        with get() = _dockerOutputDirectory
+        and set(value) = _dockerOutputDirectory <- value
+
+    member this.DockerRunOptions
+        with get() = _dockerRunOptions
+        and set(value) = _dockerRunOptions <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? DockerRequirement as other ->
+            this.DockerPull = other.DockerPull &&
+            this.DockerFile = other.DockerFile &&
+            this.DockerImageId = other.DockerImageId &&
+            this.DockerLoad = other.DockerLoad &&
+            this.DockerImport = other.DockerImport &&
+            this.DockerOutputDirectory = other.DockerOutputDirectory &&
+            this.DockerRunOptions = other.DockerRunOptions &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (
+            this.DockerPull,
+            this.DockerFile,
+            this.DockerImageId,
+            this.DockerLoad,
+            this.DockerImport,
+            this.DockerOutputDirectory,
+            this.DockerRunOptions,
+            HashHelpers.hashDynamicProperties this
+        )
+
     /// Create a DockerRequirement from a plain docker file path or explicit schema-salad reference.
     /// If both `dockerFileReference` and `dockerFile` are provided, `dockerFileReference` takes precedence.
     static member create(?dockerPull, ?dockerFile: string, ?dockerFileReference: SchemaSaladString, ?dockerImageId, ?dockerLoad, ?dockerImport, ?dockerOutputDirectory, ?dockerRunOptions: ResizeArray<string>) =
@@ -22,21 +84,47 @@ type DockerRequirement = {
             | None, Some file -> Some (SchemaSaladString.Literal file)
             | None, None -> None
 
-        {
-            DockerPull = dockerPull
-            DockerFile = resolvedDockerFile
-            DockerImageId = dockerImageId
-            DockerLoad = dockerLoad
-            DockerImport = dockerImport
-            DockerOutputDirectory = dockerOutputDirectory
-            DockerRunOptions = dockerRunOptions
-        }
+        DockerRequirement(
+            ?dockerPull = dockerPull,
+            ?dockerFile = resolvedDockerFile,
+            ?dockerImageId = dockerImageId,
+            ?dockerLoad = dockerLoad,
+            ?dockerImport = dockerImport,
+            ?dockerOutputDirectory = dockerOutputDirectory,
+            ?dockerRunOptions = dockerRunOptions
+        )
+
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "dockerPull"; "dockerFile"; "dockerImageId"; "dockerLoad"; "dockerImport"; "dockerOutputDirectory"; "cwltool:dockerRunOptions" |]
 
 /// Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.
-type EnvironmentDef = {
-    EnvName: string
-    EnvValue: string
-}
+type EnvironmentDef (envName: string, envValue: string) =
+    inherit DynamicObj ()
+
+    let mutable _envName = envName
+    let mutable _envValue = envValue
+
+    member this.EnvName
+        with get() = _envName
+        and set(value) = _envName <- value
+
+    member this.EnvValue
+        with get() = _envValue
+        and set(value) = _envValue <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? EnvironmentDef as other ->
+            this.EnvName = other.EnvName &&
+            this.EnvValue = other.EnvValue &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.EnvName, this.EnvValue, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "envName"; "envValue" |]
 
 type LoadListingEnum =
     | NoListing
@@ -55,37 +143,105 @@ type LoadListingEnum =
         | "deep_listing" -> Some DeepListing
         | _ -> None
 
-type LoadListingRequirementValue = {
-    LoadListing: LoadListingEnum
-}
+type LoadListingRequirementValue (loadListing: LoadListingEnum) =
+    inherit DynamicObj ()
 
-    with
+    let mutable _loadListing = loadListing
+
+    member this.LoadListing
+        with get() = _loadListing
+        and set(value) = _loadListing <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? LoadListingRequirementValue as other ->
+            this.LoadListing = other.LoadListing &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.LoadListing, HashHelpers.hashDynamicProperties this)
+
     static member defaultNoListing =
-        { LoadListing = NoListing }
+        LoadListingRequirementValue(NoListing)
 
-type WorkReuseRequirementValue = {
-    EnableReuse: bool
-}
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "loadListing" |]
 
-    with
+type WorkReuseRequirementValue (enableReuse: bool) =
+    inherit DynamicObj ()
+
+    let mutable _enableReuse = enableReuse
+
+    member this.EnableReuse
+        with get() = _enableReuse
+        and set(value) = _enableReuse <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? WorkReuseRequirementValue as other ->
+            this.EnableReuse = other.EnableReuse &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.EnableReuse, HashHelpers.hashDynamicProperties this)
+
     static member defaultEnabled =
-        { EnableReuse = true }
+        WorkReuseRequirementValue(true)
 
-type NetworkAccessRequirementValue = {
-    NetworkAccess: bool
-}
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "enableReuse" |]
 
-    with
+type NetworkAccessRequirementValue (networkAccess: bool) =
+    inherit DynamicObj ()
+
+    let mutable _networkAccess = networkAccess
+
+    member this.NetworkAccess
+        with get() = _networkAccess
+        and set(value) = _networkAccess <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? NetworkAccessRequirementValue as other ->
+            this.NetworkAccess = other.NetworkAccess &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.NetworkAccess, HashHelpers.hashDynamicProperties this)
+
     static member defaultEnabled =
-        { NetworkAccess = true }
+        NetworkAccessRequirementValue(true)
 
-type InplaceUpdateRequirementValue = {
-    InplaceUpdate: bool
-}
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "networkAccess" |]
 
-    with
+type InplaceUpdateRequirementValue (inplaceUpdate: bool) =
+    inherit DynamicObj ()
+
+    let mutable _inplaceUpdate = inplaceUpdate
+
+    member this.InplaceUpdate
+        with get() = _inplaceUpdate
+        and set(value) = _inplaceUpdate <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? InplaceUpdateRequirementValue as other ->
+            this.InplaceUpdate = other.InplaceUpdate &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.InplaceUpdate, HashHelpers.hashDynamicProperties this)
+
     static member defaultEnabled =
-        { InplaceUpdate = true }
+        InplaceUpdateRequirementValue(true)
+
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "inplaceUpdate" |]
 
 type ToolTimeLimitValue =
     | ToolTimeLimitSeconds of int64
@@ -99,57 +255,113 @@ type ToolTimeLimitValue =
 /// It is an error if the value of any of these fields is negative.
 /// If neither "min" nor "max" is specified for a resource, default values are used.
 type ResourceRequirementInstance (
-    ?coresMin,
-    ?coresMax,
-    ?ramMin,
-    ?ramMax,
-    ?tmpdirMin,
-    ?tmpdirMax,
-    ?outdirMin,
-    ?outdirMax
-) as this =
+    ?coresMin: obj,
+    ?coresMax: obj,
+    ?ramMin: obj,
+    ?ramMax: obj,
+    ?tmpdirMin: obj,
+    ?tmpdirMax: obj,
+    ?outdirMin: obj,
+    ?outdirMax: obj
+) =
     inherit DynamicObj ()
-    do
-        DynObj.setOptionalProperty (nameof coresMin) coresMin this
-        DynObj.setOptionalProperty (nameof coresMax) coresMax this
-        DynObj.setOptionalProperty (nameof ramMin) ramMin this
-        DynObj.setOptionalProperty (nameof ramMax) ramMax this
-        DynObj.setOptionalProperty (nameof tmpdirMin) tmpdirMin this
-        DynObj.setOptionalProperty (nameof tmpdirMax) tmpdirMax this
-        DynObj.setOptionalProperty (nameof outdirMin) outdirMin this
-        DynObj.setOptionalProperty (nameof outdirMax) outdirMax this
+
+    let mutable _coresMin = coresMin
+    let mutable _coresMax = coresMax
+    let mutable _ramMin = ramMin
+    let mutable _ramMax = ramMax
+    let mutable _tmpdirMin = tmpdirMin
+    let mutable _tmpdirMax = tmpdirMax
+    let mutable _outdirMin = outdirMin
+    let mutable _outdirMax = outdirMax
+
+    member this.CoresMin
+        with get() = _coresMin
+        and set(value) = _coresMin <- value
+
+    member this.CoresMax
+        with get() = _coresMax
+        and set(value) = _coresMax <- value
+
+    member this.RamMin
+        with get() = _ramMin
+        and set(value) = _ramMin <- value
+
+    member this.RamMax
+        with get() = _ramMax
+        and set(value) = _ramMax <- value
+
+    member this.TmpdirMin
+        with get() = _tmpdirMin
+        and set(value) = _tmpdirMin <- value
+
+    member this.TmpdirMax
+        with get() = _tmpdirMax
+        and set(value) = _tmpdirMax <- value
+
+    member this.OutdirMin
+        with get() = _outdirMin
+        and set(value) = _outdirMin <- value
+
+    member this.OutdirMax
+        with get() = _outdirMax
+        and set(value) = _outdirMax <- value
+
+    member this.TryGetKnownField(name: string) =
+        match name with
+        | "coresMin" -> this.CoresMin
+        | "coresMax" -> this.CoresMax
+        | "ramMin" -> this.RamMin
+        | "ramMax" -> this.RamMax
+        | "tmpdirMin" -> this.TmpdirMin
+        | "tmpdirMax" -> this.TmpdirMax
+        | "outdirMin" -> this.OutdirMin
+        | "outdirMax" -> this.OutdirMax
+        | _ -> None
 
     member this.TryGetInt64(name: string) =
-        this.TryGetPropertyValue(name)
-        |> Option.bind (function
-            | :? Option<obj> as optionValue -> optionValue
-            | :? int64 as value -> Some (box value)
-            | :? int as value -> Some (box (int64 value))
-            | _ -> None)
+        this.TryGetKnownField(name)
         |> Option.bind (function
             | :? int64 as value -> Some value
             | :? int as value -> Some (int64 value)
             | _ -> None)
 
     member this.TryGetFloat(name: string) =
-        this.TryGetPropertyValue(name)
-        |> Option.bind (function
-            | :? Option<obj> as optionValue -> optionValue
-            | :? float as value -> Some (box value)
-            | _ -> None)
+        this.TryGetKnownField(name)
         |> Option.bind (function
             | :? float as value -> Some value
             | _ -> None)
 
     member this.TryGetExpression(name: string) =
-        this.TryGetPropertyValue(name)
-        |> Option.bind (function
-            | :? Option<obj> as optionValue -> optionValue
-            | :? string as value -> Some (box value)
-            | _ -> None)
+        this.TryGetKnownField(name)
         |> Option.bind (function
             | :? string as value -> Some value
             | _ -> None)
+
+    member this.KnownFieldValues =
+        [
+            "coresMin", this.CoresMin
+            "coresMax", this.CoresMax
+            "ramMin", this.RamMin
+            "ramMax", this.RamMax
+            "tmpdirMin", this.TmpdirMin
+            "tmpdirMax", this.TmpdirMax
+            "outdirMin", this.OutdirMin
+            "outdirMax", this.OutdirMax
+        ]
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? ResourceRequirementInstance as other ->
+            this.KnownFieldValues = other.KnownFieldValues &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.KnownFieldValues, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "coresMin"; "coresMax"; "ramMin"; "ramMax"; "tmpdirMin"; "tmpdirMax"; "outdirMin"; "outdirMax" |]
 
 /// Entry in InitialWorkDirRequirement listing.
 /// CWL allows either a Dirent object or a string/expression entry.
@@ -159,18 +371,58 @@ type InitialWorkDirEntry =
     | FileEntry of FileInstance
     | DirectoryEntry of DirectoryInstance
 
-type InlineJavascriptRequirementValue = {
-    ExpressionLib: ResizeArray<string> option
-}
+type InlineJavascriptRequirementValue (?expressionLib: ResizeArray<string>) =
+    inherit DynamicObj ()
 
-    with
+    let mutable _expressionLib = expressionLib
+
+    member this.ExpressionLib
+        with get() = _expressionLib
+        and set(value) = _expressionLib <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? InlineJavascriptRequirementValue as other ->
+            this.ExpressionLib = other.ExpressionLib &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.ExpressionLib, HashHelpers.hashDynamicProperties this)
+
     static member defaultEmpty =
-        { ExpressionLib = None }
+        InlineJavascriptRequirementValue()
 
-type HintUnknownValue = {
-    Class: string option
-    Raw: YAMLElement
-}
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "expressionLib" |]
+
+type HintUnknownValue (class_: string option, raw: YAMLElement) =
+    inherit DynamicObj ()
+
+    let mutable _class = class_
+    let mutable _raw = raw
+
+    member this.Class
+        with get() = _class
+        and set(value) = _class <- value
+
+    member this.Raw
+        with get() = _raw
+        and set(value) = _raw <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? HintUnknownValue as other ->
+            this.Class = other.Class &&
+            this.Raw = other.Raw &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.Class, this.Raw, HashHelpers.hashDynamicProperties this)
+
+    static member KnownFieldNames =
+        ResizeArray [| "class"; "raw" |]
 
 type Requirement =
     /// Indicates that the workflow platform must support inline Javascript expressions.

--- a/src/CWL/Requirements.fs
+++ b/src/CWL/Requirements.fs
@@ -1,8 +1,10 @@
 namespace ARCtrl.CWL
 
 open DynamicObj
+open Fable.Core
 open YAMLicious.YAMLiciousTypes
 
+[<AttachMembers>]
 type DockerRequirement (
     ?dockerPull: string,
     ?dockerFile: SchemaSaladString,
@@ -60,7 +62,7 @@ type DockerRequirement (
             this.DockerImport = other.DockerImport &&
             this.DockerOutputDirectory = other.DockerOutputDirectory &&
             this.DockerRunOptions = other.DockerRunOptions &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
@@ -72,7 +74,7 @@ type DockerRequirement (
             this.DockerImport,
             this.DockerOutputDirectory,
             this.DockerRunOptions,
-            HashHelpers.hashDynamicProperties this
+            DynamicObjHelpers.hashDynamicProperties this
         )
 
     /// Create a DockerRequirement from a plain docker file path or explicit schema-salad reference.
@@ -98,6 +100,7 @@ type DockerRequirement (
         ResizeArray [| "class"; "dockerPull"; "dockerFile"; "dockerImageId"; "dockerLoad"; "dockerImport"; "dockerOutputDirectory"; "cwltool:dockerRunOptions" |]
 
 /// Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.
+[<AttachMembers>]
 type EnvironmentDef (envName: string, envValue: string) =
     inherit DynamicObj ()
 
@@ -117,11 +120,11 @@ type EnvironmentDef (envName: string, envValue: string) =
         | :? EnvironmentDef as other ->
             this.EnvName = other.EnvName &&
             this.EnvValue = other.EnvValue &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.EnvName, this.EnvValue, HashHelpers.hashDynamicProperties this)
+        hash (this.EnvName, this.EnvValue, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "envName"; "envValue" |]
@@ -143,6 +146,7 @@ type LoadListingEnum =
         | "deep_listing" -> Some DeepListing
         | _ -> None
 
+[<AttachMembers>]
 type LoadListingRequirementValue (loadListing: LoadListingEnum) =
     inherit DynamicObj ()
 
@@ -156,11 +160,11 @@ type LoadListingRequirementValue (loadListing: LoadListingEnum) =
         match o with
         | :? LoadListingRequirementValue as other ->
             this.LoadListing = other.LoadListing &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.LoadListing, HashHelpers.hashDynamicProperties this)
+        hash (this.LoadListing, DynamicObjHelpers.hashDynamicProperties this)
 
     static member defaultNoListing =
         LoadListingRequirementValue(NoListing)
@@ -168,6 +172,7 @@ type LoadListingRequirementValue (loadListing: LoadListingEnum) =
     static member KnownFieldNames =
         ResizeArray [| "class"; "loadListing" |]
 
+[<AttachMembers>]
 type WorkReuseRequirementValue (enableReuse: bool) =
     inherit DynamicObj ()
 
@@ -181,11 +186,11 @@ type WorkReuseRequirementValue (enableReuse: bool) =
         match o with
         | :? WorkReuseRequirementValue as other ->
             this.EnableReuse = other.EnableReuse &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.EnableReuse, HashHelpers.hashDynamicProperties this)
+        hash (this.EnableReuse, DynamicObjHelpers.hashDynamicProperties this)
 
     static member defaultEnabled =
         WorkReuseRequirementValue(true)
@@ -193,6 +198,7 @@ type WorkReuseRequirementValue (enableReuse: bool) =
     static member KnownFieldNames =
         ResizeArray [| "class"; "enableReuse" |]
 
+[<AttachMembers>]
 type NetworkAccessRequirementValue (networkAccess: bool) =
     inherit DynamicObj ()
 
@@ -206,11 +212,11 @@ type NetworkAccessRequirementValue (networkAccess: bool) =
         match o with
         | :? NetworkAccessRequirementValue as other ->
             this.NetworkAccess = other.NetworkAccess &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.NetworkAccess, HashHelpers.hashDynamicProperties this)
+        hash (this.NetworkAccess, DynamicObjHelpers.hashDynamicProperties this)
 
     static member defaultEnabled =
         NetworkAccessRequirementValue(true)
@@ -218,6 +224,7 @@ type NetworkAccessRequirementValue (networkAccess: bool) =
     static member KnownFieldNames =
         ResizeArray [| "class"; "networkAccess" |]
 
+[<AttachMembers>]
 type InplaceUpdateRequirementValue (inplaceUpdate: bool) =
     inherit DynamicObj ()
 
@@ -231,11 +238,11 @@ type InplaceUpdateRequirementValue (inplaceUpdate: bool) =
         match o with
         | :? InplaceUpdateRequirementValue as other ->
             this.InplaceUpdate = other.InplaceUpdate &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.InplaceUpdate, HashHelpers.hashDynamicProperties this)
+        hash (this.InplaceUpdate, DynamicObjHelpers.hashDynamicProperties this)
 
     static member defaultEnabled =
         InplaceUpdateRequirementValue(true)
@@ -254,6 +261,7 @@ type ToolTimeLimitValue =
 /// It is an error if max < min.
 /// It is an error if the value of any of these fields is negative.
 /// If neither "min" nor "max" is specified for a resource, default values are used.
+[<AttachMembers>]
 type ResourceRequirementInstance (
     ?coresMin: obj,
     ?coresMax: obj,
@@ -354,11 +362,11 @@ type ResourceRequirementInstance (
         match o with
         | :? ResourceRequirementInstance as other ->
             this.KnownFieldValues = other.KnownFieldValues &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.KnownFieldValues, HashHelpers.hashDynamicProperties this)
+        hash (this.KnownFieldValues, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "class"; "coresMin"; "coresMax"; "ramMin"; "ramMax"; "tmpdirMin"; "tmpdirMax"; "outdirMin"; "outdirMax" |]
@@ -371,6 +379,7 @@ type InitialWorkDirEntry =
     | FileEntry of FileInstance
     | DirectoryEntry of DirectoryInstance
 
+[<AttachMembers>]
 type InlineJavascriptRequirementValue (?expressionLib: ResizeArray<string>) =
     inherit DynamicObj ()
 
@@ -384,11 +393,11 @@ type InlineJavascriptRequirementValue (?expressionLib: ResizeArray<string>) =
         match o with
         | :? InlineJavascriptRequirementValue as other ->
             this.ExpressionLib = other.ExpressionLib &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.ExpressionLib, HashHelpers.hashDynamicProperties this)
+        hash (this.ExpressionLib, DynamicObjHelpers.hashDynamicProperties this)
 
     static member defaultEmpty =
         InlineJavascriptRequirementValue()
@@ -396,6 +405,7 @@ type InlineJavascriptRequirementValue (?expressionLib: ResizeArray<string>) =
     static member KnownFieldNames =
         ResizeArray [| "class"; "expressionLib" |]
 
+[<AttachMembers>]
 type HintUnknownValue (class_: string option, raw: YAMLElement) =
     inherit DynamicObj ()
 
@@ -415,11 +425,11 @@ type HintUnknownValue (class_: string option, raw: YAMLElement) =
         | :? HintUnknownValue as other ->
             this.Class = other.Class &&
             this.Raw = other.Raw &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.Class, this.Raw, HashHelpers.hashDynamicProperties this)
+        hash (this.Class, this.Raw, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
         ResizeArray [| "class"; "raw" |]

--- a/src/CWL/Requirements.fs
+++ b/src/CWL/Requirements.fs
@@ -97,7 +97,7 @@ type DockerRequirement (
         )
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "dockerPull"; "dockerFile"; "dockerImageId"; "dockerLoad"; "dockerImport"; "dockerOutputDirectory"; "cwltool:dockerRunOptions" |]
+        Set [| "class"; "dockerPull"; "dockerFile"; "dockerImageId"; "dockerLoad"; "dockerImport"; "dockerOutputDirectory"; "cwltool:dockerRunOptions" |]
 
 /// Define an environment variable that will be set in the runtime environment by the workflow platform when executing the command line tool.
 [<AttachMembers>]
@@ -127,7 +127,7 @@ type EnvironmentDef (envName: string, envValue: string) =
         hash (this.EnvName, this.EnvValue, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "envName"; "envValue" |]
+        Set [| "envName"; "envValue" |]
 
 type LoadListingEnum =
     | NoListing
@@ -170,7 +170,7 @@ type LoadListingRequirementValue (loadListing: LoadListingEnum) =
         LoadListingRequirementValue(NoListing)
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "loadListing" |]
+        Set [| "class"; "loadListing" |]
 
 [<AttachMembers>]
 type WorkReuseRequirementValue (enableReuse: bool) =
@@ -196,7 +196,7 @@ type WorkReuseRequirementValue (enableReuse: bool) =
         WorkReuseRequirementValue(true)
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "enableReuse" |]
+        Set [| "class"; "enableReuse" |]
 
 [<AttachMembers>]
 type NetworkAccessRequirementValue (networkAccess: bool) =
@@ -222,7 +222,7 @@ type NetworkAccessRequirementValue (networkAccess: bool) =
         NetworkAccessRequirementValue(true)
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "networkAccess" |]
+        Set [| "class"; "networkAccess" |]
 
 [<AttachMembers>]
 type InplaceUpdateRequirementValue (inplaceUpdate: bool) =
@@ -248,7 +248,7 @@ type InplaceUpdateRequirementValue (inplaceUpdate: bool) =
         InplaceUpdateRequirementValue(true)
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "inplaceUpdate" |]
+        Set [| "class"; "inplaceUpdate" |]
 
 type ToolTimeLimitValue =
     | ToolTimeLimitSeconds of int64
@@ -369,7 +369,7 @@ type ResourceRequirementInstance (
         hash (this.KnownFieldValues, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "coresMin"; "coresMax"; "ramMin"; "ramMax"; "tmpdirMin"; "tmpdirMax"; "outdirMin"; "outdirMax" |]
+        Set [| "class"; "coresMin"; "coresMax"; "ramMin"; "ramMax"; "tmpdirMin"; "tmpdirMax"; "outdirMin"; "outdirMax" |]
 
 /// Entry in InitialWorkDirRequirement listing.
 /// CWL allows either a Dirent object or a string/expression entry.
@@ -403,7 +403,7 @@ type InlineJavascriptRequirementValue (?expressionLib: ResizeArray<string>) =
         InlineJavascriptRequirementValue()
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "expressionLib" |]
+        Set [| "class"; "expressionLib" |]
 
 [<AttachMembers>]
 type HintUnknownValue (class_: string option, raw: YAMLElement) =
@@ -432,7 +432,7 @@ type HintUnknownValue (class_: string option, raw: YAMLElement) =
         hash (this.Class, this.Raw, DynamicObjHelpers.hashDynamicProperties this)
 
     static member KnownFieldNames =
-        ResizeArray [| "class"; "raw" |]
+        Set [| "class"; "raw" |]
 
 type Requirement =
     /// Indicates that the workflow platform must support inline Javascript expressions.

--- a/src/CWL/ToolDescription.fs
+++ b/src/CWL/ToolDescription.fs
@@ -2,12 +2,20 @@ namespace ARCtrl.CWL
 
 open DynamicObj
 open Fable.Core
+open YAMLicious.YAMLiciousTypes
 
 [<AttachMembers>]
 type CWLToolDescription (
         outputs: ResizeArray<CWLOutput>,
         ?cwlVersion: string,
         ?baseCommand: ResizeArray<string>,
+        ?arguments: YAMLElement,
+        ?stdin: string,
+        ?stderr: string,
+        ?stdout: string,
+        ?successCodes: ResizeArray<int>,
+        ?temporaryFailCodes: ResizeArray<int>,
+        ?permanentFailCodes: ResizeArray<int>,
         ?requirements: ResizeArray<Requirement>,
         ?hints: ResizeArray<HintEntry>,
         ?intent: ResizeArray<string>,
@@ -23,6 +31,13 @@ type CWLToolDescription (
     let mutable _cwlVersion: string = cwlVersion |> Option.defaultValue "v1.2"
     let mutable _outputs: ResizeArray<CWLOutput> = outputs
     let mutable _baseCommand: ResizeArray<string> option = baseCommand
+    let mutable _arguments: YAMLElement option = arguments
+    let mutable _stdin: string option = stdin
+    let mutable _stderr: string option = stderr
+    let mutable _stdout: string option = stdout
+    let mutable _successCodes: ResizeArray<int> option = successCodes
+    let mutable _temporaryFailCodes: ResizeArray<int> option = temporaryFailCodes
+    let mutable _permanentFailCodes: ResizeArray<int> option = permanentFailCodes
     let mutable _requirements: ResizeArray<Requirement> option = requirements
     let mutable _hints: ResizeArray<HintEntry> option = hints
     let mutable _intent: ResizeArray<string> option = intent
@@ -46,6 +61,34 @@ type CWLToolDescription (
     member this.BaseCommand
         with get() = _baseCommand
         and set(baseCommand) = _baseCommand <- baseCommand
+
+    member this.Arguments
+        with get() = _arguments
+        and set(value) = _arguments <- value
+
+    member this.Stdin
+        with get() = _stdin
+        and set(value) = _stdin <- value
+
+    member this.Stderr
+        with get() = _stderr
+        and set(value) = _stderr <- value
+
+    member this.Stdout
+        with get() = _stdout
+        and set(value) = _stdout <- value
+
+    member this.SuccessCodes
+        with get() = _successCodes
+        and set(value) = _successCodes <- value
+
+    member this.TemporaryFailCodes
+        with get() = _temporaryFailCodes
+        and set(value) = _temporaryFailCodes <- value
+
+    member this.PermanentFailCodes
+        with get() = _permanentFailCodes
+        and set(value) = _permanentFailCodes <- value
 
     member this.Requirements
         with get() = _requirements
@@ -74,6 +117,28 @@ type CWLToolDescription (
     member this.Doc
         with get() = _doc
         and set(doc) = _doc <- doc
+
+    static member KnownFieldNames =
+        ResizeArray [|
+            "inputs"
+            "outputs"
+            "class"
+            "id"
+            "label"
+            "doc"
+            "intent"
+            "requirements"
+            "hints"
+            "cwlVersion"
+            "baseCommand"
+            "arguments"
+            "stdin"
+            "stderr"
+            "stdout"
+            "successCodes"
+            "temporaryFailCodes"
+            "permanentFailCodes"
+        |]
 
     /// Returns the tool's inputs or an empty ResizeArray if None.
     static member getInputsOrEmpty (tool: CWLToolDescription) =

--- a/src/CWL/ToolDescription.fs
+++ b/src/CWL/ToolDescription.fs
@@ -119,7 +119,7 @@ type CWLToolDescription (
         and set(doc) = _doc <- doc
 
     static member KnownFieldNames =
-        ResizeArray [|
+        Set [|
             "inputs"
             "outputs"
             "class"

--- a/src/CWL/WorkflowDescription.fs
+++ b/src/CWL/WorkflowDescription.fs
@@ -76,6 +76,21 @@ type CWLWorkflowDescription(
         with get() = _doc
         and set(doc) = _doc <- doc
 
+    static member KnownFieldNames =
+        ResizeArray [|
+            "inputs"
+            "outputs"
+            "label"
+            "doc"
+            "intent"
+            "class"
+            "steps"
+            "id"
+            "requirements"
+            "hints"
+            "cwlVersion"
+        |]
+
     /// Returns workflow inputs.
     static member getInputs (workflow: CWLWorkflowDescription) =
         workflow.Inputs

--- a/src/CWL/WorkflowDescription.fs
+++ b/src/CWL/WorkflowDescription.fs
@@ -77,7 +77,7 @@ type CWLWorkflowDescription(
         and set(doc) = _doc <- doc
 
     static member KnownFieldNames =
-        ResizeArray [|
+        Set [|
             "inputs"
             "outputs"
             "label"

--- a/src/CWL/WorkflowSteps.fs
+++ b/src/CWL/WorkflowSteps.fs
@@ -181,7 +181,7 @@ type StepInput (
         )
 
     static member KnownFieldNames =
-        ResizeArray [|
+        Set [|
             "id"
             "source"
             "default"
@@ -224,7 +224,7 @@ type StepOutputParameter (id: string) =
         StepOutputParameter(id)
 
     static member KnownFieldNames =
-        ResizeArray [| "id" |]
+        Set [| "id" |]
 
 [<AttachMembers>]
 type StepOutput =
@@ -339,7 +339,7 @@ type WorkflowStep (
         )
 
     static member KnownFieldNames =
-        ResizeArray [|
+        Set [|
             "id"
             "run"
             "in"

--- a/src/CWL/WorkflowSteps.fs
+++ b/src/CWL/WorkflowSteps.fs
@@ -137,7 +137,7 @@ type StepInput (
             this.LoadContents = other.LoadContents &&
             this.LoadListing = other.LoadListing &&
             this.Label = other.Label &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
@@ -152,7 +152,7 @@ type StepInput (
             this.LoadContents,
             this.LoadListing,
             this.Label,
-            HashHelpers.hashDynamicProperties this
+            DynamicObjHelpers.hashDynamicProperties this
         )
 
     static member create(
@@ -214,11 +214,11 @@ type StepOutputParameter (id: string) =
         match o with
         | :? StepOutputParameter as other ->
             this.Id = other.Id &&
-            HashHelpers.dynamicPropertiesEqual this other
+            DynamicObjHelpers.dynamicPropertiesEqual this other
         | _ -> false
 
     override this.GetHashCode() =
-        hash (this.Id, HashHelpers.hashDynamicProperties this)
+        hash (this.Id, DynamicObjHelpers.hashDynamicProperties this)
 
     static member create(id: string) =
         StepOutputParameter(id)

--- a/src/CWL/WorkflowSteps.fs
+++ b/src/CWL/WorkflowSteps.fs
@@ -59,20 +59,102 @@ type ScatterMethod =
         | _ -> None
 
 [<AttachMembers>]
-type StepInput = {
-    Id: string
-    Source: ResizeArray<string> option
-    DefaultValue: YAMLElement option
-    ValueFrom: string option
-    LinkMerge: LinkMergeMethod option
-    PickValue: PickValueMethod option
-    Doc: string option
-    LoadContents: bool option
-    LoadListing: string option
-    Label: string option
-}
+type StepInput (
+    id: string,
+    ?source: ResizeArray<string>,
+    ?defaultValue: YAMLElement,
+    ?valueFrom: string,
+    ?linkMerge: LinkMergeMethod,
+    ?pickValue: PickValueMethod,
+    ?doc: string,
+    ?loadContents: bool,
+    ?loadListing: string,
+    ?label: string
+) =
+    inherit DynamicObj ()
 
-    with
+    let mutable _id = id
+    let mutable _source = source
+    let mutable _defaultValue = defaultValue
+    let mutable _valueFrom = valueFrom
+    let mutable _linkMerge = linkMerge
+    let mutable _pickValue = pickValue
+    let mutable _doc = doc
+    let mutable _loadContents = loadContents
+    let mutable _loadListing = loadListing
+    let mutable _label = label
+
+    member this.Id
+        with get() = _id
+        and set(value) = _id <- value
+
+    member this.Source
+        with get() = _source
+        and set(value) = _source <- value
+
+    member this.DefaultValue
+        with get() = _defaultValue
+        and set(value) = _defaultValue <- value
+
+    member this.ValueFrom
+        with get() = _valueFrom
+        and set(value) = _valueFrom <- value
+
+    member this.LinkMerge
+        with get() = _linkMerge
+        and set(value) = _linkMerge <- value
+
+    member this.PickValue
+        with get() = _pickValue
+        and set(value) = _pickValue <- value
+
+    member this.Doc
+        with get() = _doc
+        and set(value) = _doc <- value
+
+    member this.LoadContents
+        with get() = _loadContents
+        and set(value) = _loadContents <- value
+
+    member this.LoadListing
+        with get() = _loadListing
+        and set(value) = _loadListing <- value
+
+    member this.Label
+        with get() = _label
+        and set(value) = _label <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? StepInput as other ->
+            this.Id = other.Id &&
+            this.Source = other.Source &&
+            this.DefaultValue = other.DefaultValue &&
+            this.ValueFrom = other.ValueFrom &&
+            this.LinkMerge = other.LinkMerge &&
+            this.PickValue = other.PickValue &&
+            this.Doc = other.Doc &&
+            this.LoadContents = other.LoadContents &&
+            this.LoadListing = other.LoadListing &&
+            this.Label = other.Label &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (
+            this.Id,
+            this.Source,
+            this.DefaultValue,
+            this.ValueFrom,
+            this.LinkMerge,
+            this.PickValue,
+            this.Doc,
+            this.LoadContents,
+            this.LoadListing,
+            this.Label,
+            HashHelpers.hashDynamicProperties this
+        )
+
     static member create(
         id: string,
         ?source: ResizeArray<string>,
@@ -85,16 +167,32 @@ type StepInput = {
         ?loadListing: string,
         ?label: string
     ) =
-        { Id = id
-          Source = source
-          DefaultValue = defaultValue
-          ValueFrom = valueFrom
-          LinkMerge = linkMerge
-          PickValue = pickValue
-          Doc = doc
-          LoadContents = loadContents
-          LoadListing = loadListing
-          Label = label }
+        StepInput(
+            id,
+            ?source = source,
+            ?defaultValue = defaultValue,
+            ?valueFrom = valueFrom,
+            ?linkMerge = linkMerge,
+            ?pickValue = pickValue,
+            ?doc = doc,
+            ?loadContents = loadContents,
+            ?loadListing = loadListing,
+            ?label = label
+        )
+
+    static member KnownFieldNames =
+        ResizeArray [|
+            "id"
+            "source"
+            "default"
+            "valueFrom"
+            "linkMerge"
+            "pickValue"
+            "doc"
+            "loadContents"
+            "loadListing"
+            "label"
+        |]
 
     /// Updates a StepInput at the given index.
     static member updateAt (index: int) (f: StepInput -> StepInput) (inputs: ResizeArray<StepInput>) =
@@ -103,13 +201,30 @@ type StepInput = {
         inputs.[index] <- f inputs.[index]
 
 [<AttachMembers>]
-type StepOutputParameter = {
-    Id: string
-}
+type StepOutputParameter (id: string) =
+    inherit DynamicObj ()
 
-    with
+    let mutable _id = id
+
+    member this.Id
+        with get() = _id
+        and set(value) = _id <- value
+
+    override this.Equals(o: obj) =
+        match o with
+        | :? StepOutputParameter as other ->
+            this.Id = other.Id &&
+            HashHelpers.dynamicPropertiesEqual this other
+        | _ -> false
+
+    override this.GetHashCode() =
+        hash (this.Id, HashHelpers.hashDynamicProperties this)
+
     static member create(id: string) =
-        { Id = id }
+        StepOutputParameter(id)
+
+    static member KnownFieldNames =
+        ResizeArray [| "id" |]
 
 [<AttachMembers>]
 type StepOutput =
@@ -222,6 +337,21 @@ type WorkflowStep (
             ?requirements = requirements,
             ?hints = hints
         )
+
+    static member KnownFieldNames =
+        ResizeArray [|
+            "id"
+            "run"
+            "in"
+            "out"
+            "requirements"
+            "hints"
+            "label"
+            "doc"
+            "scatter"
+            "scatterMethod"
+            "when"
+        |]
 
     /// Updates a workflow step input by index.
     static member updateInputAt (index: int) (f: StepInput -> StepInput) (step: WorkflowStep) =

--- a/tests/ARCtrl/ROCrateConversion.Tests.fs
+++ b/tests/ARCtrl/ROCrateConversion.Tests.fs
@@ -26,39 +26,19 @@ module Helper =
         
         /// Create an InputRecordField with minimal boilerplate
         let field name type_ : ARCtrl.CWL.InputRecordField = 
-            { 
-                Name = name
-                Type = type_
-                Doc = None
-                Label = None 
-            }
+            ARCtrl.CWL.InputRecordField(name, type_)
         
         /// Create a CWL Record type with fields
         let record (fields: ARCtrl.CWL.InputRecordField list) : ARCtrl.CWL.CWLType = 
-            ARCtrl.CWL.CWLType.Record { 
-                Fields = Some (ResizeArray fields)
-                Label = None
-                Doc = None
-                Name = None 
-            }
+            ARCtrl.CWL.CWLType.Record (ARCtrl.CWL.InputRecordSchema(fields = ResizeArray fields))
         
         /// Create a CWL Enum type with symbols
         let enum (symbols: string list) : ARCtrl.CWL.CWLType = 
-            ARCtrl.CWL.CWLType.Enum { 
-                Symbols = ResizeArray symbols
-                Label = None
-                Doc = None
-                Name = None 
-            }
+            ARCtrl.CWL.CWLType.Enum (ARCtrl.CWL.InputEnumSchema(ResizeArray symbols))
         
         /// Create a CWL Array type
         let array (items: ARCtrl.CWL.CWLType) : ARCtrl.CWL.CWLType = 
-            ARCtrl.CWL.CWLType.Array { 
-                Items = items
-                Label = None
-                Doc = None
-                Name = None 
-            }
+            ARCtrl.CWL.CWLType.Array (ARCtrl.CWL.InputArraySchema(items))
         
         /// Create an optional type (union of null and another type)
         let optional (type_: ARCtrl.CWL.CWLType) : ARCtrl.CWL.CWLType =
@@ -1726,7 +1706,7 @@ let tests_FormalParameter =
             testCase "File_GlobBinding" (fun () ->
                 let name = "MyOutput"
                 let t = CWLType.file()
-                let binding : OutputBinding= {Glob = Some "*.txt"}
+                let binding = OutputBinding.create(glob = "*.txt")
                 let output = CWL.CWLOutput(name = name, type_ = t, outputBinding = binding)
                 let formalParameter = WorkflowConversion.composeFormalParameterFromOutput output
                 let name' = Expect.wantSome (LDFormalParameter.tryGetNameAsString formalParameter) "FormalParameter should have a name"
@@ -1742,7 +1722,7 @@ let tests_FormalParameter =
             testCase "File_GlobBinding_Roundabout" (fun () ->
                 let name = "MyOutput"
                 let t = CWLType.file()
-                let binding : OutputBinding= {Glob = Some "*.txt"}
+                let binding = OutputBinding.create(glob = "*.txt")
                 let output = CWL.CWLOutput(name = name, type_ = t, outputBinding = binding)
                 let formalParameter = WorkflowConversion.composeFormalParameterFromOutput output
                 let output' = WorkflowConversion.decomposeOutputFromFormalParameter formalParameter
@@ -1771,28 +1751,28 @@ let tests_AdditionalTypeDecoding =
                 Expect.equal decoded expected "Should decode File from YAML"
             )
             testCase "FileArray" (fun () ->
-                let expected = CWLType.Array { Items = CWLType.file(); Label = None; Doc = None; Name = None }
+                let expected = CWLType.Array (InputArraySchema(CWLType.file()))
                 let encoded = "File[]"
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded expected "Should decode File[] from YAML"
             )
             testCase "StringArray" (fun () ->
-                let expected = CWLType.Array { Items = CWLType.String; Label = None; Doc = None; Name = None }
+                let expected = CWLType.Array (InputArraySchema(CWLType.String))
                 let encoded = "string[]"
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded expected "Should decode string[] from YAML"
             )
             testCase "NestedFileArray" (fun () ->
-                let inner = { Items = CWLType.file(); Label = None; Doc = None; Name = None }
-                let expected = CWLType.Array { Items = CWLType.Array inner; Label = None; Doc = None; Name = None }
+                let inner = InputArraySchema(CWLType.file())
+                let expected = CWLType.Array (InputArraySchema(CWLType.Array inner))
                 let encoded = "File[][]"
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded expected "Should decode File[][] from YAML"
             )
             testCase "DeeplyNestedStringArray" (fun () ->
-                let innerArray = { Items = CWLType.String; Label = None; Doc = None; Name = None }
-                let middleArray = { Items = CWLType.Array innerArray; Label = None; Doc = None; Name = None }
-                let expected = CWLType.Array { Items = CWLType.Array middleArray; Label = None; Doc = None; Name = None }
+                let innerArray = InputArraySchema(CWLType.String)
+                let middleArray = InputArraySchema(CWLType.Array innerArray)
+                let expected = CWLType.Array (InputArraySchema(CWLType.Array middleArray))
                 let encoded = "string[][][]"
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded expected "Should decode string[][][] from YAML"
@@ -1853,13 +1833,13 @@ let tests_AdditionalTypeDecoding =
         ]
         testList "EdgeCases" [
             testCase "EmptyRecord" (fun () ->
-                let original = CWLType.Record { Fields = Some (ResizeArray []); Label = None; Doc = None; Name = None }
+                let original = CWLType.Record (InputRecordSchema(fields = ResizeArray []))
                 let encoded = WorkflowConversion.composeAdditionalType original
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded original "Should decode empty Record correctly"
             )
             testCase "SingleSymbolEnum" (fun () ->
-                let original = CWLType.Enum { Symbols = ResizeArray ["only"]; Label = None; Doc = None; Name = None }
+                let original = CWLType.Enum (InputEnumSchema(ResizeArray ["only"]))
                 let encoded = WorkflowConversion.composeAdditionalType original
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded original "Should decode single symbol Enum correctly"
@@ -1873,21 +1853,21 @@ let tests_AdditionalTypeDecoding =
                 Expect.equal decoded original "String should round-trip correctly"
             )
             testCase "Array_RoundTrip" (fun () ->
-                let original = CWLType.Array { Items = CWLType.String; Label = None; Doc = None; Name = None }
+                let original = CWLType.Array (InputArraySchema(CWLType.String))
                 let encoded = WorkflowConversion.composeAdditionalType original
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded original "Array should round-trip correctly"
             )
             testCase "Record_RoundTrip" (fun () ->
-                let field1 = { Name = "name"; Type = CWLType.String; Doc = None; Label = None }
-                let field2 = { Name = "count"; Type = CWLType.Int; Doc = None; Label = None }
-                let original = CWLType.Record { Fields = Some (ResizeArray [field1; field2]); Label = None; Doc = None; Name = None }
+                let field1 = InputRecordField("name", CWLType.String)
+                let field2 = InputRecordField("count", CWLType.Int)
+                let original = CWLType.Record (InputRecordSchema(fields = ResizeArray [field1; field2]))
                 let encoded = WorkflowConversion.composeAdditionalType original
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded original "Record should round-trip correctly"
             )
             testCase "Enum_RoundTrip" (fun () ->
-                let original = CWLType.Enum { Symbols = ResizeArray ["red"; "green"; "blue"]; Label = None; Doc = None; Name = None }
+                let original = CWLType.Enum (InputEnumSchema(ResizeArray ["red"; "green"; "blue"]))
                 let encoded = WorkflowConversion.composeAdditionalType original
                 let decoded = WorkflowConversion.decomposeAdditionalType encoded
                 Expect.equal decoded original "Enum should round-trip correctly"
@@ -1951,24 +1931,24 @@ let tests_AdditionalTypeEncoding =
                 Expect.equal encoded expected "Record should encode to single-line YAML"
             )
             testCase "Enum" (fun () ->
-                let schema = { Symbols = ResizeArray ["option1"; "option2"; "option3"]; Label = None; Doc = None; Name = None }
+                let schema = InputEnumSchema(ResizeArray ["option1"; "option2"; "option3"])
                 let t = CWLType.Enum schema
                 let encoded = WorkflowConversion.composeAdditionalType t
                 let expected = "{type: enum, symbols: [option1, option2, option3]}"
                 Expect.equal encoded expected "Enum should encode to single-line YAML"
             )
             testCase "RecordArray" (fun () ->
-                let field = { Name = "value"; Type = CWLType.String; Doc = None; Label = None }
-                let recordSchema = { Fields = Some (ResizeArray [field]); Label = None; Doc = None; Name = None }
-                let arraySchema = { Items = CWLType.Record recordSchema; Label = None; Doc = None; Name = None }
+                let field = InputRecordField("value", CWLType.String)
+                let recordSchema = InputRecordSchema(fields = ResizeArray [field])
+                let arraySchema = InputArraySchema(CWLType.Record recordSchema)
                 let t = CWLType.Array arraySchema
                 let encoded = WorkflowConversion.composeAdditionalType t
                 let expected = "{type: array, items: {type: record, fields: [{name: value, type: string}]}}"
                 Expect.equal encoded expected "Array of records should encode to single-line YAML"
             )
             testCase "EnumArray" (fun () ->
-                let enumSchema = { Symbols = ResizeArray ["A"; "B"; "C"]; Label = None; Doc = None; Name = None }
-                let arraySchema = { Items = CWLType.Enum enumSchema; Label = None; Doc = None; Name = None }
+                let enumSchema = InputEnumSchema(ResizeArray ["A"; "B"; "C"])
+                let arraySchema = InputArraySchema(CWLType.Enum enumSchema)
                 let t = CWLType.Array arraySchema
                 let encoded = WorkflowConversion.composeAdditionalType t
                 let expected = "{type: array, items: {type: enum, symbols: [A, B, C]}}"
@@ -1982,14 +1962,14 @@ let tests_AdditionalTypeEncoding =
                 Expect.equal encoded "string?" "Optional string should use YAML shorthand"
             )
             testCase "OptionalFileArray_YAML" (fun () ->
-                let fileArray = { Items = CWLType.file(); Label = None; Doc = None; Name = None }
+                let fileArray = InputArraySchema(CWLType.file())
                 let t = CWLType.Union (ResizeArray [CWLType.Null; CWLType.Array fileArray])
                 let encoded = WorkflowConversion.composeAdditionalType t
                 Expect.equal encoded "File[]?" "Optional File[] should use YAML shorthand"
             )
             testCase "OptionalRecord_YAML" (fun () ->
-                let field = { Name = "name"; Type = CWLType.String; Doc = None; Label = None }
-                let recordSchema = { Fields = Some (ResizeArray [field]); Label = None; Doc = None; Name = None }
+                let field = InputRecordField("name", CWLType.String)
+                let recordSchema = InputRecordSchema(fields = ResizeArray [field])
                 let t = CWLType.Union (ResizeArray [CWLType.Null; CWLType.Record recordSchema])
                 let encoded = WorkflowConversion.composeAdditionalType t
                 let expected = "[\"null\", {type: record, fields: [{name: name, type: string}]}]"
@@ -1998,14 +1978,14 @@ let tests_AdditionalTypeEncoding =
         ]
         testList "EdgeCases" [
             testCase "EmptyRecord" (fun () ->
-                let schema = { Fields = None; Label = None; Doc = None; Name = None }
+                let schema = InputRecordSchema()
                 let t = CWLType.Record schema
                 let encoded = WorkflowConversion.composeAdditionalType t
                 let expected = "{type: record, fields: []}"
                 Expect.equal encoded expected "Empty record should encode to single-line YAML"
             )
             testCase "SingleSymbolEnum" (fun () ->
-                let schema = { Symbols = ResizeArray ["only"]; Label = None; Doc = None; Name = None }
+                let schema = InputEnumSchema(ResizeArray ["only"])
                 let t = CWLType.Enum schema
                 let encoded = WorkflowConversion.composeAdditionalType t
                 let expected = "{type: enum, symbols: [only]}"
@@ -2014,8 +1994,8 @@ let tests_AdditionalTypeEncoding =
         ]
         testList "Integration_WithFormalParameter" [
             testCase "RecordInput_CreatesValidFormalParameter" (fun () ->
-                let field = { Name = "name"; Type = CWLType.String; Doc = None; Label = None }
-                let recordSchema = { Fields = Some (ResizeArray [field]); Label = None; Doc = None; Name = None }
+                let field = InputRecordField("name", CWLType.String)
+                let recordSchema = InputRecordSchema(fields = ResizeArray [field])
                 let t = CWLType.Record recordSchema
                 let input = CWL.CWLInput(name = "MyRecordInput", type_ = t)
                 let formalParameter = WorkflowConversion.composeFormalParameterFromInput input
@@ -2027,7 +2007,7 @@ let tests_AdditionalTypeEncoding =
                 Expect.equal additionalType expected "AdditionalType should be single-line YAML-encoded record"
             )
             testCase "FileArrayInput_CreatesValidFormalParameter" (fun () ->
-                let arraySchema = { Items = CWLType.file(); Label = None; Doc = None; Name = None }
+                let arraySchema = InputArraySchema(CWLType.file())
                 let t = CWLType.Array arraySchema
                 let input = CWL.CWLInput(name = "MyFileArrayInput", type_ = t)
                 let formalParameter = WorkflowConversion.composeFormalParameterFromInput input
@@ -2101,7 +2081,7 @@ let tests_AdditionalTypeErrorHandling =
             )
             testCase "EmptyEnumSymbols_NotSupported" (fun () ->
                 // Empty enum symbols cause decoder error - this is a known limitation
-                let schema = { Symbols = ResizeArray []; Label = None; Doc = None; Name = None }
+                let schema = InputEnumSchema(ResizeArray [])
                 let original = CWLType.Enum schema
                 
                 let encoded = WorkflowConversion.composeAdditionalType original
@@ -2134,7 +2114,7 @@ let tests_AdditionalTypeErrorHandling =
             testCase "ArrayOfUnions_RoundTrip" (fun () ->
                 // Arrays containing union item types are supported and should round-trip.
                 let unionType = CWLType.Union (ResizeArray [CWLType.String; CWLType.Int])
-                let arraySchema = { Items = unionType; Label = None; Doc = None; Name = None }
+                let arraySchema = InputArraySchema(unionType)
                 let original = CWLType.Array arraySchema
                 
                 let encoded = WorkflowConversion.composeAdditionalType original
@@ -2243,7 +2223,7 @@ let tests_YAMLInputValue =
             let runName = "MyRun"
             let value = ["a"; "b"]
             let paramValue = CWLParameterReference(name, values = ResizeArray value)
-            let cwlParam = CWL.CWLInput(name = name, type_ = CWLType.Array({ Items = CWLType.String; Label = None; Doc = None; Name = None }))
+            let cwlParam = CWL.CWLInput(name = name, type_ = CWLType.Array(InputArraySchema(CWLType.String)))
             let formalParam = WorkflowConversion.composeFormalParameterFromInput cwlParam
             let propValue = RunConversion.composeCWLInputValue(paramValue, formalParam, cwlParam, runName)
             Expect.sequenceEqual propValue.SchemaType [LDPropertyValue.schemaType] "PropertyValue should have correct schema type"
@@ -2259,7 +2239,7 @@ let tests_YAMLInputValue =
             let value = ["a"; "b"]
             let inputBinding = CWL.InputBinding.create(itemSeparator = ";")
             let paramValue = CWLParameterReference(name, values = ResizeArray value)
-            let cwlParam = CWL.CWLInput(name = name, type_ = CWLType.Array({ Items = CWLType.String; Label = None; Doc = None; Name = None }), inputBinding = inputBinding)
+            let cwlParam = CWL.CWLInput(name = name, type_ = CWLType.Array(InputArraySchema(CWLType.String)), inputBinding = inputBinding)
             let formalParam = WorkflowConversion.composeFormalParameterFromInput cwlParam
             let propValue = RunConversion.composeCWLInputValue(paramValue, formalParam, cwlParam, runName)
             Expect.sequenceEqual propValue.SchemaType [LDPropertyValue.schemaType] "PropertyValue should have correct schema type"

--- a/tests/CWL/CWLObject.Tests.fs
+++ b/tests/CWL/CWLObject.Tests.fs
@@ -91,7 +91,7 @@ outputs: {}"""
             testCase "InitialWorkDirRequirement" <| fun _ ->
                 let expected =
                     InitialWorkDirRequirement (
-                        ResizeArray [| DirentEntry { Entry = SchemaSaladString.Include "script.fsx"; Entryname = Some (SchemaSaladString.Literal "script.fsx"); Writable = None } |]
+                        ResizeArray [| DirentEntry (DirentInstance(SchemaSaladString.Include "script.fsx", entryname = SchemaSaladString.Literal "script.fsx")) |]
                     )
                 let actual = requirementsItem.Value.[0]
                 match actual, expected with
@@ -99,14 +99,14 @@ outputs: {}"""
                     Expect.sequenceEqual actualType expectedType ""
                 | _ -> failwith "This test case can only be InitialWorkDirRequirement"
             testCase "EnvVarRequirement" <| fun _ ->
-                let expected = EnvVarRequirement (ResizeArray [|{EnvName = "DOTNET_NOLOGO"; EnvValue = "true"}|])
+                let expected = EnvVarRequirement (ResizeArray [| EnvironmentDef("DOTNET_NOLOGO", "true") |])
                 let actual = requirementsItem.Value.[1]
                 match actual, expected with
                 | EnvVarRequirement actualType, EnvVarRequirement expectedType ->
                     Expect.sequenceEqual actualType expectedType ""
                 | _ -> failwith "This test case can only be EnvVarRequirement"
             testCase "NetworkAccessRequirement" <| fun _ ->
-                let expected = NetworkAccessRequirement { NetworkAccess = true }
+                let expected = NetworkAccessRequirement (NetworkAccessRequirementValue(true))
                 let actual = requirementsItem.Value.[2]
                 Expect.equal actual expected ""
         ]
@@ -127,7 +127,7 @@ outputs: {}"""
                     let actual = fileItem.Type_.Value
                     Expect.equal actual expected ""
                 testCase "InputBinding" <| fun _ ->
-                    let expected = Some {Position = Some 1; Prefix = None; ItemSeparator = None; Separate = None}
+                    let expected = Some (InputBinding.create(position = 1))
                     let actual = fileItem.InputBinding
                     Expect.equal actual expected ""
             ]
@@ -142,7 +142,7 @@ outputs: {}"""
                     let actual = stringItem.Type_.Value
                     Expect.equal actual expected ""
                 testCase "InputBinding" <| fun _ ->
-                    let expected = Some {Position = Some 2; Prefix = None; ItemSeparator = None; Separate = None}
+                    let expected = Some (InputBinding.create(position = 2))
                     let actual = stringItem.InputBinding
                     Expect.equal actual expected ""
             ]
@@ -164,7 +164,7 @@ outputs: {}"""
                     let actual = directoryItem.Type_.Value
                     Expect.equal actual expected ""
                 testCase "OutputBinding" <| fun _ ->
-                    let expected = Some {Glob = Some "$(runtime.outdir)/.nuget"}
+                    let expected = Some (OutputBinding.create(glob = "$(runtime.outdir)/.nuget"))
                     let actual = directoryItem.OutputBinding
                     Expect.equal actual expected ""
             ]
@@ -179,7 +179,7 @@ outputs: {}"""
                     let actual = fileItem.Type_.Value
                     Expect.equal actual expected ""
                 testCase "OutputBinding" <| fun _ ->
-                    let expected = Some {Glob = Some "$(runtime.outdir)/*.csv"}
+                    let expected = Some (OutputBinding.create(glob = "$(runtime.outdir)/*.csv"))
                     let actual = fileItem.OutputBinding
                     Expect.equal actual expected ""
             ]
@@ -213,7 +213,7 @@ let testCWLToolDescriptionMetadata =
             testCase "InitialWorkDirRequirement" <| fun _ ->
                 let expected =
                     InitialWorkDirRequirement (
-                        ResizeArray [| DirentEntry { Entry = SchemaSaladString.Include "script.fsx"; Entryname = Some (SchemaSaladString.Literal "script.fsx"); Writable = None } |]
+                        ResizeArray [| DirentEntry (DirentInstance(SchemaSaladString.Include "script.fsx", entryname = SchemaSaladString.Literal "script.fsx")) |]
                     )
                 let actual = requirementsItem.Value.[0]
                 match actual, expected with
@@ -221,14 +221,14 @@ let testCWLToolDescriptionMetadata =
                     Expect.sequenceEqual actualType expectedType ""
                 | _ -> failwith "This test case can only be InitialWorkDirRequirement"
             testCase "EnvVarRequirement" <| fun _ ->
-                let expected = EnvVarRequirement (ResizeArray [|{EnvName = "DOTNET_NOLOGO"; EnvValue = "true"}|])
+                let expected = EnvVarRequirement (ResizeArray [| EnvironmentDef("DOTNET_NOLOGO", "true") |])
                 let actual = requirementsItem.Value.[1]
                 match actual, expected with
                 | EnvVarRequirement actualType, EnvVarRequirement expectedType ->
                     Expect.sequenceEqual actualType expectedType ""
                 | _ -> failwith "This test case can only be EnvVarRequirement"
             testCase "NetworkAccessRequirement" <| fun _ ->
-                let expected = NetworkAccessRequirement { NetworkAccess = true }
+                let expected = NetworkAccessRequirement (NetworkAccessRequirementValue(true))
                 let actual = requirementsItem.Value.[2]
                 Expect.equal actual expected ""
         ]
@@ -249,7 +249,7 @@ let testCWLToolDescriptionMetadata =
                     let actual = fileItem.Type_.Value
                     Expect.equal actual expected ""
                 testCase "InputBinding" <| fun _ ->
-                    let expected = Some {Position = Some 1; Prefix = None; ItemSeparator = None; Separate = None}
+                    let expected = Some (InputBinding.create(position = 1))
                     let actual = fileItem.InputBinding
                     Expect.equal actual expected ""
             ]
@@ -264,7 +264,7 @@ let testCWLToolDescriptionMetadata =
                     let actual = stringItem.Type_.Value
                     Expect.equal actual expected ""
                 testCase "InputBinding" <| fun _ ->
-                    let expected = Some {Position = Some 2; Prefix = None; ItemSeparator = None; Separate = None}
+                    let expected = Some (InputBinding.create(position = 2))
                     let actual = stringItem.InputBinding
                     Expect.equal actual expected ""
             ]
@@ -286,7 +286,7 @@ let testCWLToolDescriptionMetadata =
                     let actual = directoryItem.Type_.Value
                     Expect.equal actual expected ""
                 testCase "OutputBinding" <| fun _ ->
-                    let expected = Some {Glob = Some "$(runtime.outdir)/.nuget"}
+                    let expected = Some (OutputBinding.create(glob = "$(runtime.outdir)/.nuget"))
                     let actual = directoryItem.OutputBinding
                     Expect.equal actual expected ""
             ]
@@ -301,7 +301,7 @@ let testCWLToolDescriptionMetadata =
                     let actual = fileItem.Type_.Value
                     Expect.equal actual expected ""
                 testCase "OutputBinding" <| fun _ ->
-                    let expected = Some {Glob = Some "$(runtime.outdir)/*.csv"}
+                    let expected = Some (OutputBinding.create(glob = "$(runtime.outdir)/*.csv"))
                     let actual = fileItem.OutputBinding
                     Expect.equal actual expected ""
             ]
@@ -351,6 +351,24 @@ let testCWLToolDescriptionEncode =
                 let metadataText = metadata |> DynObj.format
                 Expect.stringContains encoded "arc:technology platform" "Encoded tool should keep unknown metadata keys"
                 Expect.stringContains metadataText "arc:technology platform" "Decoded metadata should still include unknown keys"
+            testCase "CommandLineTool command fields decode as typed members and roundtrip" <| fun _ ->
+                let decoded = Decode.decodeCommandLineTool TestObjects.CWL.CommandLineTool.DecodeEdgeCases.commandFieldsOverflowFile
+
+                Expect.isSome decoded.Arguments "arguments should decode to a typed field."
+                Expect.equal decoded.Stdin (Some "stdin.txt") "stdin should decode to a typed field."
+                Expect.equal decoded.Stdout (Some "stdout.txt") "stdout should decode to a typed field."
+                Expect.equal decoded.Stderr (Some "stderr.txt") "stderr should decode to a typed field."
+                Expect.sequenceEqual decoded.SuccessCodes.Value (ResizeArray [| 0 |]) "successCodes should decode to a typed field."
+                Expect.sequenceEqual decoded.TemporaryFailCodes.Value (ResizeArray [| 75 |]) "temporaryFailCodes should decode to a typed field."
+                Expect.sequenceEqual decoded.PermanentFailCodes.Value (ResizeArray [| 1; 2 |]) "permanentFailCodes should decode to a typed field."
+                Expect.isNone (DynObj.tryGetTypedPropertyValue<obj> "arguments" decoded) "Known fields should not be direct overflow."
+                let metadata = Expect.wantSome decoded.Metadata "Extension field should decode as metadata."
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" metadata) (Some "keep overflow") "Extension field should stay in metadata."
+
+                let encoded = Encode.encodeToolDescription decoded
+                let roundTripped = Decode.decodeCommandLineTool encoded
+                Expect.isSome roundTripped.Arguments "arguments should survive roundtrip."
+                Expect.equal roundTripped.Stdout (Some "stdout.txt") "stdout should survive roundtrip."
         ]
     ]
 
@@ -388,12 +406,7 @@ let testNestedArrayDecoding =
 
 let testUnionArrayItemDecoding =
     let expectedMixedInputType =
-        Array {
-            Items = Union (ResizeArray [String; File (FileInstance())])
-            Label = None
-            Doc = None
-            Name = None
-        }
+        Array (InputArraySchema(Union (ResizeArray [String; File (FileInstance())])))
 
     let assertMixedInputType (decoded: CWLToolDescription) =
         let inputs = Expect.wantSome decoded.Inputs "Union-array-items fixture should decode inputs."
@@ -638,6 +651,40 @@ outputs:
             Expect.equal d1.Outputs.Count d2.Outputs.Count ""
     ]
 
+let testTopLevelDirectDynamicOverflow =
+    testList "Top-level direct DynamicObj overflow" [
+        testCase "CommandLineTool direct overflow encodes and decodes as metadata" <| fun _ ->
+            let tool = CWLToolDescription(outputs = ResizeArray())
+            DynObj.setProperty "arc:direct note" "tool note" tool
+            let encoded = Encode.encodeToolDescription tool
+            Expect.stringContains encoded "arc:direct note: tool note" "Direct DynamicObj overflow should be encoded."
+            let roundTripped = Decode.decodeCommandLineTool encoded
+            let metadata = Expect.wantSome roundTripped.Metadata "Decoded unknown top-level fields should remain available as metadata."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:direct note" metadata) (Some "tool note") "Encoded direct overflow should decode back as top-level metadata."
+
+        testCase "ExpressionTool direct overflow encodes and decodes as metadata" <| fun _ ->
+            let expressionTool = CWLExpressionToolDescription(outputs = ResizeArray(), expression = "$(null)")
+            DynObj.setProperty "arc:direct note" "expression note" expressionTool
+            let encoded = Encode.encodeExpressionToolDescription expressionTool
+            Expect.stringContains encoded "arc:direct note: expression note" "Direct DynamicObj overflow should be encoded."
+            let roundTripped = Decode.decodeExpressionTool encoded
+            let metadata = Expect.wantSome roundTripped.Metadata "Decoded unknown top-level fields should remain available as metadata."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:direct note" metadata) (Some "expression note") "Encoded direct overflow should decode back as top-level metadata."
+
+        testCase "Operation direct overflow encodes and decodes as metadata" <| fun _ ->
+            let operation =
+                CWLOperationDescription(
+                    inputs = ResizeArray [| CWLInput("input", CWLType.String) |],
+                    outputs = ResizeArray [| CWLOutput("output", CWLType.String) |]
+                )
+            DynObj.setProperty "arc:direct note" "operation note" operation
+            let encoded = Encode.encodeOperationDescription operation
+            Expect.stringContains encoded "arc:direct note: operation note" "Direct DynamicObj overflow should be encoded."
+            let roundTripped = Decode.decodeOperation encoded
+            let metadata = Expect.wantSome roundTripped.Metadata "Decoded unknown top-level fields should remain available as metadata."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:direct note" metadata) (Some "operation note") "Encoded direct overflow should decode back as top-level metadata."
+    ]
+
 let main = 
     testList "CWLToolDescription" [
         testCWLToolDescriptionDecode
@@ -648,5 +695,6 @@ let main =
         testUnionArrayItemDecoding
         testExpressionTool
         testOperation
+        testTopLevelDirectDynamicOverflow
     ]
 

--- a/tests/CWL/CWLObject.Tests.fs
+++ b/tests/CWL/CWLObject.Tests.fs
@@ -542,7 +542,7 @@ expression: $(null)"""
             Expect.stringContains roundTripped.Expression "inputs.directory_single" "directory_single input reference should survive roundtrip."
             Expect.stringContains roundTripped.Expression "inputs.file_single" "file_single input reference should survive roundtrip."
             Expect.stringContains roundTripped.Expression "inputs.newname" "newname input reference should survive roundtrip."
-            Expect.stringContains roundTripped.Expression "class: Directory" "Directory class literal should survive roundtrip."
+            Expect.stringContains roundTripped.Expression "\"Directory\"" "Directory class literal should survive roundtrip."
             Expect.stringContains roundTripped.Expression "listing: outputList" "listing assignment should survive roundtrip."
     ]
 

--- a/tests/CWL/CWLObject.Tests.fs
+++ b/tests/CWL/CWLObject.Tests.fs
@@ -307,10 +307,33 @@ let testCWLToolDescriptionMetadata =
             ]
         ]
         testCase "Metadata" <| fun _ ->
-            Expect.isSome decodeCWLToolDescriptionMetadata.Metadata $"Expected {decodeCWLToolDescriptionMetadata.Metadata} to be Some"
-            let expected = TestObjects.CWL.CommandLineToolMetadata.expectedMetadataString.Trim().Replace("\r\n", "\n")
-            let actual = (decodeCWLToolDescriptionMetadata.Metadata.Value |> DynObj.format).Trim().Replace("\r\n", "\n")
-            Expect.equal actual expected ""
+            let metadata = Expect.wantSome decodeCWLToolDescriptionMetadata.Metadata "Metadata should decode."
+            let singletonObject fieldName (parent: DynamicObj) =
+                let values =
+                    Expect.wantSome
+                        (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> fieldName parent)
+                        $"{fieldName} should remain a sequence."
+                Expect.equal values.Count 1 $"{fieldName} should have one value."
+                values.[0] :?> DynamicObj
+
+            let technologyType = singletonObject "arc:has technology type" metadata
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "class" technologyType) (Some "arc:technology type") ""
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:annotation value" technologyType) (Some "Fsharp Devcontainer") ""
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:technology platform" metadata) (Some ".NET") ""
+
+            let performer = singletonObject "arc:performer" metadata
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:first name" performer) (Some "Timo") ""
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:last name" performer) (Some "Mühlhaus") ""
+            let role = singletonObject "arc:has role" performer
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:annotation value" role) (Some "Formal analysis") ""
+
+            let processSequence = singletonObject "arc:has process sequence" metadata
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:name" processSequence) (Some "script.fsx") ""
+            let processInput = singletonObject "arc:has input" processSequence
+            Expect.equal
+                (DynObj.tryGetTypedPropertyValue<string> "arc:name" processInput)
+                (Some "./arc/assays/measurement1/dataset/table.csv")
+                ""
     ]
 
 let testCWLToolDescriptionEncode =

--- a/tests/CWL/CWLObject.Tests.fs
+++ b/tests/CWL/CWLObject.Tests.fs
@@ -17,18 +17,18 @@ let decodeCWLToolDescriptionMetadata: CWLToolDescription =
 
 let testCWLToolDescriptionDecode =
     testList "Decode" [
-        testCase "sanitize allows shebang and full-line comments" <| fun _ ->
+        testCase "decode allows shebang and full-line comments" <| fun _ ->
             let withShebangAndComments = TestObjects.CWL.CommandLineTool.DecodeEdgeCases.withShebangAndComments
             let decoded = Decode.decodeCommandLineTool withShebangAndComments
             Expect.equal decoded.CWLVersion "v1.2" ""
             Expect.equal decoded.Outputs.Count 0 ""
-        testCase "sanitize removes whitespace-only lines" <| fun _ ->
+        testCase "decode allows whitespace-only separator lines" <| fun _ ->
             let withWhitespaceOnlyLine = TestObjects.CWL.CommandLineTool.DecodeEdgeCases.withWhitespaceOnlyLine
             let decoded = Decode.decodeCommandLineTool withWhitespaceOnlyLine
             let inputs = Expect.wantSome decoded.Inputs "Inputs should decode when whitespace-only separator lines are present."
             Expect.equal inputs.Count 1 ""
             Expect.equal inputs.[0].Name "sample" ""
-        testCase "sanitize preserves plain multiline scalar semantics" <| fun _ ->
+        testCase "decode preserves plain multiline scalar semantics" <| fun _ ->
             let yaml = """cwlVersion: v1.2
 class: CommandLineTool
 doc: First paragraph line
@@ -45,11 +45,11 @@ outputs: {}
                 |> YAMLicious.Decode.object (fun get -> get.Required.Field "doc" YAMLicious.Decode.string)
             let decoded = Decode.decodeCommandLineTool yaml
             Expect.equal decoded.Doc (Some expectedDoc) "Plain multiline scalars should survive ARCtrl sanitization unchanged."
-        testCase "sanitize does not hide malformed yaml errors" <| fun _ ->
+        testCase "decode does not hide malformed yaml errors" <| fun _ ->
             let malformed = TestObjects.CWL.CommandLineTool.DecodeEdgeCases.malformedYaml
             let decodeMalformed () = Decode.decodeCWLProcessingUnit malformed |> ignore
             Expect.throws decodeMalformed "Malformed YAML should fail decoding"
-        testCase "sanitize propagates non-recoverable exception type" <| fun _ ->
+        testCase "decode propagates non-recoverable exception type" <| fun _ ->
             let nonRecoverableInput = "cwlVersion:\u0000 v1.2"
             let decodeInvalid () = Decode.decodeCWLProcessingUnit nonRecoverableInput |> ignore
             Expect.throws decodeInvalid "Non-recoverable parse exceptions should not be swallowed"

--- a/tests/CWL/CWLWorkflow.Tests.fs
+++ b/tests/CWL/CWLWorkflow.Tests.fs
@@ -239,6 +239,15 @@ let testCWLWorkflowDescriptionDecode =
             Expect.equal decoded.Steps.[0].In.Count 2 "Blank lines before and between nested step inputs should decode."
             Expect.isTrue (decoded.Inputs |> Seq.exists (fun input -> input.Name = "trial_id")) "trial_id should decode."
             Expect.equal decoded.Steps.[0].Id "collect" "The step following blank separators should stay mapped under steps."
+        testCase "comment-separated map-form workflow inputs decode" <| fun _ ->
+            let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithLowerIndentedCommentMapInputsFile
+            Expect.equal decoded.Inputs.Count 2 "Comment-separated map-form inputs should decode."
+            Expect.isTrue (decoded.Inputs |> Seq.exists (fun input -> input.Name = "first")) "first input should decode."
+            Expect.isTrue (decoded.Inputs |> Seq.exists (fun input -> input.Name = "second")) "second input should decode."
+        testCase "comment before sequence-form workflow inputs decodes" <| fun _ ->
+            let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithLowerIndentedCommentBeforeSequenceInputFile
+            Expect.equal decoded.Inputs.Count 1 "Comment before sequence-form inputs should decode."
+            Expect.equal decoded.Inputs.[0].Name "first" "first input should decode."
         testCase "decodeWorkflowWithWarnings skips malformed unnamed entries" <| fun _ ->
             let result = Decode.decodeWorkflowWithWarnings TestObjects.CWL.Workflow.workflowWithUnnamedMalformedEntriesFile
             Expect.equal result.Value.Inputs.Count 1 "Only valid input should decode."

--- a/tests/CWL/CWLWorkflow.Tests.fs
+++ b/tests/CWL/CWLWorkflow.Tests.fs
@@ -651,6 +651,20 @@ let testCWLWorkflowDescriptionEncode =
 
                 Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:step note" step) (Some "keep step note") "Workflow step overflow should roundtrip."
                 Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:step input note" stepInput) (Some "keep step input note") "Step input overflow should roundtrip."
+            testCase "workflow decimal overflow roundtrips" <| fun _ ->
+                let yaml = """cwlVersion: v1.2
+class: Workflow
+inputs:
+  sample:
+    type: string
+    arc:threshold: 2.5
+outputs: {}
+steps: {}"""
+                let decoded = Decode.decodeWorkflow yaml
+                let encoded = Encode.encodeWorkflowDescription decoded
+                let roundTripped = Decode.decodeWorkflow encoded
+                let input = roundTripped.Inputs |> Seq.find (fun input -> input.Name = "sample")
+                Expect.equal (DynObj.tryGetTypedPropertyValue<float> "arc:threshold" input) (Some 2.5) "Decimal overflow should roundtrip as a float."
             testList "PickValueMethod roundtrip" [
                 for (pickValueMethod, cwlString) in [
                     FirstNonNull, "first_non_null"

--- a/tests/CWL/CWLWorkflow.Tests.fs
+++ b/tests/CWL/CWLWorkflow.Tests.fs
@@ -316,6 +316,65 @@ let testCWLWorkflowDescriptionDecode =
             Expect.throws
                 (fun _ -> Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithMalformedNamedInputFile |> ignore)
                 "Named CWL inputs with missing type should fail."
+        testCase "malformed known field on named input fails" <| fun _ ->
+            let yaml = """cwlVersion: v1.2
+class: Workflow
+inputs:
+- id: named
+  type: string
+  label: [not, a, string]
+outputs: {}
+steps: {}"""
+            Expect.throws
+                (fun _ -> Decode.decodeWorkflow yaml |> ignore)
+                "Named CWL inputs with malformed known fields should fail."
+        testCase "malformed id-bearing sequence entries fail instead of becoming warnings" <| fun _ ->
+            let malformedInputId = """cwlVersion: v1.2
+class: Workflow
+inputs:
+- id: [not, a, string]
+  type: string
+outputs: {}
+steps: {}"""
+            let malformedOutputId = """cwlVersion: v1.2
+class: Workflow
+inputs: {}
+outputs:
+- id: [not, a, string]
+  type: string
+steps: {}"""
+            let malformedStepId = """cwlVersion: v1.2
+class: Workflow
+inputs: {}
+outputs: {}
+steps:
+- id: [not, a, string]
+  run: ./tool.cwl
+  in: []
+  out: []"""
+            let malformedStepInputId = """cwlVersion: v1.2
+class: Workflow
+inputs: {}
+outputs: {}
+steps:
+- id: step1
+  run: ./tool.cwl
+  in:
+  - id: [not, a, string]
+    source: input
+  out: []"""
+            Expect.throws
+                (fun _ -> Decode.decodeWorkflowWithWarnings malformedInputId |> ignore)
+                "Malformed input ids should fail rather than become skipped unnamed inputs."
+            Expect.throws
+                (fun _ -> Decode.decodeWorkflowWithWarnings malformedOutputId |> ignore)
+                "Malformed output ids should fail rather than become skipped unnamed outputs."
+            Expect.throws
+                (fun _ -> Decode.decodeWorkflowWithWarnings malformedStepId |> ignore)
+                "Malformed step ids should fail rather than become skipped unnamed steps."
+            Expect.throws
+                (fun _ -> Decode.decodeWorkflowWithWarnings malformedStepInputId |> ignore)
+                "Malformed step input ids should fail rather than become skipped unnamed step inputs."
         testCase "unknown fields on named ports and steps are preserved as dynamic properties" <| fun _ ->
             let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithUnknownPortFieldsFile
             let input = decoded.Inputs |> Seq.find (fun input -> input.Name = "sample")
@@ -665,6 +724,22 @@ steps: {}"""
                 let roundTripped = Decode.decodeWorkflow encoded
                 let input = roundTripped.Inputs |> Seq.find (fun input -> input.Name = "sample")
                 Expect.equal (DynObj.tryGetTypedPropertyValue<float> "arc:threshold" input) (Some 2.5) "Decimal overflow should roundtrip as a float."
+            testCase "workflow singleton sequence overflow roundtrips as a sequence" <| fun _ ->
+                let yaml = """cwlVersion: v1.2
+class: Workflow
+inputs:
+  sample:
+    type: string
+    arc:list: [only]
+outputs: {}
+steps: {}"""
+                let decoded = Decode.decodeWorkflow yaml
+                let encoded = Encode.encodeWorkflowDescription decoded
+                let roundTripped = Decode.decodeWorkflow encoded
+                let input = roundTripped.Inputs |> Seq.find (fun input -> input.Name = "sample")
+                let items = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "arc:list" input) "Singleton overflow should roundtrip as a collection."
+                Expect.equal items.Count 1 "Singleton overflow sequence should keep its item count."
+                Expect.equal (items.[0] :?> string) "only" "Singleton overflow sequence should keep its value."
             testList "PickValueMethod roundtrip" [
                 for (pickValueMethod, cwlString) in [
                     FirstNonNull, "first_non_null"

--- a/tests/CWL/CWLWorkflow.Tests.fs
+++ b/tests/CWL/CWLWorkflow.Tests.fs
@@ -248,6 +248,14 @@ let testCWLWorkflowDescriptionDecode =
             let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithLowerIndentedCommentBeforeSequenceInputFile
             Expect.equal decoded.Inputs.Count 1 "Comment before sequence-form inputs should decode."
             Expect.equal decoded.Inputs.[0].Name "first" "first input should decode."
+        testCase "multiline valueFrom expression decodes as one string" <| fun _ ->
+            let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithMultilineValueFromFile
+            let step = decoded.Steps |> Seq.find (fun step -> step.Id = "expr_step")
+            let stepInput = step.In |> Seq.find (fun input -> input.Id = "reads")
+            let valueFrom = Expect.wantSome stepInput.ValueFrom "valueFrom should decode."
+            Expect.stringContains valueFrom "${" "valueFrom should include the expression opener."
+            Expect.stringContains valueFrom "return reads;" "valueFrom should include the expression body."
+            Expect.stringContains valueFrom "}" "valueFrom should include the expression closer."
         testCase "decodeWorkflowWithWarnings skips malformed unnamed entries" <| fun _ ->
             let result = Decode.decodeWorkflowWithWarnings TestObjects.CWL.Workflow.workflowWithUnnamedMalformedEntriesFile
             Expect.equal result.Value.Inputs.Count 1 "Only valid input should decode."

--- a/tests/CWL/CWLWorkflow.Tests.fs
+++ b/tests/CWL/CWLWorkflow.Tests.fs
@@ -256,6 +256,51 @@ let testCWLWorkflowDescriptionDecode =
             Expect.stringContains valueFrom "${" "valueFrom should include the expression opener."
             Expect.stringContains valueFrom "return reads;" "valueFrom should include the expression body."
             Expect.stringContains valueFrom "}" "valueFrom should include the expression closer."
+        testCase "optional array shorthand input types decode" <| fun _ ->
+            let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithOptionalArrayInputTypesFile
+            let assertOptionalArray name expectedItem =
+                let input = decoded.Inputs |> Seq.find (fun input -> input.Name = name)
+                match input.Type_ with
+                | Some (Union types) ->
+                    Expect.isTrue (types |> Seq.exists ((=) Null)) $"{name} should include null in the union."
+                    let arrayItems =
+                        types
+                        |> Seq.choose (function | Array arraySchema -> Some arraySchema.Items | _ -> None)
+                        |> Seq.toList
+                    Expect.equal arrayItems [expectedItem] $"{name} should include exactly one array type."
+                | other -> failwithf "Expected optional array type for %s, got %A" name other
+            assertOptionalArray "optional_files" (File (FileInstance()))
+            assertOptionalArray "optional_dirs" (Directory (DirectoryInstance()))
+        testCase "inline enum and record schema union types decode" <| fun _ ->
+            let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithInlineSchemaUnionTypesFile
+            let mode = decoded.Inputs |> Seq.find (fun input -> input.Name = "mode")
+            match mode.Type_ with
+            | Some (Union types) ->
+                Expect.isTrue (types |> Seq.exists ((=) Null)) "mode should include null in the union."
+                match types |> Seq.choose (function | Enum schema -> Some schema | _ -> None) |> Seq.toList with
+                | [enumSchema] ->
+                    Expect.equal enumSchema.Name (Some "Mode") "Inline enum name should decode."
+                    Expect.sequenceEqual enumSchema.Symbols (ResizeArray [| "fast"; "stringent" |]) "Inline enum symbols should decode."
+                | other -> failwithf "Expected one inline enum schema, got %A" other
+            | other -> failwithf "Expected mode to decode as a union, got %A" other
+            let recordPayload = decoded.Inputs |> Seq.find (fun input -> input.Name = "record_payload")
+            match recordPayload.Type_ with
+            | Some (Union types) ->
+                Expect.isTrue (types |> Seq.exists ((=) Null)) "record_payload should include null in the union."
+                match types |> Seq.choose (function | Record schema -> Some schema | _ -> None) |> Seq.toList with
+                | [recordSchema] ->
+                    Expect.equal recordSchema.Name (Some "Payload") "Inline record name should decode."
+                    let fields = Expect.wantSome recordSchema.Fields "Inline record fields should decode."
+                    let sampleId = fields |> Seq.find (fun field -> field.Name = "sample_id")
+                    Expect.equal sampleId.Type String "sample_id type should decode."
+                    let files = fields |> Seq.find (fun field -> field.Name = "files")
+                    match files.Type with
+                    | Array arraySchema -> Expect.equal arraySchema.Items (File (FileInstance())) "files should decode as File array."
+                    | other -> failwithf "Expected files to decode as an array, got %A" other
+                | other -> failwithf "Expected one inline record schema, got %A" other
+            | other -> failwithf "Expected record_payload to decode as a union, got %A" other
+            Expect.isNone (DynObj.tryGetTypedPropertyValue<obj> "symbols" decoded) "Nested enum fields should not become workflow overflow."
+            Expect.isNone (DynObj.tryGetTypedPropertyValue<obj> "fields" decoded) "Nested record fields should not become workflow overflow."
         testCase "decodeWorkflowWithWarnings skips malformed unnamed entries" <| fun _ ->
             let result = Decode.decodeWorkflowWithWarnings TestObjects.CWL.Workflow.workflowWithUnnamedMalformedEntriesFile
             Expect.equal result.Value.Inputs.Count 1 "Only valid input should decode."

--- a/tests/CWL/CWLWorkflow.Tests.fs
+++ b/tests/CWL/CWLWorkflow.Tests.fs
@@ -231,6 +231,14 @@ let testCWLWorkflowDescriptionDecode =
             Expect.isTrue (decoded.Inputs |> Seq.exists (fun input -> input.Name = "input_data")) "input_data should decode."
             Expect.isTrue (decoded.Outputs |> Seq.exists (fun output -> output.Name = "result_data")) "result_data output should decode."
             Expect.equal decoded.Doc (Some "Workflow doc line.\n# This line is doc text, not a YAML comment.\n") "Block scalar comment-looking text should be preserved."
+        testCase "sequence-form workflow fields with blank separator lines decode" <| fun _ ->
+            let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithBlankSeparatedSequenceFieldsFile
+            Expect.equal decoded.Inputs.Count 2 "Blank lines before and between sequence-form inputs should decode."
+            Expect.equal decoded.Outputs.Count 1 "Blank lines before sequence-form outputs should decode."
+            Expect.equal decoded.Steps.Count 1 "Blank lines before sequence-form steps should decode."
+            Expect.equal decoded.Steps.[0].In.Count 2 "Blank lines before and between nested step inputs should decode."
+            Expect.isTrue (decoded.Inputs |> Seq.exists (fun input -> input.Name = "trial_id")) "trial_id should decode."
+            Expect.equal decoded.Steps.[0].Id "collect" "The step following blank separators should stay mapped under steps."
         testCase "decodeWorkflowWithWarnings skips malformed unnamed entries" <| fun _ ->
             let result = Decode.decodeWorkflowWithWarnings TestObjects.CWL.Workflow.workflowWithUnnamedMalformedEntriesFile
             Expect.equal result.Value.Inputs.Count 1 "Only valid input should decode."

--- a/tests/CWL/CWLWorkflow.Tests.fs
+++ b/tests/CWL/CWLWorkflow.Tests.fs
@@ -39,18 +39,7 @@ let renderYamlPair pair =
     |> Encode.writeYaml
 
 let mkStepInput id source linkMerge =
-    {
-        Id = id
-        Source = source
-        DefaultValue = None
-        ValueFrom = None
-        LinkMerge = linkMerge
-        PickValue = None
-        Doc = None
-        LoadContents = None
-        LoadListing = None
-        Label = None
-    }
+    StepInput.create(id, ?source = source, ?linkMerge = linkMerge)
 
 let testCWLWorkflowDescriptionDecode =
     testList "Decode" [
@@ -211,7 +200,7 @@ let testCWLWorkflowDescriptionDecode =
             Expect.equal step.In.[0].LoadListing (Some "deep_listing") ""
             Expect.equal step.In.[0].Label (Some "Input label") ""
             Expect.equal step.In.[0].LinkMerge (Some MergeNested) ""
-            let expectedOut = ResizeArray [| StepOutputRecord { Id = "out" } |]
+            let expectedOut = ResizeArray [| StepOutputRecord (StepOutputParameter.create "out") |]
             Expect.sequenceEqual step.Out expectedOut ""
         testCase "inline run commandline tool decode" <| fun _ ->
             let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithInlineRunCommandLineToolFile
@@ -234,6 +223,84 @@ let testCWLWorkflowDescriptionDecode =
             let yaml = TestObjects.CWL.Workflow.workflowWithNoStepsFile
             let decoded = Decode.decodeWorkflow yaml
             Expect.equal decoded.Steps.Count 0 ""
+        testCase "sequence-form workflow ports with comments decode" <| fun _ ->
+            let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithSequencePortsAndCommentsFile
+            Expect.equal decoded.Inputs.Count 2 "Sequence-form inputs should decode."
+            Expect.equal decoded.Outputs.Count 2 "Sequence-form outputs should decode."
+            Expect.equal decoded.Steps.Count 2 "Sequence-form steps should decode after comments."
+            Expect.isTrue (decoded.Inputs |> Seq.exists (fun input -> input.Name = "input_data")) "input_data should decode."
+            Expect.isTrue (decoded.Outputs |> Seq.exists (fun output -> output.Name = "result_data")) "result_data output should decode."
+            Expect.equal decoded.Doc (Some "Workflow doc line.\n# This line is doc text, not a YAML comment.\n") "Block scalar comment-looking text should be preserved."
+        testCase "decodeWorkflowWithWarnings skips malformed unnamed entries" <| fun _ ->
+            let result = Decode.decodeWorkflowWithWarnings TestObjects.CWL.Workflow.workflowWithUnnamedMalformedEntriesFile
+            Expect.equal result.Value.Inputs.Count 1 "Only valid input should decode."
+            Expect.equal result.Value.Outputs.Count 1 "Only valid output should decode."
+            Expect.equal result.Value.Steps.Count 1 "Only valid step should decode."
+            Expect.equal result.Value.Steps.[0].In.Count 1 "Only valid step input should decode."
+            Expect.equal result.Warnings.Count 4 "Each malformed unnamed entry should produce one warning."
+            Expect.sequenceEqual
+                (result.Warnings |> Seq.map (fun w -> w.Path) |> Seq.sort |> ResizeArray)
+                (ResizeArray [| "inputs[1]"; "outputs[1]"; "steps[0]"; "steps[1].in[1]" |] |> Seq.sort |> ResizeArray)
+                "Warning paths should identify skipped entries."
+        testCase "malformed named input still fails" <| fun _ ->
+            Expect.throws
+                (fun _ -> Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithMalformedNamedInputFile |> ignore)
+                "Named CWL inputs with missing type should fail."
+        testCase "unknown fields on named ports and steps are preserved as dynamic properties" <| fun _ ->
+            let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithUnknownPortFieldsFile
+            let input = decoded.Inputs |> Seq.find (fun input -> input.Name = "sample")
+            let output = decoded.Outputs |> Seq.find (fun output -> output.Name = "result")
+            let step = decoded.Steps |> Seq.find (fun step -> step.Id = "step1")
+            let stepInput = step.In |> Seq.find (fun input -> input.Id = "sample")
+            let inputBinding = Expect.wantSome input.InputBinding "Input binding should decode."
+            let outputBinding = Expect.wantSome output.OutputBinding "Output binding should decode."
+            Expect.equal
+                (DynObj.tryGetTypedPropertyValue<string> "arc:note" input)
+                (Some "keep input note")
+                "Unknown input fields should be preserved."
+            match input.Type_ with
+            | Some (CWLType.File file) ->
+                Expect.equal
+                    (DynObj.tryGetTypedPropertyValue<string> "arc:type note" file)
+                    (Some "keep input type note")
+                    "Unknown input type-object fields should be preserved on the file instance."
+            | other -> failwith $"Expected sample input to decode as File, got %A{other}."
+            Expect.isNone
+                (DynObj.tryGetTypedPropertyValue<string> "arc:binding note" input)
+                "Unknown input binding fields should not be flattened onto the input."
+            Expect.equal
+                (DynObj.tryGetTypedPropertyValue<string> "arc:binding note" inputBinding)
+                (Some "keep input binding note")
+                "Unknown input binding fields should be preserved on the binding."
+            Expect.equal
+                (DynObj.tryGetTypedPropertyValue<string> "arc:note" output)
+                (Some "keep output note")
+                "Unknown output fields should be preserved."
+            match output.Type_ with
+            | Some (CWLType.File file) ->
+                Expect.equal
+                    (DynObj.tryGetTypedPropertyValue<string> "arc:type note" file)
+                    (Some "keep output type note")
+                    "Unknown output type-object fields should be preserved on the file instance."
+            | other -> failwith $"Expected result output to decode as File, got %A{other}."
+            Expect.isNone
+                (DynObj.tryGetTypedPropertyValue<string> "arc:binding note" output)
+                "Unknown output binding fields should not be flattened onto the output."
+            Expect.equal
+                (DynObj.tryGetTypedPropertyValue<string> "arc:binding note" outputBinding)
+                (Some "keep output binding note")
+                "Unknown output binding fields should be preserved on the binding."
+            Expect.equal
+                (DynObj.tryGetTypedPropertyValue<string> "arc:step note" step)
+                (Some "keep step note")
+                "Unknown workflow step fields should be preserved."
+            Expect.isNone
+                (DynObj.tryGetTypedPropertyValue<string> "arc:step input note" step)
+                "Unknown step input fields should not be flattened onto the step."
+            Expect.equal
+                (DynObj.tryGetTypedPropertyValue<string> "arc:step input note" stepInput)
+                (Some "keep step input note")
+                "Unknown step input fields should be preserved on the step input."
         testCase "steps array form decode with when/pickValue/doc/default" <| fun _ ->
             let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithStepsArrayFile
             let step = decoded.Steps.[0]
@@ -483,6 +550,37 @@ let testCWLWorkflowDescriptionEncode =
                 Expect.stringContains encoded "intent:" "Workflow intent should be present in encoded output"
                 let intent = Expect.wantSome roundTripped.Intent "Workflow intent should survive roundtrip"
                 Expect.sequenceEqual intent (ResizeArray [|"primary-analysis"; "quality-control"|]) ""
+            testCase "workflow direct overflow and nested port overflow roundtrip" <| fun _ ->
+                let decoded = Decode.decodeWorkflow TestObjects.CWL.Workflow.workflowWithUnknownPortFieldsFile
+                DynObj.setProperty "arc:direct note" "workflow note" decoded
+                let encoded = Encode.encodeWorkflowDescription decoded
+                let roundTripped = Decode.decodeWorkflow encoded
+                let metadata = Expect.wantSome roundTripped.Metadata "Decoded direct overflow should be available as metadata."
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:direct note" metadata) (Some "workflow note") "Workflow direct DynamicObj overflow should encode."
+
+                let input = roundTripped.Inputs |> Seq.find (fun input -> input.Name = "sample")
+                let output = roundTripped.Outputs |> Seq.find (fun output -> output.Name = "result")
+                let step = roundTripped.Steps |> Seq.find (fun step -> step.Id = "step1")
+                let stepInput = step.In |> Seq.find (fun input -> input.Id = "sample")
+                let inputBinding = Expect.wantSome input.InputBinding "Input binding should survive roundtrip."
+                let outputBinding = Expect.wantSome output.OutputBinding "Output binding should survive roundtrip."
+
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" input) (Some "keep input note") "Input overflow should roundtrip."
+                match input.Type_ with
+                | Some (CWLType.File file) ->
+                    Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:type note" file) (Some "keep input type note") "Input type overflow should roundtrip."
+                | other -> failwith $"Expected File input type, got %A{other}."
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:binding note" inputBinding) (Some "keep input binding note") "Input binding overflow should roundtrip."
+
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" output) (Some "keep output note") "Output overflow should roundtrip."
+                match output.Type_ with
+                | Some (CWLType.File file) ->
+                    Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:type note" file) (Some "keep output type note") "Output type overflow should roundtrip."
+                | other -> failwith $"Expected File output type, got %A{other}."
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:binding note" outputBinding) (Some "keep output binding note") "Output binding overflow should roundtrip."
+
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:step note" step) (Some "keep step note") "Workflow step overflow should roundtrip."
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:step input note" stepInput) (Some "keep step input note") "Step input overflow should roundtrip."
             testList "PickValueMethod roundtrip" [
                 for (pickValueMethod, cwlString) in [
                     FirstNonNull, "first_non_null"
@@ -552,14 +650,14 @@ let testCWLWorkflowDescriptionEncode =
                 let decodedHints = Expect.wantSome decodedStep.Hints "Step hints should decode"
                 let decodedRequirements = Expect.wantSome decodedStep.Requirements "Step requirements should decode"
                 Expect.equal decodedHints.[0] (KnownHint StepInputExpressionRequirement) ""
-                Expect.equal decodedRequirements.[0] (NetworkAccessRequirement { NetworkAccess = true }) ""
+                Expect.equal decodedRequirements.[0] (NetworkAccessRequirement (NetworkAccessRequirementValue(true))) ""
                 let encoded = Encode.encodeWorkflowDescription decoded
                 let roundTripped = Decode.decodeWorkflow encoded
                 let roundTrippedStep = roundTripped.Steps.[0]
                 let roundTrippedHints = Expect.wantSome roundTrippedStep.Hints "Step hints should survive roundtrip"
                 let roundTrippedRequirements = Expect.wantSome roundTrippedStep.Requirements "Step requirements should survive roundtrip"
                 Expect.equal roundTrippedHints.[0] (KnownHint StepInputExpressionRequirement) ""
-                Expect.equal roundTrippedRequirements.[0] (NetworkAccessRequirement { NetworkAccess = true }) ""
+                Expect.equal roundTrippedRequirements.[0] (NetworkAccessRequirement (NetworkAccessRequirementValue(true))) ""
             testCase "inline ExpressionTool roundtrip preserves expression" <| fun _ ->
                 let original = Decode.decodeWorkflow TestObjects.CWL.ExpressionTool.workflowWithMixedToolAndExpressionStepFile
                 let encoded = Encode.encodeWorkflowDescription original

--- a/tests/CWL/Inputs.Tests.fs
+++ b/tests/CWL/Inputs.Tests.fs
@@ -93,8 +93,8 @@ let testInputMutationApi =
                     streamable = false
                 )
 
-            Expect.sequenceEqual InputBinding.KnownFieldNames (ResizeArray [| "loadContents"; "position"; "prefix"; "separate"; "itemSeparator"; "valueFrom"; "shellQuote" |]) "InputBinding known fields should be declared on the type."
-            Expect.sequenceEqual CWLInput.KnownFieldNames (ResizeArray [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "loadContents"; "loadListing"; "default"; "inputBinding" |]) "CWLInput known fields should be declared on the type."
+            Expect.sequenceEqual InputBinding.KnownFieldNames (Set [| "loadContents"; "position"; "prefix"; "separate"; "itemSeparator"; "valueFrom"; "shellQuote" |]) "InputBinding known fields should be declared on the type."
+            Expect.sequenceEqual CWLInput.KnownFieldNames (Set [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "loadContents"; "loadListing"; "default"; "inputBinding" |]) "CWLInput known fields should be declared on the type."
             Expect.isEmpty (binding |> DynamicObjHelpers.dynamicPropertiesSnapshot) "InputBinding known fields should not be stored as dynamic properties."
             Expect.isEmpty (input |> DynamicObjHelpers.dynamicPropertiesSnapshot) "CWLInput known fields should not be stored as dynamic properties."
 

--- a/tests/CWL/Inputs.Tests.fs
+++ b/tests/CWL/Inputs.Tests.fs
@@ -1,6 +1,7 @@
 module Tests.Inputs
 
 open ARCtrl.CWL
+open DynamicObj
 open YAMLicious
 open TestingUtils
 
@@ -22,7 +23,7 @@ let testInput =
             let fileItem = decodeInput.[1]
             testCase "Name" <| fun _ -> Expect.equal "firstArg"  fileItem.Name ""
             testCase "Type" <| fun _ -> Expect.equal (File (FileInstance()))  fileItem.Type_.Value ""
-            testCase "InputBinding" <| fun _ -> Expect.equal (Some {Position = Some 1; Prefix = Some "--example"; ItemSeparator = None; Separate = None}) fileItem.InputBinding ""
+            testCase "InputBinding" <| fun _ -> Expect.equal (Some (InputBinding.create(position = 1, prefix = "--example"))) fileItem.InputBinding ""
         ]
         testList "File optional" [
             let fileItem = decodeInput.[2]
@@ -36,7 +37,7 @@ let testInput =
             let fileItem = decodeInput.[3]
             testCase "Name" <| fun _ -> Expect.equal "argOptionalMap"  fileItem.Name ""
             testCase "Type" <| fun _ -> 
-                let expected = Union (ResizeArray [Null; Array {Items = File (FileInstance()); Label = None; Doc = None; Name = None}])
+                let expected = Union (ResizeArray [Null; Array (InputArraySchema(File (FileInstance())))])
                 Expect.equal fileItem.Type_.Value expected "Should be Union of [Null; File[]]"
             testCase "Optional" <| fun _ -> Expect.equal (Some true) fileItem.Optional ""
         ]
@@ -48,7 +49,7 @@ let testInput =
                 let actual = stringItem.Type_.Value
                 Expect.equal actual expected ""
             testCase "InputBinding" <| fun _ ->
-                let expected = Some {Position = Some 2; Prefix = None; ItemSeparator = None; Separate = Some false}
+                let expected = Some (InputBinding.create(position = 2, separate = false))
                 let actual = stringItem.InputBinding
                 Expect.equal actual expected ""
         ]
@@ -59,11 +60,11 @@ let testInputMutationApi =
         testCase "typed setters roundtrip values" <| fun _ ->
             let input = CWLInput("arg")
             input.Type_ <- Some CWLType.String
-            input.InputBinding <- Some { Prefix = Some "--arg"; Position = Some 1; ItemSeparator = None; Separate = Some true }
+            input.InputBinding <- Some (InputBinding.create(prefix = "--arg", position = 1, separate = true))
             input.Optional <- Some true
 
             Expect.equal input.Type_ (Some CWLType.String) "Type_ setter should write DynamicObj-backed value."
-            Expect.equal input.InputBinding (Some { Prefix = Some "--arg"; Position = Some 1; ItemSeparator = None; Separate = Some true }) "InputBinding setter should write value."
+            Expect.equal input.InputBinding (Some (InputBinding.create(prefix = "--arg", position = 1, separate = true))) "InputBinding setter should write value."
             Expect.equal input.Optional (Some true) "Optional setter should write value."
 
         testCase "typed setters can clear optional values" <| fun _ ->
@@ -75,6 +76,75 @@ let testInputMutationApi =
             Expect.isNone input.Type_ "Type_ should be removable."
             Expect.isNone input.Optional "Optional should be removable."
             Expect.isNone input.InputBinding "InputBinding should be removable."
+
+        testCase "known fields are typed fields, not dynamic overflow" <| fun _ ->
+            let binding = InputBinding.create(prefix = "--arg", position = 1, itemSeparator = ",", separate = true, loadContents = true, valueFrom = "$(self)", shellQuote = false)
+            let input =
+                CWLInput(
+                    "arg",
+                    type_ = CWLType.String,
+                    inputBinding = binding,
+                    optional = true,
+                    label = "Argument",
+                    doc = "Argument docs",
+                    format = "edam:format_2330",
+                    loadContents = true,
+                    loadListing = LoadListingEnum.ShallowListing,
+                    streamable = false
+                )
+
+            Expect.sequenceEqual InputBinding.KnownFieldNames (ResizeArray [| "loadContents"; "position"; "prefix"; "separate"; "itemSeparator"; "valueFrom"; "shellQuote" |]) "InputBinding known fields should be declared on the type."
+            Expect.sequenceEqual CWLInput.KnownFieldNames (ResizeArray [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "loadContents"; "loadListing"; "default"; "inputBinding" |]) "CWLInput known fields should be declared on the type."
+            Expect.isEmpty (binding |> DynamicObjHelpers.dynamicPropertiesSnapshot) "InputBinding known fields should not be stored as dynamic properties."
+            Expect.isEmpty (input |> DynamicObjHelpers.dynamicPropertiesSnapshot) "CWLInput known fields should not be stored as dynamic properties."
+
+            DynObj.setProperty "arc:note" "keep overflow" input
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" input) (Some "keep overflow") "Unknown fields should still use DynamicObj overflow."
+
+        testCase "known DynamicObj keys are not encoded as input overflow" <| fun _ ->
+            let input = CWLInput("arg", type_ = CWLType.String)
+            DynObj.setProperty "label" "dynamic label" input
+            DynObj.setProperty "arc:note" "keep overflow" input
+
+            let _, encoded = Encode.encodeCWLInput input
+            let yaml = Encode.writeYaml encoded
+
+            Expect.isFalse (yaml.Contains("label")) "Known input fields should not be encoded from DynamicObj storage."
+            Expect.stringContains yaml "arc:note" "Unknown overflow should still be encoded."
+
+        testCase "missing optional inputBinding fields are not encoded as defaults" <| fun _ ->
+            let binding = InputBinding.create(prefix = "--arg")
+
+            let yaml =
+                binding
+                |> Encode.encodeInputBinding
+                |> Encode.writeYaml
+
+            Expect.stringContains yaml "prefix" "The present prefix field should be encoded."
+            Expect.isFalse (yaml.Contains("position")) "Missing position should not encode as 0."
+            Expect.isFalse (yaml.Contains("_position")) "Compiler backing storage should not be encoded."
+            Expect.isFalse (yaml.Contains("itemSeparator")) "Missing itemSeparator should not encode as an empty string."
+
+        testCase "spec input fields decode as typed members regardless of order" <| fun _ ->
+            let input =
+                TestObjects.CWL.Inputs.specInputFieldsDecodeFileContent
+                |> Decode.read
+                |> Decode.inputsDecoder
+                |> Option.get
+                |> fun inputs -> inputs.[0]
+
+            Expect.equal input.Label (Some "Sample") "label should decode to a typed field."
+            Expect.equal input.Doc (Some "Sample input docs") "doc should decode to a typed field."
+            Expect.equal input.Format (Some "edam:format_2330") "format should decode to a typed field."
+            Expect.equal input.LoadContents (Some true) "loadContents should decode to a typed field."
+            Expect.equal input.LoadListing (Some LoadListingEnum.ShallowListing) "loadListing should decode to a typed field."
+            Expect.equal input.Streamable (Some false) "streamable should decode to a typed field."
+            Expect.isSome input.DefaultValue "default should decode to a typed field."
+            Expect.isSome input.SecondaryFiles "secondaryFiles should decode to a typed field."
+            Expect.equal input.InputBinding.Value.ValueFrom (Some "$(self.path)") "inputBinding.valueFrom should decode to a typed field."
+            Expect.equal input.InputBinding.Value.LoadContents (Some true) "inputBinding.loadContents should decode to a typed field."
+            Expect.equal input.InputBinding.Value.ShellQuote (Some false) "inputBinding.shellQuote should decode to a typed field."
+            Expect.isEmpty (input |> DynamicObjHelpers.dynamicPropertiesSnapshot) "Known input fields should not be overflow."
     ]
 
 let testProcessingUnitInputOps =
@@ -194,7 +264,7 @@ let testProcessingUnitRequirementOps =
             Expect.equal operationReqs.Count 0 "Operation requirements should normalize to empty collection."
 
         testCase "getRequirements returns existing collection for all variants" <| fun _ ->
-            let toolReqs = ResizeArray [| NetworkAccessRequirement { NetworkAccess = true } |]
+            let toolReqs = ResizeArray [| NetworkAccessRequirement (NetworkAccessRequirementValue(true)) |]
             let workflowReqs = ResizeArray [| SubworkflowFeatureRequirement |]
             let expressionReqs = ResizeArray [| Requirement.defaultInlineJavascriptRequirement |]
             let operationReqs = ResizeArray [| Requirement.defaultInlineJavascriptRequirement |]
@@ -265,8 +335,8 @@ let testProcessingUnitHintOps =
             let operationHints = CWLOperationDescription.getOrCreateHints operation
 
             toolHints.Add(KnownHint Requirement.defaultInlineJavascriptRequirement)
-            workflowHints.Add(UnknownHint { Class = Some "acme:Hint"; Raw = Decode.read "class: acme:Hint" })
-            expressionHints.Add(KnownHint (NetworkAccessRequirement { NetworkAccess = true }))
+            workflowHints.Add(UnknownHint (HintUnknownValue(Some "acme:Hint", Decode.read "class: acme:Hint")))
+            expressionHints.Add(KnownHint (NetworkAccessRequirement (NetworkAccessRequirementValue(true))))
             operationHints.Add(KnownHint Requirement.defaultInlineJavascriptRequirement)
 
             Expect.equal tool.Hints.Value.Count 1 "Tool hints should be initialized and retained."
@@ -278,8 +348,8 @@ let testProcessingUnitHintOps =
             let hints =
                 ResizeArray [|
                     KnownHint Requirement.defaultInlineJavascriptRequirement
-                    UnknownHint { Class = Some "acme:Hint"; Raw = Decode.read "class: acme:Hint" }
-                    KnownHint (WorkReuseRequirement { EnableReuse = true })
+                    UnknownHint (HintUnknownValue(Some "acme:Hint", Decode.read "class: acme:Hint"))
+                    KnownHint (WorkReuseRequirement (WorkReuseRequirementValue(true)))
                 |]
 
             let tool = CWLToolDescription(outputs = ResizeArray(), hints = hints)

--- a/tests/CWL/Metadata.Tests.fs
+++ b/tests/CWL/Metadata.Tests.fs
@@ -1,5 +1,6 @@
 module Tests.Metadata
 
+open ARCtrl.CWL
 open ARCtrl.CWL.Decode
 open DynamicObj
 open YAMLicious
@@ -23,13 +24,32 @@ let testMetadata =
             let actual = overflowDictionary.Keys |> List.ofSeq
             Expect.equal actual expected ""
         testCase "DynObj Keys" <| fun _ ->
-            let expected = ["arc:has technology type"; "arc:technology platform"; "arc:performer"; "arc:has process sequence"]
-            let actual = dynObj.GetProperties(false) |> List.ofSeq |> List.map (fun x -> x.Key)
+            let expected = ["arc:has process sequence"; "arc:has technology type"; "arc:performer"; "arc:technology platform"]
+            let actual = dynObj |> DynamicObjHelpers.dynamicPropertiesSnapshot |> List.map fst
             Expect.equal actual expected ""
         testCase "DynObj setProperty Value check" <| fun _ ->
             let expectedValue = ".NET"
             let actualValue = dynObj |> DynObj.tryGetTypedPropertyValue<string> "arc:technology platform"
             Expect.equal actualValue.Value expectedValue ""
+        testCase "multiple sequence entries stay distinct in overflow" <| fun _ ->
+            let yaml = """arc:items:
+  - class: arc:First
+    arc:name: one
+  - class: arc:Second
+    arc:name: two"""
+            let decoded =
+                yaml
+                |> Decode.read
+                |> Decode.object (fun get -> get.Overflow.FieldList [])
+                |> overflowDecoder (DynamicObj())
+            let items = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "arc:items" decoded) "Sequence overflow should decode as a collection."
+            Expect.equal items.Count 2 "Both sequence entries should survive."
+            let first = items.[0] :?> DynamicObj
+            let second = items.[1] :?> DynamicObj
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "class" first) (Some "arc:First") "First item should keep its own class."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:name" first) (Some "one") "First item should keep its own payload."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "class" second) (Some "arc:Second") "Second item should keep its own class."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:name" second) (Some "two") "Second item should keep its own payload."
     ]
 
 

--- a/tests/CWL/Metadata.Tests.fs
+++ b/tests/CWL/Metadata.Tests.fs
@@ -50,6 +50,22 @@ let testMetadata =
             Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:name" first) (Some "one") "First item should keep its own payload."
             Expect.equal (DynObj.tryGetTypedPropertyValue<string> "class" second) (Some "arc:Second") "Second item should keep its own class."
             Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:name" second) (Some "two") "Second item should keep its own payload."
+        testCase "nested overflow decodes unquoted YAML primitive scalars with their types" <| fun _ ->
+            let yaml = """arc:nested:
+  enabled: true
+  count: 1
+  threshold: 2.5
+  quotedFlag: 'true'"""
+            let decoded =
+                yaml
+                |> Decode.read
+                |> Decode.object (fun get -> get.Overflow.FieldList [])
+                |> overflowDecoder (DynamicObj())
+            let nested = Expect.wantSome (DynObj.tryGetTypedPropertyValue<DynamicObj> "arc:nested" decoded) "Nested overflow should decode as an object."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<bool> "enabled" nested) (Some true) "Plain booleans should retain their YAML type."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<int64> "count" nested) (Some 1L) "Plain integers should retain their YAML type."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<float> "threshold" nested) (Some 2.5) "Plain floats should retain their YAML type."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "quotedFlag" nested) (Some "true") "Quoted scalar text should remain text."
     ]
 
 

--- a/tests/CWL/Metadata.Tests.fs
+++ b/tests/CWL/Metadata.Tests.fs
@@ -50,6 +50,16 @@ let testMetadata =
             Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:name" first) (Some "one") "First item should keep its own payload."
             Expect.equal (DynObj.tryGetTypedPropertyValue<string> "class" second) (Some "arc:Second") "Second item should keep its own class."
             Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:name" second) (Some "two") "Second item should keep its own payload."
+        testCase "single sequence entry stays a collection in overflow" <| fun _ ->
+            let yaml = "arc:list: [only]"
+            let decoded =
+                yaml
+                |> Decode.read
+                |> Decode.object (fun get -> get.Overflow.FieldList [])
+                |> overflowDecoder (DynamicObj())
+            let items = Expect.wantSome (DynObj.tryGetTypedPropertyValue<ResizeArray<obj>> "arc:list" decoded) "Singleton sequence overflow should remain a collection."
+            Expect.equal items.Count 1 "Singleton sequence should keep one entry."
+            Expect.equal (items.[0] :?> string) "only" "Singleton sequence entry should be preserved."
         testCase "nested overflow decodes unquoted YAML primitive scalars with their types" <| fun _ ->
             let yaml = """arc:nested:
   enabled: true

--- a/tests/CWL/Outputs.Tests.fs
+++ b/tests/CWL/Outputs.Tests.fs
@@ -1,6 +1,7 @@
 module Tests.Outputs
 
 open ARCtrl.CWL
+open DynamicObj
 open YAMLicious
 open TestingUtils
 
@@ -26,7 +27,7 @@ let testOutput =
                 let actual = fileItem.Type_.Value
                 Expect.equal actual expected ""
             testCase "OutputBinding" <| fun _ ->
-                let expected = Some {Glob = Some "./arc/runs/fsResult1/result.csv"}
+                let expected = Some (OutputBinding.create(glob = "./arc/runs/fsResult1/result.csv"))
                 let actual = fileItem.OutputBinding
                 Expect.equal actual expected ""
         ]
@@ -41,7 +42,7 @@ let testOutput =
                 let actual = directoryItem.Type_.Value
                 Expect.equal actual expected ""
             testCase "OutputBinding" <| fun _ ->
-                let expected = Some {Glob = Some "./arc/runs/fsResult1/example.csv"}
+                let expected = Some (OutputBinding.create(glob = "./arc/runs/fsResult1/example.csv"))
                 let actual = directoryItem.OutputBinding
                 Expect.equal actual expected ""
         ]
@@ -67,11 +68,11 @@ let testOutput =
                 let actual = fileArrayItem.Name
                 Expect.equal actual expected ""
             testCase "Type" <| fun _ ->
-                let expected = Array { Items = File (FileInstance()); Label = None; Doc = None; Name = None }
+                let expected = Array (InputArraySchema(File (FileInstance())))
                 let actual = fileArrayItem.Type_.Value
                 Expect.equal actual expected ""
             testCase "OutputBinding" <| fun _ ->
-                let expected = Some {Glob = Some "./arc/runs/fsResult1/example.csv"}
+                let expected = Some (OutputBinding.create(glob = "./arc/runs/fsResult1/example.csv"))
                 let actual = fileArrayItem.OutputBinding
                 Expect.equal actual expected ""
         ]
@@ -82,11 +83,11 @@ let testOutput =
                 let actual = fileArrayItem.Name
                 Expect.equal actual expected ""
             testCase "Type" <| fun _ ->
-                let expected = Array { Items = File (FileInstance()); Label = None; Doc = None; Name = None }
+                let expected = Array (InputArraySchema(File (FileInstance())))
                 let actual = fileArrayItem.Type_.Value
                 Expect.equal actual expected ""
             testCase "OutputBinding" <| fun _ ->
-                let expected = Some {Glob = Some "./arc/runs/fsResult1/example.csv"}
+                let expected = Some (OutputBinding.create(glob = "./arc/runs/fsResult1/example.csv"))
                 let actual = fileArrayItem.OutputBinding
                 Expect.equal actual expected ""
         ]
@@ -97,11 +98,11 @@ let testOutputMutationApi =
         testCase "typed setters roundtrip values" <| fun _ ->
             let output = CWLOutput("result")
             output.Type_ <- Some (File (FileInstance()))
-            output.OutputBinding <- Some { Glob = Some "results/*.txt" }
+            output.OutputBinding <- Some (OutputBinding.create(glob = "results/*.txt"))
             output.OutputSource <- Some (OutputSource.Single "step/out")
 
             Expect.equal output.Type_ (Some (File (FileInstance()))) "Type_ setter should write DynamicObj-backed value."
-            Expect.equal output.OutputBinding (Some { Glob = Some "results/*.txt" }) "OutputBinding setter should write value."
+            Expect.equal output.OutputBinding (Some (OutputBinding.create(glob = "results/*.txt"))) "OutputBinding setter should write value."
             Expect.equal output.OutputSource (Some (OutputSource.Single "step/out")) "OutputSource setter should write value."
 
         testCase "typed setters can clear optional values" <| fun _ ->
@@ -109,7 +110,7 @@ let testOutputMutationApi =
                 CWLOutput(
                     "result",
                     type_ = CWLType.String,
-                    outputBinding = { Glob = Some "*.txt" },
+                    outputBinding = OutputBinding.create(glob = "*.txt"),
                     outputSource = OutputSource.Single "step/out"
                 )
             output.Type_ <- None
@@ -119,6 +120,49 @@ let testOutputMutationApi =
             Expect.isNone output.Type_ "Type_ should be removable."
             Expect.isNone output.OutputBinding "OutputBinding should be removable."
             Expect.isNone output.OutputSource "OutputSource should be removable."
+
+        testCase "constructor normalizes empty outputSource collections" <| fun _ ->
+            let output = CWLOutput("result", outputSource = OutputSource.Multiple (ResizeArray()))
+            Expect.isNone output.OutputSource "Empty outputSource collections should normalize to None."
+
+        testCase "known fields are typed fields, not dynamic overflow" <| fun _ ->
+            let binding = OutputBinding.create(glob = "*.txt", loadContents = true, loadListing = LoadListingEnum.DeepListing, outputEval = "$(self[0])")
+            let output =
+                CWLOutput(
+                    "result",
+                    type_ = CWLType.String,
+                    outputBinding = binding,
+                    outputSource = OutputSource.Single "step/out",
+                    label = "Result",
+                    doc = "Result docs",
+                    format = "edam:format_2330",
+                    streamable = true
+                )
+
+            Expect.sequenceEqual OutputBinding.KnownFieldNames (ResizeArray [| "loadContents"; "loadListing"; "glob"; "outputEval" |]) "OutputBinding known fields should be declared on the type."
+            Expect.sequenceEqual CWLOutput.KnownFieldNames (ResizeArray [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "outputBinding"; "outputSource" |]) "CWLOutput known fields should be declared on the type."
+            Expect.isEmpty (binding |> DynamicObjHelpers.dynamicPropertiesSnapshot) "OutputBinding known fields should not be stored as dynamic properties."
+            Expect.isEmpty (output |> DynamicObjHelpers.dynamicPropertiesSnapshot) "CWLOutput known fields should not be stored as dynamic properties."
+
+            DynObj.setProperty "arc:note" "keep overflow" output
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" output) (Some "keep overflow") "Unknown fields should still use DynamicObj overflow."
+
+        testCase "spec output fields decode as typed members regardless of order" <| fun _ ->
+            let output =
+                TestObjects.CWL.Outputs.specOutputFieldsDecodeFileContent
+                |> Decode.read
+                |> Decode.outputsDecoder
+                |> fun outputs -> outputs.[0]
+
+            Expect.equal output.Label (Some "Result") "label should decode to a typed field."
+            Expect.equal output.Doc (Some "Result docs") "doc should decode to a typed field."
+            Expect.equal output.Format (Some "edam:format_2330") "format should decode to a typed field."
+            Expect.equal output.Streamable (Some true) "streamable should decode to a typed field."
+            Expect.isSome output.SecondaryFiles "secondaryFiles should decode to a typed field."
+            Expect.equal output.OutputBinding.Value.LoadContents (Some true) "outputBinding.loadContents should decode to a typed field."
+            Expect.equal output.OutputBinding.Value.LoadListing (Some LoadListingEnum.DeepListing) "outputBinding.loadListing should decode to a typed field."
+            Expect.equal output.OutputBinding.Value.OutputEval (Some "$(self[0])") "outputBinding.outputEval should decode to a typed field."
+            Expect.isEmpty (output |> DynamicObjHelpers.dynamicPropertiesSnapshot) "Known output fields should not be overflow."
     ]
 
 let main = 

--- a/tests/CWL/Outputs.Tests.fs
+++ b/tests/CWL/Outputs.Tests.fs
@@ -139,8 +139,8 @@ let testOutputMutationApi =
                     streamable = true
                 )
 
-            Expect.sequenceEqual OutputBinding.KnownFieldNames (ResizeArray [| "loadContents"; "loadListing"; "glob"; "outputEval" |]) "OutputBinding known fields should be declared on the type."
-            Expect.sequenceEqual CWLOutput.KnownFieldNames (ResizeArray [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "outputBinding"; "outputSource" |]) "CWLOutput known fields should be declared on the type."
+            Expect.sequenceEqual OutputBinding.KnownFieldNames (Set [| "loadContents"; "loadListing"; "glob"; "outputEval" |]) "OutputBinding known fields should be declared on the type."
+            Expect.sequenceEqual CWLOutput.KnownFieldNames (Set [| "id"; "type"; "label"; "secondaryFiles"; "streamable"; "doc"; "format"; "outputBinding"; "outputSource" |]) "CWLOutput known fields should be declared on the type."
             Expect.isEmpty (binding |> DynamicObjHelpers.dynamicPropertiesSnapshot) "OutputBinding known fields should not be stored as dynamic properties."
             Expect.isEmpty (output |> DynamicObjHelpers.dynamicPropertiesSnapshot) "CWLOutput known fields should not be stored as dynamic properties."
 

--- a/tests/CWL/Requirements.Tests.fs
+++ b/tests/CWL/Requirements.Tests.fs
@@ -156,9 +156,7 @@ outputs: {}"""
 
             testCase "Encode emits expressionLib when present" <| fun _ ->
                 let requirement =
-                    InlineJavascriptRequirement {
-                        ExpressionLib = Some (ResizeArray [| "$(function() { return 1; })" |])
-                    }
+                    InlineJavascriptRequirement (InlineJavascriptRequirementValue(expressionLib = ResizeArray [| "$(function() { return 1; })" |]))
                 let encoded = Encode.encodeRequirement requirement |> Encode.writeYaml
                 Expect.stringContains encoded "class: InlineJavascriptRequirement" "Encoded output should include class"
                 Expect.stringContains encoded "expressionLib" "Encoded output should include expressionLib"
@@ -169,7 +167,7 @@ outputs: {}"""
                 Expect.isFalse (encoded.Contains("expressionLib")) "Encoded output should omit expressionLib when absent"
 
             testCase "Encode omits expressionLib when empty" <| fun _ ->
-                let requirement = InlineJavascriptRequirement { ExpressionLib = Some (ResizeArray()) }
+                let requirement = InlineJavascriptRequirement (InlineJavascriptRequirementValue(expressionLib = ResizeArray()))
                 let encoded = Encode.encodeRequirement requirement |> Encode.writeYaml
                 Expect.isFalse (encoded.Contains("expressionLib")) "Encoded output should omit expressionLib for empty arrays"
         ]
@@ -217,6 +215,36 @@ outputs: {}"""
                     Expect.stringContains encoded "--gpus=all" "Encoded hint should keep cwltool docker run option values."
                 | _ ->
                     failwith "Expected DockerRequirement hint"
+
+            testCase "Unknown DockerRequirement payload fields stay on payload and roundtrip" <| fun _ ->
+                let yaml = """requirements:
+  - class: DockerRequirement
+    dockerPull: ubuntu:24.04
+    arc:note: keep docker note"""
+                let reqs = decodeRequirements yaml
+                let requirement = findRequirement reqs (function DockerRequirement _ -> true | _ -> false)
+                match requirement with
+                | DockerRequirement dockerRequirement ->
+                    Expect.equal
+                        (DynObj.tryGetTypedPropertyValue<string> "arc:note" dockerRequirement)
+                        (Some "keep docker note")
+                        "Unknown DockerRequirement fields should be stored on the DockerRequirement payload."
+                    let encoded = Encode.encodeRequirement requirement |> Encode.writeYaml
+                    let document = "requirements:\n  - " + encoded.Replace("\n", "\n    ")
+                    let roundTripped =
+                        Decode.read document
+                        |> Decode.requirementsDecoder
+                        |> Option.get
+                        |> fun reqs -> findRequirement reqs (function DockerRequirement _ -> true | _ -> false)
+                    match roundTripped with
+                    | DockerRequirement roundTrippedDocker ->
+                        Expect.equal
+                            (DynObj.tryGetTypedPropertyValue<string> "arc:note" roundTrippedDocker)
+                            (Some "keep docker note")
+                            "Unknown DockerRequirement fields should survive encode/decode."
+                    | _ -> failwith "Expected DockerRequirement after roundtrip"
+                | _ ->
+                    failwith "Expected DockerRequirement"
         ]
         testList "InitialWorkDirRequirement" [
             testCase "Class Syntax" <| fun _ ->
@@ -225,8 +253,8 @@ outputs: {}"""
                 let expected =
                     InitialWorkDirRequirement (
                         ResizeArray [|
-                            DirentEntry { Entryname = Some (SchemaSaladString.Literal "arc"); Entry = SchemaSaladString.Literal "$(inputs.arcDirectory)"; Writable = Some true }
-                            DirentEntry { Entryname = None; Entry = SchemaSaladString.Literal "$(inputs.outputDirectory)"; Writable = Some true }
+                            DirentEntry (DirentInstance(SchemaSaladString.Literal "$(inputs.arcDirectory)", entryname = SchemaSaladString.Literal "arc", writable = true))
+                            DirentEntry (DirentInstance(SchemaSaladString.Literal "$(inputs.outputDirectory)", writable = true))
                         |]
                     )
                 let actual = initialWorkDirItem
@@ -241,8 +269,8 @@ outputs: {}"""
                 let expected =
                     InitialWorkDirRequirement (
                         ResizeArray [|
-                            DirentEntry { Entryname = Some (SchemaSaladString.Literal "arc"); Entry = SchemaSaladString.Literal "$(inputs.arcDirectory)"; Writable = Some true }
-                            DirentEntry { Entryname = None; Entry = SchemaSaladString.Literal "$(inputs.outputDirectory)"; Writable = Some true }
+                            DirentEntry (DirentInstance(SchemaSaladString.Literal "$(inputs.arcDirectory)", entryname = SchemaSaladString.Literal "arc", writable = true))
+                            DirentEntry (DirentInstance(SchemaSaladString.Literal "$(inputs.outputDirectory)", writable = true))
                         |]
                     )
                 let actual = initialWorkDirItem
@@ -257,8 +285,8 @@ outputs: {}"""
                 let expected =
                     InitialWorkDirRequirement (
                         ResizeArray [|
-                            DirentEntry { Entryname = Some (SchemaSaladString.Literal "arc"); Entry = SchemaSaladString.Literal "$(inputs.arcDirectory)"; Writable = Some true }
-                            DirentEntry { Entryname = None; Entry = SchemaSaladString.Literal "$(inputs.outputDirectory)"; Writable = Some true }
+                            DirentEntry (DirentInstance(SchemaSaladString.Literal "$(inputs.arcDirectory)", entryname = SchemaSaladString.Literal "arc", writable = true))
+                            DirentEntry (DirentInstance(SchemaSaladString.Literal "$(inputs.outputDirectory)", writable = true))
                         |]
                     )
                 let actual = initialWorkDirItem
@@ -336,11 +364,7 @@ outputs: {}"""
                 | InitialWorkDirRequirement listing ->
                     let expected =
                         ResizeArray [|
-                            DirentEntry {
-                                Entry = SchemaSaladString.Include "scripts/bootstrap.sh"
-                                Entryname = Some (SchemaSaladString.Literal "script-name.txt")
-                                Writable = None
-                            }
+                            DirentEntry (DirentInstance(SchemaSaladString.Include "scripts/bootstrap.sh", entryname = SchemaSaladString.Literal "script-name.txt"))
                         |]
                     Expect.sequenceEqual listing expected "Dirent entry include wrapper should preserve directive kind."
                 | _ ->
@@ -370,7 +394,7 @@ outputs: {}"""
             testCase "Class Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsClassFileContent
                 let envVarItem = findRequirement reqs (function EnvVarRequirement _ -> true | _ -> false)
-                let expected = EnvVarRequirement (ResizeArray [|{EnvName = "DOTNET_NOLOGO"; EnvValue = "true"}; {EnvName = "TEST"; EnvValue = "false"}|])
+                let expected = EnvVarRequirement (ResizeArray [| EnvironmentDef("DOTNET_NOLOGO", "true"); EnvironmentDef("TEST", "false") |])
                 let actual = envVarItem
                 match actual, expected with
                 | EnvVarRequirement a, EnvVarRequirement e ->
@@ -380,7 +404,7 @@ outputs: {}"""
             testCase "Mapping Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsMappingFileContent
                 let envVarItem = findRequirement reqs (function EnvVarRequirement _ -> true | _ -> false)
-                let expected = EnvVarRequirement (ResizeArray [|{EnvName = "DOTNET_NOLOGO"; EnvValue = "true"}; {EnvName = "TEST"; EnvValue = "false"}|])
+                let expected = EnvVarRequirement (ResizeArray [| EnvironmentDef("DOTNET_NOLOGO", "true"); EnvironmentDef("TEST", "false") |])
                 let actual = envVarItem
                 match actual, expected with
                 | EnvVarRequirement a, EnvVarRequirement e ->
@@ -390,7 +414,7 @@ outputs: {}"""
             testCase "Json Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsJSONFileContent
                 let envVarItem = findRequirement reqs (function EnvVarRequirement _ -> true | _ -> false)
-                let expected = EnvVarRequirement (ResizeArray [|{EnvName = "DOTNET_NOLOGO"; EnvValue = "true"}; {EnvName = "TEST"; EnvValue = "false"}|])
+                let expected = EnvVarRequirement (ResizeArray [| EnvironmentDef("DOTNET_NOLOGO", "true"); EnvironmentDef("TEST", "false") |])
                 let actual = envVarItem
                 match actual, expected with
                 | EnvVarRequirement a, EnvVarRequirement e ->
@@ -407,7 +431,7 @@ outputs: {}"""
                 let envVarItem = findRequirement reqs (function EnvVarRequirement _ -> true | _ -> false)
                 match envVarItem with
                 | EnvVarRequirement envs ->
-                    let expected = ResizeArray [|{EnvName = "DOTNET_NOLOGO"; EnvValue = "true"}; {EnvName = "TEST"; EnvValue = "false"}|]
+                    let expected = ResizeArray [| EnvironmentDef("DOTNET_NOLOGO", "true"); EnvironmentDef("TEST", "false") |]
                     Expect.sequenceEqual envs expected "EnvVar map shorthand should decode to normalized EnvironmentDef list."
                 | _ ->
                     failwith "Wrong requirement type: expected EnvVarRequirement"
@@ -441,7 +465,7 @@ outputs: {}"""
                 Expect.stringContains encoded "envValue: \"true\"" "Boolean-like strings should remain quoted in default array encoder"
 
             testCase "Compact map encode helper emits envDef map" <| fun _ ->
-                let envs = ResizeArray [|{ EnvName = "DOTNET_NOLOGO"; EnvValue = "true" }; { EnvName = "TEST"; EnvValue = "false" }|]
+                let envs = ResizeArray [| EnvironmentDef("DOTNET_NOLOGO", "true"); EnvironmentDef("TEST", "false") |]
                 let encoded = Encode.encodeEnvVarRequirementCompactMap envs |> Encode.writeYaml
                 Expect.stringContains encoded "class: EnvVarRequirement" "EnvVar compact helper should emit class"
                 Expect.stringContains encoded "envDef:" "EnvVar compact helper should emit envDef map"
@@ -451,7 +475,7 @@ outputs: {}"""
             testCase "Class Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsClassFileContent
                 let softwareItem = findRequirement reqs (function SoftwareRequirement _ -> true | _ -> false)
-                let expected = SoftwareRequirement (ResizeArray [|{Package = "interproscan"; Specs = Some (ResizeArray [| "https://identifiers.org/rrid/RRID:SCR_005829" |]); Version = Some (ResizeArray[| "5.21-60" |])}|])
+                let expected = SoftwareRequirement (ResizeArray [| SoftwarePackage("interproscan", version = ResizeArray [| "5.21-60" |], specs = ResizeArray [| "https://identifiers.org/rrid/RRID:SCR_005829" |]) |])
                 let actual = softwareItem
                 match actual, expected with
                 | SoftwareRequirement actualType, SoftwareRequirement expectedType ->
@@ -465,7 +489,7 @@ outputs: {}"""
             testCase "Mapping Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsMappingFileContent
                 let softwareItem = findRequirement reqs (function SoftwareRequirement _ -> true | _ -> false)
-                let expected = SoftwareRequirement (ResizeArray [|{Package = "interproscan"; Specs = Some (ResizeArray [| "https://identifiers.org/rrid/RRID:SCR_005829" |]); Version = Some (ResizeArray[| "5.21-60" |])}|])
+                let expected = SoftwareRequirement (ResizeArray [| SoftwarePackage("interproscan", version = ResizeArray [| "5.21-60" |], specs = ResizeArray [| "https://identifiers.org/rrid/RRID:SCR_005829" |]) |])
                 let actual = softwareItem
                 match actual, expected with
                 | SoftwareRequirement actualType, SoftwareRequirement expectedType ->
@@ -479,7 +503,7 @@ outputs: {}"""
             testCase "Json Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsJSONFileContent
                 let softwareItem = findRequirement reqs (function SoftwareRequirement _ -> true | _ -> false)
-                let expected = SoftwareRequirement (ResizeArray [|{Package = "interproscan"; Specs = Some (ResizeArray [| "https://identifiers.org/rrid/RRID:SCR_005829" |]); Version = Some (ResizeArray[| "5.21-60" |])}|])
+                let expected = SoftwareRequirement (ResizeArray [| SoftwarePackage("interproscan", version = ResizeArray [| "5.21-60" |], specs = ResizeArray [| "https://identifiers.org/rrid/RRID:SCR_005829" |]) |])
                 let actual = softwareItem
                 match actual, expected with
                 | SoftwareRequirement actualType, SoftwareRequirement expectedType ->
@@ -564,11 +588,11 @@ outputs: {}"""
             testCase "Compact map encode helper emits packages map" <| fun _ ->
                 let packages =
                     ResizeArray [|
-                        {
-                            Package = "interproscan"
-                            Specs = Some (ResizeArray [| "https://identifiers.org/rrid/RRID:SCR_005829" |])
-                            Version = Some (ResizeArray [| "5.21-60" |])
-                        }
+                        SoftwarePackage(
+                            "interproscan",
+                            version = ResizeArray [| "5.21-60" |],
+                            specs = ResizeArray [| "https://identifiers.org/rrid/RRID:SCR_005829" |]
+                        )
                     |]
                 let encoded = Encode.encodeSoftwareRequirementCompactMap packages |> Encode.writeYaml
                 Expect.stringContains encoded "class: SoftwareRequirement" "Software compact helper should emit class"
@@ -579,19 +603,19 @@ outputs: {}"""
             testCase "Class Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsClassFileContent
                 let networkAccessItem = findRequirement reqs (function NetworkAccessRequirement _ -> true | _ -> false)
-                let expected = NetworkAccessRequirement { NetworkAccess = true }
+                let expected = NetworkAccessRequirement (NetworkAccessRequirementValue(true))
                 let actual = networkAccessItem
                 Expect.equal actual expected "Type of Decode Classs Syntax for NetworkAccess, Requirement can only be NetworkAccess"
             testCase "Mapping Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsMappingFileContent
                 let networkAccessItem = findRequirement reqs (function NetworkAccessRequirement _ -> true | _ -> false)
-                let expected = NetworkAccessRequirement { NetworkAccess = true }
+                let expected = NetworkAccessRequirement (NetworkAccessRequirementValue(true))
                 let actual = networkAccessItem
                 Expect.equal actual expected "Type of Decode Mapping Syntax for NetworkAccess, Requirement can only be NetworkAccess"
             testCase "Json Syntax" <| fun _ ->
                 let reqs = decodeRequirements TestObjects.CWL.Requirements.requirementsJSONFileContent
                 let networkAccessItem = findRequirement reqs (function NetworkAccessRequirement _ -> true | _ -> false)
-                let expected = NetworkAccessRequirement { NetworkAccess = true }
+                let expected = NetworkAccessRequirement (NetworkAccessRequirementValue(true))
                 let actual = networkAccessItem
                 Expect.equal actual expected "Type of Decode Json Syntax for NetworkAccess, Requirement can only be NetworkAccess"
         ]
@@ -646,7 +670,7 @@ outputs: {}"""
     loadListing: deep_listing"""
                 let reqs = decodeRequirements yaml
                 let requirement = findRequirement reqs (function LoadListingRequirement _ -> true | _ -> false)
-                let expected = LoadListingRequirement { LoadListing = DeepListing }
+                let expected = LoadListingRequirement (LoadListingRequirementValue(DeepListing))
                 Expect.equal requirement expected "Class-array syntax should decode LoadListingRequirement payload."
             testCase "Mapping Syntax" <| fun _ ->
                 let yaml = """requirements:
@@ -654,20 +678,20 @@ outputs: {}"""
     loadListing: shallow_listing"""
                 let reqs = decodeRequirements yaml
                 let requirement = findRequirement reqs (function LoadListingRequirement _ -> true | _ -> false)
-                let expected = LoadListingRequirement { LoadListing = ShallowListing }
+                let expected = LoadListingRequirement (LoadListingRequirementValue(ShallowListing))
                 Expect.equal requirement expected "Mapping syntax should decode LoadListingRequirement payload."
             testCase "Json Syntax" <| fun _ ->
                 let yaml = """requirements: { LoadListingRequirement: { loadListing: "no_listing" } }"""
                 let reqs = decodeRequirements yaml
                 let requirement = findRequirement reqs (function LoadListingRequirement _ -> true | _ -> false)
-                let expected = LoadListingRequirement { LoadListing = NoListing }
+                let expected = LoadListingRequirement (LoadListingRequirementValue(NoListing))
                 Expect.equal requirement expected "JSON object syntax should decode LoadListingRequirement payload."
             testCase "Default value when field omitted" <| fun _ ->
                 let yaml = """requirements:
   - class: LoadListingRequirement"""
                 let reqs = decodeRequirements yaml
                 let requirement = findRequirement reqs (function LoadListingRequirement _ -> true | _ -> false)
-                let expected = LoadListingRequirement { LoadListing = NoListing }
+                let expected = LoadListingRequirement (LoadListingRequirementValue(NoListing))
                 Expect.equal requirement expected "Missing loadListing should default to no_listing."
             testCase "Invalid value fails clearly" <| fun _ ->
                 let yaml = """requirements:
@@ -686,7 +710,7 @@ outputs: {}"""
                     "Non-canonical case should fail for loadListing values."
 
             testCase "Encode canonical loadListing symbol" <| fun _ ->
-                let requirement = LoadListingRequirement { LoadListing = ShallowListing }
+                let requirement = LoadListingRequirement (LoadListingRequirementValue(ShallowListing))
                 let encoded = Encode.encodeRequirement requirement |> Encode.writeYaml
                 Expect.stringContains encoded "loadListing: shallow_listing" "Enum should encode to canonical CWL symbol."
         ]
@@ -698,8 +722,8 @@ outputs: {}"""
                 let reqs = decodeRequirements yaml
                 let workReuse = findRequirement reqs (function WorkReuseRequirement _ -> true | _ -> false)
                 let inplace = findRequirement reqs (function InplaceUpdateRequirement _ -> true | _ -> false)
-                Expect.equal workReuse (WorkReuseRequirement { EnableReuse = true }) "WorkReuse without explicit payload should default to true."
-                Expect.equal inplace (InplaceUpdateRequirement { InplaceUpdate = true }) "InplaceUpdateRequirement without payload should default to true."
+                Expect.equal workReuse (WorkReuseRequirement (WorkReuseRequirementValue(true))) "WorkReuse without explicit payload should default to true."
+                Expect.equal inplace (InplaceUpdateRequirement (InplaceUpdateRequirementValue(true))) "InplaceUpdateRequirement without payload should default to true."
             testCase "WorkReuse, NetworkAccess, InplaceUpdate decode explicit false payloads" <| fun _ ->
                 let yaml = """requirements:
   - class: WorkReuse
@@ -712,9 +736,9 @@ outputs: {}"""
                 let workReuse = findRequirement reqs (function WorkReuseRequirement _ -> true | _ -> false)
                 let network = findRequirement reqs (function NetworkAccessRequirement _ -> true | _ -> false)
                 let inplace = findRequirement reqs (function InplaceUpdateRequirement _ -> true | _ -> false)
-                Expect.equal workReuse (WorkReuseRequirement { EnableReuse = false }) "WorkReuse enableReuse=false should decode."
-                Expect.equal network (NetworkAccessRequirement { NetworkAccess = false }) "NetworkAccess networkAccess=false should decode."
-                Expect.equal inplace (InplaceUpdateRequirement { InplaceUpdate = false }) "InplaceUpdateRequirement inplaceUpdate=false should decode."
+                Expect.equal workReuse (WorkReuseRequirement (WorkReuseRequirementValue(false))) "WorkReuse enableReuse=false should decode."
+                Expect.equal network (NetworkAccessRequirement (NetworkAccessRequirementValue(false))) "NetworkAccess networkAccess=false should decode."
+                Expect.equal inplace (InplaceUpdateRequirement (InplaceUpdateRequirementValue(false))) "InplaceUpdateRequirement inplaceUpdate=false should decode."
             testCase "WorkReuse and NetworkAccess accept expression payloads" <| fun _ ->
                 let yaml = """requirements:
   - class: WorkReuse
@@ -787,10 +811,10 @@ outputs: {}"""
                 let requirement = findRequirement reqs (function ResourceRequirement _ -> true | _ -> false)
                 match requirement with
                 | ResourceRequirement resourceRequirement ->
-                    let coresMin = resourceRequirement.GetPropertyValue("coresMin") |> unbox<obj option> |> Option.get |> unbox<int64>
-                    let coresMax = resourceRequirement.GetPropertyValue("coresMax") |> unbox<obj option> |> Option.get |> unbox<int64>
-                    let ramMin = resourceRequirement.GetPropertyValue("ramMin") |> unbox<obj option> |> Option.get |> unbox<float>
-                    let outdirMin = resourceRequirement.GetPropertyValue("outdirMin") |> unbox<obj option> |> Option.get |> unbox<string>
+                    let coresMin = resourceRequirement.CoresMin.Value :?> int64
+                    let coresMax = resourceRequirement.CoresMax.Value :?> int64
+                    let ramMin = resourceRequirement.RamMin.Value :?> float
+                    let outdirMin = resourceRequirement.OutdirMin.Value :?> string
                     Expect.equal coresMin 2L "coresMin should decode to int64"
                     Expect.equal coresMax 922337203685477580L "coresMax should decode to int64"
                     Expect.equal ramMin 4.5 "ramMin should decode to float"
@@ -801,9 +825,45 @@ outputs: {}"""
                 | _ ->
                     failwith "Expected ResourceRequirement"
 
-            testCase "Resource scalars roundtrip through encode and decode" <| fun _ ->
+            testCase "known fields are typed fields, not dynamic overflow" <| fun _ ->
+                let resourceRequirement =
+                    ResourceRequirementInstance(coresMin = 2L, ramMin = 4.5, outdirMin = "$(inputs.outdir_min)")
+
+                Expect.sequenceEqual
+                    ResourceRequirementInstance.KnownFieldNames
+                    (ResizeArray [| "class"; "coresMin"; "coresMax"; "ramMin"; "ramMax"; "tmpdirMin"; "tmpdirMax"; "outdirMin"; "outdirMax" |])
+                    "ResourceRequirement known fields should be declared on the type."
+                Expect.isEmpty
+                    (resourceRequirement |> DynamicObjHelpers.dynamicPropertiesSnapshot)
+                    "ResourceRequirement known fields should not be stored as dynamic properties."
+                Expect.equal (resourceRequirement.TryGetInt64("coresMin")) (Some 2L) "Typed int64 getter should read known field."
+                Expect.equal (resourceRequirement.TryGetFloat("ramMin")) (Some 4.5) "Typed float getter should read known field."
+                Expect.equal (resourceRequirement.TryGetExpression("outdirMin")) (Some "$(inputs.outdir_min)") "Typed expression getter should read known field."
+
+                DynObj.setProperty "arc:note" "keep overflow" resourceRequirement
+                Expect.equal
+                    (DynObj.tryGetTypedPropertyValue<string> "arc:note" resourceRequirement)
+                    (Some "keep overflow")
+                    "Unknown fields should still use DynamicObj overflow."
+
+            testCase "DynamicObj values with known resource keys are not treated as typed fields" <| fun _ ->
                 let resourceRequirement = ResourceRequirementInstance()
-                DynObj.setProperty "coresMin" (Some (box 2L)) resourceRequirement
+                DynObj.setProperty "coresMin" (box 99L) resourceRequirement
+                DynObj.setProperty "arc:note" "keep overflow" resourceRequirement
+
+                Expect.equal
+                    (resourceRequirement.TryGetInt64("coresMin"))
+                    None
+                    "Typed getters should not read known resource fields from DynamicObj storage."
+
+                let yaml = Encode.encodeRequirement (ResourceRequirement resourceRequirement) |> Encode.writeYaml
+                Expect.isFalse
+                    (yaml.Contains("coresMin"))
+                    "Encoding should not emit known resource fields from DynamicObj storage."
+                Expect.stringContains yaml "arc:note" "Unknown overflow should still be encoded."
+
+            testCase "Resource scalars roundtrip through encode and decode" <| fun _ ->
+                let resourceRequirement = ResourceRequirementInstance(coresMin = 2L)
                 let requirement = ResourceRequirement resourceRequirement
                 let encodedElement = Encode.encodeRequirement requirement
                 let roundtripped =
@@ -812,9 +872,8 @@ outputs: {}"""
 
                 match requirement, roundtripped with
                 | ResourceRequirement original, ResourceRequirement roundtrip ->
-                    let originalCoresMin = original.GetPropertyValue("coresMin") |> unbox<obj option> |> Option.get |> unbox<int64>
-
-                    let roundtripCoresMin = roundtrip.GetPropertyValue("coresMin") |> unbox<obj option> |> Option.get |> unbox<int64>
+                    let originalCoresMin = original.CoresMin.Value :?> int64
+                    let roundtripCoresMin = roundtrip.CoresMin.Value :?> int64
 
                     Expect.equal roundtripCoresMin originalCoresMin "coresMin should roundtrip as int64"
                 | _ ->
@@ -831,7 +890,7 @@ outputs: {}"""
                 let requirement = findRequirement reqs (function SchemaDefRequirement _ -> true | _ -> false)
                 match requirement with
                 | SchemaDefRequirement definitions ->
-                    let expected = ResizeArray [| { Name = "SampleId"; Type_ = CWLType.String } |]
+                    let expected = ResizeArray [| SchemaDefRequirementType("SampleId", CWLType.String) |]
                     Expect.sequenceEqual definitions expected "Legacy map-style schema definitions should decode into explicit schema-def entries."
                 | _ ->
                     failwith "Expected SchemaDefRequirement"
@@ -902,7 +961,7 @@ let testRequirementEncode =
                 let listing =
                     ResizeArray [|
                         StringEntry (SchemaSaladString.Literal "$(inputs.stageDirectory)")
-                        DirentEntry { Entry = SchemaSaladString.Literal "$(inputs.outputDirectory)"; Entryname = Some (SchemaSaladString.Literal "outdir"); Writable = Some true }
+                        DirentEntry (DirentInstance(SchemaSaladString.Literal "$(inputs.outputDirectory)", entryname = SchemaSaladString.Literal "outdir", writable = true))
                     |]
                 let req = InitialWorkDirRequirement listing
                 let yaml = Encode.encodeRequirement req |> Encode.writeYaml
@@ -922,7 +981,7 @@ let testRequirementEncode =
                     ResizeArray [|
                         StringEntry (SchemaSaladString.Include "scripts/load.js")
                         StringEntry (SchemaSaladString.Import "scripts/manifest.yml")
-                        DirentEntry { Entry = SchemaSaladString.Include "scripts/bootstrap.sh"; Entryname = Some (SchemaSaladString.Import "scripts/name.txt"); Writable = Some false }
+                        DirentEntry (DirentInstance(SchemaSaladString.Include "scripts/bootstrap.sh", entryname = SchemaSaladString.Import "scripts/name.txt", writable = false))
                     |]
                 let req = InitialWorkDirRequirement listing
                 let yaml = Encode.encodeRequirement req |> Encode.writeYaml
@@ -1012,7 +1071,7 @@ let testRequirementEncode =
                     |> Option.get
                 Expect.equal decoded.[0] requirement "dockerFile $import directive should roundtrip."
             testCase "LoadListingRequirement roundtrips" <| fun _ ->
-                let requirement = LoadListingRequirement { LoadListing = DeepListing }
+                let requirement = LoadListingRequirement (LoadListingRequirementValue(DeepListing))
                 let yaml = Encode.encodeRequirement requirement |> Encode.writeYaml
                 let document = "requirements:\n  - " + yaml.Replace("\n", "\n    ")
                 let decoded =
@@ -1023,9 +1082,9 @@ let testRequirementEncode =
             testCase "WorkReuse/NetworkAccess/InplaceUpdate payloads roundtrip" <| fun _ ->
                 let requirements =
                     ResizeArray [|
-                        WorkReuseRequirement { EnableReuse = false }
-                        NetworkAccessRequirement { NetworkAccess = false }
-                        InplaceUpdateRequirement { InplaceUpdate = false }
+                        WorkReuseRequirement (WorkReuseRequirementValue(false))
+                        NetworkAccessRequirement (NetworkAccessRequirementValue(false))
+                        InplaceUpdateRequirement (InplaceUpdateRequirementValue(false))
                     |]
                 let encodedLines =
                     requirements
@@ -1048,7 +1107,7 @@ let testRequirementEncode =
                 Expect.equal decoded.[0] requirement "Expression timelimit should roundtrip."
             testCase "SchemaDefRequirement roundtrips with explicit typed representation" <| fun _ ->
                 let requirement =
-                    SchemaDefRequirement (ResizeArray [| { Name = "SampleId"; Type_ = CWLType.String } |])
+                    SchemaDefRequirement (ResizeArray [| SchemaDefRequirementType("SampleId", CWLType.String) |])
                 let yaml = Encode.encodeRequirement requirement |> Encode.writeYaml
                 Expect.stringContains yaml "name: SampleId" "SchemaDefRequirement should encode canonical name field."
                 Expect.stringContains yaml "type: string" "SchemaDefRequirement should encode canonical type field."
@@ -1060,7 +1119,7 @@ let testRequirementEncode =
                     |> Option.get
                 match decoded.[0] with
                 | SchemaDefRequirement definitions ->
-                    let expected = ResizeArray [| { Name = "SampleId"; Type_ = CWLType.String } |]
+                    let expected = ResizeArray [| SchemaDefRequirementType("SampleId", CWLType.String) |]
                     Expect.sequenceEqual definitions expected "SchemaDefRequirement should roundtrip with explicit Name/Type_ entries."
                 | _ ->
                     failwith "Expected SchemaDefRequirement"
@@ -1092,10 +1151,8 @@ let testInitialWorkDirFileDirectoryEntries =
                 failwith "Wrong requirement type: expected InitialWorkDirRequirement"
 
         testCase "Encode mixed listing with File and Directory entries" <| fun _ ->
-            let file = FileInstance()
-            DynObj.setProperty "path" "/tmp/input.txt" file
-            let directory = DirectoryInstance()
-            DynObj.setProperty "path" "/tmp/output" directory
+            let file = FileInstance(path = "/tmp/input.txt", basename = "input.txt")
+            let directory = DirectoryInstance(path = "/tmp/output", basename = "output")
             let requirement =
                 InitialWorkDirRequirement (
                     ResizeArray [|
@@ -1108,6 +1165,193 @@ let testInitialWorkDirFileDirectoryEntries =
             Expect.stringContains encoded "class: InitialWorkDirRequirement" "Encoded output should include requirement class"
             Expect.stringContains encoded "class: File" "Encoded output should include File listing entry"
             Expect.stringContains encoded "class: Directory" "Encoded output should include Directory listing entry"
+
+        testCase "File and Directory listing object fields decode as typed members" <| fun _ ->
+            let reqs = decodeRequirements TestObjects.CWL.Requirements.initialWorkDirListingTypedFileContent
+            match findRequirement reqs (function InitialWorkDirRequirement _ -> true | _ -> false) with
+            | InitialWorkDirRequirement listing ->
+                match listing.[0], listing.[1] with
+                | FileEntry file, DirectoryEntry directory ->
+                    Expect.equal file.Path (Some "/tmp/in.txt") "File path should decode as a typed field."
+                    Expect.equal file.Basename (Some "in.txt") "File basename should decode as a typed field."
+                    Expect.equal file.Checksum (Some "sha1$abc") "File checksum should decode as a typed field."
+                    Expect.equal file.Size (Some 42L) "File size should decode as a typed field."
+                    Expect.equal directory.Path (Some "/tmp/out") "Directory path should decode as a typed field."
+                    Expect.equal directory.Basename (Some "out") "Directory basename should decode as a typed field."
+                    Expect.isSome directory.Listing "Directory listing should decode as a typed field."
+                    Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:file note" file) (Some "keep file overflow") "File extension should remain overflow."
+                    Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:dir note" directory) (Some "keep dir overflow") "Directory extension should remain overflow."
+                    Expect.isNone (DynObj.tryGetTypedPropertyValue<string> "path" file) "Known File fields should not be overflow."
+                    Expect.isNone (DynObj.tryGetTypedPropertyValue<string> "path" directory) "Known Directory fields should not be overflow."
+                | _ -> failwith "Expected File and Directory entries"
+            | _ ->
+                failwith "Expected InitialWorkDirRequirement"
+    ]
+
+let testDynamicPayloadModel =
+    testList "DynamicObj payload model" [
+        testCase "CWL schema payloads keep known fields typed and overflow dynamic" <| fun _ ->
+            let field = InputRecordField("sampleName", CWLType.String, doc = "field docs", label = "Sample")
+            let recordSchema = InputRecordSchema(fields = ResizeArray [| field |], doc = "record docs", name = "SampleRecord")
+            let arraySchema = InputArraySchema(CWLType.Record recordSchema, label = "array label")
+            let enumSchema = InputEnumSchema(ResizeArray [| "A"; "B" |], name = "Choice")
+            let dirent = DirentInstance(SchemaSaladString.Literal "$(inputs.sample)", entryname = SchemaSaladString.Literal "sample.txt")
+            let schemaDef = SchemaDefRequirementType("SampleRecord", CWLType.Record recordSchema)
+            let package = SoftwarePackage("samtools", version = ResizeArray [| "1.19" |])
+
+            Expect.sequenceEqual InputRecordField.KnownFieldNames (ResizeArray [| "name"; "type"; "doc"; "label" |]) ""
+            Expect.sequenceEqual InputRecordSchema.KnownFieldNames (ResizeArray [| "type"; "fields"; "label"; "doc"; "name" |]) ""
+            Expect.sequenceEqual InputArraySchema.KnownFieldNames (ResizeArray [| "type"; "items"; "label"; "doc"; "name" |]) ""
+            Expect.sequenceEqual InputEnumSchema.KnownFieldNames (ResizeArray [| "type"; "symbols"; "label"; "doc"; "name" |]) ""
+            Expect.sequenceEqual DirentInstance.KnownFieldNames (ResizeArray [| "entry"; "entryname"; "writable" |]) ""
+            Expect.sequenceEqual SchemaDefRequirementType.KnownFieldNames (ResizeArray [| "name"; "type" |]) ""
+            Expect.sequenceEqual SoftwarePackage.KnownFieldNames (ResizeArray [| "package"; "version"; "specs" |]) ""
+
+            for dynObj in [
+                field :> DynamicObj
+                recordSchema :> DynamicObj
+                arraySchema :> DynamicObj
+                enumSchema :> DynamicObj
+                dirent :> DynamicObj
+                schemaDef :> DynamicObj
+                package :> DynamicObj
+            ] do
+                Expect.equal (dynObj |> DynamicObjHelpers.dynamicPropertiesSnapshot |> Seq.length) 0 "Known fields should not be stored in dynamic overflow."
+                DynObj.setProperty "arc:note" "keep me" dynObj
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" dynObj) (Some "keep me") "Unknown fields should stay in dynamic overflow."
+
+        testCase "requirement payloads keep known fields typed and overflow dynamic" <| fun _ ->
+            let docker = DockerRequirement.create(dockerPull = "ubuntu:24.04")
+            let env = EnvironmentDef("PATH", "/usr/bin")
+            let loadListing = LoadListingRequirementValue(DeepListing)
+            let workReuse = WorkReuseRequirementValue(false)
+            let network = NetworkAccessRequirementValue(false)
+            let inplace = InplaceUpdateRequirementValue(false)
+            let inlineJs = InlineJavascriptRequirementValue(expressionLib = ResizeArray [| "helper.js" |])
+            let unknownHint = HintUnknownValue(Some "acme:Hint", Decode.read "class: acme:Hint")
+
+            Expect.sequenceEqual DockerRequirement.KnownFieldNames (ResizeArray [| "class"; "dockerPull"; "dockerFile"; "dockerImageId"; "dockerLoad"; "dockerImport"; "dockerOutputDirectory"; "cwltool:dockerRunOptions" |]) ""
+            Expect.sequenceEqual EnvironmentDef.KnownFieldNames (ResizeArray [| "envName"; "envValue" |]) ""
+            Expect.sequenceEqual LoadListingRequirementValue.KnownFieldNames (ResizeArray [| "class"; "loadListing" |]) ""
+            Expect.sequenceEqual WorkReuseRequirementValue.KnownFieldNames (ResizeArray [| "class"; "enableReuse" |]) ""
+            Expect.sequenceEqual NetworkAccessRequirementValue.KnownFieldNames (ResizeArray [| "class"; "networkAccess" |]) ""
+            Expect.sequenceEqual InplaceUpdateRequirementValue.KnownFieldNames (ResizeArray [| "class"; "inplaceUpdate" |]) ""
+            Expect.sequenceEqual InlineJavascriptRequirementValue.KnownFieldNames (ResizeArray [| "class"; "expressionLib" |]) ""
+            Expect.sequenceEqual HintUnknownValue.KnownFieldNames (ResizeArray [| "class"; "raw" |]) ""
+
+            for dynObj in [
+                docker :> DynamicObj
+                env :> DynamicObj
+                loadListing :> DynamicObj
+                workReuse :> DynamicObj
+                network :> DynamicObj
+                inplace :> DynamicObj
+                inlineJs :> DynamicObj
+                unknownHint :> DynamicObj
+            ] do
+                Expect.equal (dynObj |> DynamicObjHelpers.dynamicPropertiesSnapshot |> Seq.length) 0 "Known fields should not be stored in dynamic overflow."
+                DynObj.setProperty "arc:note" "keep me" dynObj
+                Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" dynObj) (Some "keep me") "Unknown fields should stay in dynamic overflow."
+    ]
+
+let testRequirementDynamicOverflowRoundtrip =
+    let encodeDecodeRequirement requirement =
+        let encoded = Encode.encodeRequirement requirement |> Encode.writeYaml
+        let document = "requirements:\n  - " + encoded.Replace("\n", "\n    ")
+        let decoded =
+            Decode.read document
+            |> Decode.requirementsDecoder
+            |> Option.get
+        decoded.[0]
+
+    testList "Requirement DynamicObj overflow roundtrip" [
+        testCase "payload and nested entry overflow survives encode/decode" <| fun _ ->
+            let inlineJs = InlineJavascriptRequirementValue(expressionLib = ResizeArray [| "helper.js" |])
+            DynObj.setProperty "arc:inline note" "inline" inlineJs
+
+            let loadListing = LoadListingRequirementValue(DeepListing)
+            DynObj.setProperty "arc:load note" "load" loadListing
+
+            let workReuse = WorkReuseRequirementValue(false)
+            DynObj.setProperty "arc:reuse note" "reuse" workReuse
+
+            let network = NetworkAccessRequirementValue(true)
+            DynObj.setProperty "arc:network note" "network" network
+
+            let inplace = InplaceUpdateRequirementValue(true)
+            DynObj.setProperty "arc:inplace note" "inplace" inplace
+
+            let dirent = DirentInstance(SchemaSaladString.Literal "contents", entryname = SchemaSaladString.Literal "file.txt")
+            DynObj.setProperty "arc:dirent note" "dirent" dirent
+
+            let env = EnvironmentDef("ENV_NAME", "ENV_VALUE")
+            DynObj.setProperty "arc:env note" "env" env
+
+            let package = SoftwarePackage("samtools", version = ResizeArray [| "1.19" |])
+            DynObj.setProperty "arc:package note" "package" package
+
+            let recordField = InputRecordField("sample", CWLType.String)
+            DynObj.setProperty "arc:field note" "field" recordField
+            let recordSchema = InputRecordSchema(fields = ResizeArray [| recordField |], name = "SampleRecord")
+            DynObj.setProperty "arc:record note" "record" recordSchema
+            let schemaDef = SchemaDefRequirementType("SampleRecord", CWLType.Record recordSchema)
+            DynObj.setProperty "arc:schema note" "schema" schemaDef
+
+            let cases =
+                [
+                    InlineJavascriptRequirement inlineJs, fun requirement ->
+                        match requirement with
+                        | InlineJavascriptRequirement value -> DynObj.tryGetTypedPropertyValue<string> "arc:inline note" value
+                        | _ -> None
+                    LoadListingRequirement loadListing, fun requirement ->
+                        match requirement with
+                        | LoadListingRequirement value -> DynObj.tryGetTypedPropertyValue<string> "arc:load note" value
+                        | _ -> None
+                    WorkReuseRequirement workReuse, fun requirement ->
+                        match requirement with
+                        | WorkReuseRequirement value -> DynObj.tryGetTypedPropertyValue<string> "arc:reuse note" value
+                        | _ -> None
+                    NetworkAccessRequirement network, fun requirement ->
+                        match requirement with
+                        | NetworkAccessRequirement value -> DynObj.tryGetTypedPropertyValue<string> "arc:network note" value
+                        | _ -> None
+                    InplaceUpdateRequirement inplace, fun requirement ->
+                        match requirement with
+                        | InplaceUpdateRequirement value -> DynObj.tryGetTypedPropertyValue<string> "arc:inplace note" value
+                        | _ -> None
+                    InitialWorkDirRequirement (ResizeArray [| DirentEntry dirent |]), fun requirement ->
+                        match requirement with
+                        | InitialWorkDirRequirement listing ->
+                            match listing.[0] with
+                            | DirentEntry value -> DynObj.tryGetTypedPropertyValue<string> "arc:dirent note" value
+                            | _ -> None
+                        | _ -> None
+                    EnvVarRequirement (ResizeArray [| env |]), fun requirement ->
+                        match requirement with
+                        | EnvVarRequirement envs -> DynObj.tryGetTypedPropertyValue<string> "arc:env note" envs.[0]
+                        | _ -> None
+                    SoftwareRequirement (ResizeArray [| package |]), fun requirement ->
+                        match requirement with
+                        | SoftwareRequirement packages -> DynObj.tryGetTypedPropertyValue<string> "arc:package note" packages.[0]
+                        | _ -> None
+                    SchemaDefRequirement (ResizeArray [| schemaDef |]), fun requirement ->
+                        match requirement with
+                        | SchemaDefRequirement definitions ->
+                            match definitions.[0].Type_ with
+                            | CWLType.Record schema ->
+                                let field = schema.Fields.Value.[0]
+                                let wrapperOverflow = DynObj.tryGetTypedPropertyValue<string> "arc:schema note" definitions.[0]
+                                let schemaOverflow = DynObj.tryGetTypedPropertyValue<string> "arc:record note" schema
+                                let fieldOverflow = DynObj.tryGetTypedPropertyValue<string> "arc:field note" field
+                                if wrapperOverflow = Some "schema" && schemaOverflow = Some "record" && fieldOverflow = Some "field" then Some "schema"
+                                else None
+                            | _ -> None
+                        | _ -> None
+                ]
+
+            for requirement, getOverflow in cases do
+                let roundTripped = encodeDecodeRequirement requirement
+                Expect.isSome (getOverflow roundTripped) $"Overflow should survive for %A{requirement}."
     ]
 
 let main = 
@@ -1116,6 +1360,8 @@ let main =
         testDecodeAllRequirementSyntaxes
         testRequirementEncode
         testInitialWorkDirFileDirectoryEntries
+        testDynamicPayloadModel
+        testRequirementDynamicOverflowRoundtrip
     ]
 
 

--- a/tests/CWL/Requirements.Tests.fs
+++ b/tests/CWL/Requirements.Tests.fs
@@ -831,7 +831,7 @@ outputs: {}"""
 
                 Expect.sequenceEqual
                     ResourceRequirementInstance.KnownFieldNames
-                    (ResizeArray [| "class"; "coresMin"; "coresMax"; "ramMin"; "ramMax"; "tmpdirMin"; "tmpdirMax"; "outdirMin"; "outdirMax" |])
+                    (Set [| "class"; "coresMin"; "coresMax"; "ramMin"; "ramMax"; "tmpdirMin"; "tmpdirMax"; "outdirMin"; "outdirMax" |])
                     "ResourceRequirement known fields should be declared on the type."
                 Expect.isEmpty
                     (resourceRequirement |> DynamicObjHelpers.dynamicPropertiesSnapshot)
@@ -1202,13 +1202,13 @@ let testDynamicPayloadModel =
             let schemaDef = SchemaDefRequirementType("SampleRecord", CWLType.Record recordSchema)
             let package = SoftwarePackage("samtools", version = ResizeArray [| "1.19" |])
 
-            Expect.sequenceEqual InputRecordField.KnownFieldNames (ResizeArray [| "name"; "type"; "doc"; "label" |]) ""
-            Expect.sequenceEqual InputRecordSchema.KnownFieldNames (ResizeArray [| "type"; "fields"; "label"; "doc"; "name" |]) ""
-            Expect.sequenceEqual InputArraySchema.KnownFieldNames (ResizeArray [| "type"; "items"; "label"; "doc"; "name" |]) ""
-            Expect.sequenceEqual InputEnumSchema.KnownFieldNames (ResizeArray [| "type"; "symbols"; "label"; "doc"; "name" |]) ""
-            Expect.sequenceEqual DirentInstance.KnownFieldNames (ResizeArray [| "entry"; "entryname"; "writable" |]) ""
-            Expect.sequenceEqual SchemaDefRequirementType.KnownFieldNames (ResizeArray [| "name"; "type" |]) ""
-            Expect.sequenceEqual SoftwarePackage.KnownFieldNames (ResizeArray [| "package"; "version"; "specs" |]) ""
+            Expect.sequenceEqual InputRecordField.KnownFieldNames (Set [| "name"; "type"; "doc"; "label" |]) ""
+            Expect.sequenceEqual InputRecordSchema.KnownFieldNames (Set [| "type"; "fields"; "label"; "doc"; "name" |]) ""
+            Expect.sequenceEqual InputArraySchema.KnownFieldNames (Set [| "type"; "items"; "label"; "doc"; "name" |]) ""
+            Expect.sequenceEqual InputEnumSchema.KnownFieldNames (Set [| "type"; "symbols"; "label"; "doc"; "name" |]) ""
+            Expect.sequenceEqual DirentInstance.KnownFieldNames (Set [| "entry"; "entryname"; "writable" |]) ""
+            Expect.sequenceEqual SchemaDefRequirementType.KnownFieldNames (Set [| "name"; "type" |]) ""
+            Expect.sequenceEqual SoftwarePackage.KnownFieldNames (Set [| "package"; "version"; "specs" |]) ""
 
             for dynObj in [
                 field :> DynamicObj
@@ -1233,14 +1233,14 @@ let testDynamicPayloadModel =
             let inlineJs = InlineJavascriptRequirementValue(expressionLib = ResizeArray [| "helper.js" |])
             let unknownHint = HintUnknownValue(Some "acme:Hint", Decode.read "class: acme:Hint")
 
-            Expect.sequenceEqual DockerRequirement.KnownFieldNames (ResizeArray [| "class"; "dockerPull"; "dockerFile"; "dockerImageId"; "dockerLoad"; "dockerImport"; "dockerOutputDirectory"; "cwltool:dockerRunOptions" |]) ""
-            Expect.sequenceEqual EnvironmentDef.KnownFieldNames (ResizeArray [| "envName"; "envValue" |]) ""
-            Expect.sequenceEqual LoadListingRequirementValue.KnownFieldNames (ResizeArray [| "class"; "loadListing" |]) ""
-            Expect.sequenceEqual WorkReuseRequirementValue.KnownFieldNames (ResizeArray [| "class"; "enableReuse" |]) ""
-            Expect.sequenceEqual NetworkAccessRequirementValue.KnownFieldNames (ResizeArray [| "class"; "networkAccess" |]) ""
-            Expect.sequenceEqual InplaceUpdateRequirementValue.KnownFieldNames (ResizeArray [| "class"; "inplaceUpdate" |]) ""
-            Expect.sequenceEqual InlineJavascriptRequirementValue.KnownFieldNames (ResizeArray [| "class"; "expressionLib" |]) ""
-            Expect.sequenceEqual HintUnknownValue.KnownFieldNames (ResizeArray [| "class"; "raw" |]) ""
+            Expect.sequenceEqual DockerRequirement.KnownFieldNames (Set [| "class"; "dockerPull"; "dockerFile"; "dockerImageId"; "dockerLoad"; "dockerImport"; "dockerOutputDirectory"; "cwltool:dockerRunOptions" |]) ""
+            Expect.sequenceEqual EnvironmentDef.KnownFieldNames (Set [| "envName"; "envValue" |]) ""
+            Expect.sequenceEqual LoadListingRequirementValue.KnownFieldNames (Set [| "class"; "loadListing" |]) ""
+            Expect.sequenceEqual WorkReuseRequirementValue.KnownFieldNames (Set [| "class"; "enableReuse" |]) ""
+            Expect.sequenceEqual NetworkAccessRequirementValue.KnownFieldNames (Set [| "class"; "networkAccess" |]) ""
+            Expect.sequenceEqual InplaceUpdateRequirementValue.KnownFieldNames (Set [| "class"; "inplaceUpdate" |]) ""
+            Expect.sequenceEqual InlineJavascriptRequirementValue.KnownFieldNames (Set [| "class"; "expressionLib" |]) ""
+            Expect.sequenceEqual HintUnknownValue.KnownFieldNames (Set [| "class"; "raw" |]) ""
 
             for dynObj in [
                 docker :> DynamicObj

--- a/tests/CWL/Requirements.Tests.fs
+++ b/tests/CWL/Requirements.Tests.fs
@@ -863,7 +863,7 @@ outputs: {}"""
                 Expect.stringContains yaml "arc:note" "Unknown overflow should still be encoded."
 
             testCase "Resource scalars roundtrip through encode and decode" <| fun _ ->
-                let resourceRequirement = ResourceRequirementInstance(coresMin = 2L)
+                let resourceRequirement = ResourceRequirementInstance(coresMin = 2L, ramMin = 4.5)
                 let requirement = ResourceRequirement resourceRequirement
                 let encodedElement = Encode.encodeRequirement requirement
                 let roundtripped =
@@ -874,8 +874,11 @@ outputs: {}"""
                 | ResourceRequirement original, ResourceRequirement roundtrip ->
                     let originalCoresMin = original.CoresMin.Value :?> int64
                     let roundtripCoresMin = roundtrip.CoresMin.Value :?> int64
+                    let originalRamMin = original.RamMin.Value :?> float
+                    let roundtripRamMin = roundtrip.RamMin.Value :?> float
 
                     Expect.equal roundtripCoresMin originalCoresMin "coresMin should roundtrip as int64"
+                    Expect.equal roundtripRamMin originalRamMin "ramMin should roundtrip as float"
                 | _ ->
                     failwith "Expected ResourceRequirement in both original and roundtrip values"
 

--- a/tests/CWL/WorkflowSteps.Tests.fs
+++ b/tests/CWL/WorkflowSteps.Tests.fs
@@ -1,6 +1,7 @@
 module Tests.WorkflowSteps
 
 open ARCtrl.CWL
+open DynamicObj
 open YAMLicious
 open YAMLicious.YAMLiciousTypes
 open TestingUtils
@@ -17,18 +18,13 @@ let tryYamlScalarString (y: YAMLElement) =
     | _ -> None
 
 let mkStepInput id source defaultValue valueFrom linkMerge =
-    {
-        Id = id
-        Source = source
-        DefaultValue = defaultValue
-        ValueFrom = valueFrom
-        LinkMerge = linkMerge
-        PickValue = None
-        Doc = None
-        LoadContents = None
-        LoadListing = None
-        Label = None
-    }
+    StepInput.create(
+        id,
+        ?source = source,
+        ?defaultValue = defaultValue,
+        ?valueFrom = valueFrom,
+        ?linkMerge = linkMerge
+    )
 
 let testWorkflowStep =
     testList "Decode" [
@@ -179,6 +175,12 @@ let testWorkflowStep =
                 |> Decode.stepsDecoder
                 |> ignore
             Expect.throws decodeInvalid "Step output record without id should fail decoding"
+        testCase "step output parameter known fields are typed fields, not dynamic overflow" <| fun _ ->
+            let output = StepOutputParameter.create "out"
+            Expect.sequenceEqual StepOutputParameter.KnownFieldNames (ResizeArray [| "id" |]) "Step output known fields should be declared on the type."
+            Expect.isEmpty (output |> DynamicObjHelpers.dynamicPropertiesSnapshot) "Step output known fields should not be stored as dynamic properties."
+            DynObj.setProperty "arc:note" "keep overflow" output
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" output) (Some "keep overflow") "Unknown fields should still use DynamicObj overflow."
         testCase "tryGetTool returns None for wrong obj type" <| fun _ ->
             let run = RunCommandLineTool (box "not a tool")
             let actual = WorkflowStepRunOps.tryGetTool run
@@ -229,7 +231,10 @@ let testWorkflowStepOps =
                     runPath = "./tool.cwl"
                 )
 
-            WorkflowStep.updateInputAt 0 (fun i -> { i with Source = Some (ResizeArray [| "new" |]) }) step
+            WorkflowStep.updateInputAt 0 (fun i ->
+                i.Source <- Some (ResizeArray [| "new" |])
+                i
+            ) step
             Expect.sequenceEqual step.In.[0].Source.Value (ResizeArray [| "new" |]) "Input source should be updated."
 
         testCase "updateInputById updates only matching input" <| fun _ ->
@@ -245,7 +250,10 @@ let testWorkflowStepOps =
                     runPath = "./tool.cwl"
                 )
 
-            WorkflowStep.updateInputById "second" (fun i -> { i with ValueFrom = Some "$(self)" }) step
+            WorkflowStep.updateInputById "second" (fun i ->
+                i.ValueFrom <- Some "$(self)"
+                i
+            ) step
             Expect.isNone step.In.[0].ValueFrom "First input should remain unchanged."
             Expect.equal step.In.[1].ValueFrom (Some "$(self)") "Second input should be updated."
 
@@ -258,7 +266,10 @@ let testWorkflowStepOps =
                     runPath = "./tool.cwl"
                 )
 
-            WorkflowStep.updateInputById "missing" (fun i -> { i with ValueFrom = Some "$(self)" }) step
+            WorkflowStep.updateInputById "missing" (fun i ->
+                i.ValueFrom <- Some "$(self)"
+                i
+            ) step
             Expect.isNone step.In.[0].ValueFrom "First input should remain unchanged."
             Expect.isNone step.In.[1].ValueFrom "Second input should remain unchanged."
 

--- a/tests/CWL/WorkflowSteps.Tests.fs
+++ b/tests/CWL/WorkflowSteps.Tests.fs
@@ -177,7 +177,7 @@ let testWorkflowStep =
             Expect.throws decodeInvalid "Step output record without id should fail decoding"
         testCase "step output parameter known fields are typed fields, not dynamic overflow" <| fun _ ->
             let output = StepOutputParameter.create "out"
-            Expect.sequenceEqual StepOutputParameter.KnownFieldNames (ResizeArray [| "id" |]) "Step output known fields should be declared on the type."
+            Expect.sequenceEqual StepOutputParameter.KnownFieldNames (Set [| "id" |]) "Step output known fields should be declared on the type."
             Expect.isEmpty (output |> DynamicObjHelpers.dynamicPropertiesSnapshot) "Step output known fields should not be stored as dynamic properties."
             DynObj.setProperty "arc:note" "keep overflow" output
             Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" output) (Some "keep overflow") "Unknown fields should still use DynamicObj overflow."

--- a/tests/CWL/YAMLParameterFile.Tests.fs
+++ b/tests/CWL/YAMLParameterFile.Tests.fs
@@ -67,7 +67,7 @@ let testYAMLParameterFile =
                     values = ResizeArray [| "value" |],
                     type_ = CWLType.String
                 )
-            Expect.sequenceEqual CWLParameterReference.KnownFieldNames (ResizeArray [| "class"; "path"; "location"; "type"; "value" |]) ""
+            Expect.sequenceEqual CWLParameterReference.KnownFieldNames (Set [| "class"; "path"; "location"; "type"; "value" |]) ""
             Expect.isEmpty ((reference :> DynamicObj) |> DynamicObjHelpers.dynamicPropertiesSnapshot) "Known fields should not be stored as dynamic properties."
             DynObj.setProperty "arc:note" "keep me" reference
             Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" reference) (Some "keep me") "Unknown fields should stay in dynamic overflow."

--- a/tests/CWL/YAMLParameterFile.Tests.fs
+++ b/tests/CWL/YAMLParameterFile.Tests.fs
@@ -1,6 +1,7 @@
 module Tests.YAMLParameterFile
 
 open ARCtrl.CWL
+open DynamicObj
 open YAMLicious
 open TestingUtils
 
@@ -59,6 +60,30 @@ let testYAMLParameterFile =
             Expect.equal expected.Key decodeYAMLParameterFile.[4].Key ""
             Expect.sequenceEqual expected.Values decodeYAMLParameterFile.[4].Values ""
             Expect.equal expected.Type decodeYAMLParameterFile.[4].Type ""
+        testCase "known fields are typed fields, not dynamic overflow" <| fun _ ->
+            let reference =
+                CWLParameterReference(
+                    key = "input",
+                    values = ResizeArray [| "value" |],
+                    type_ = CWLType.String
+                )
+            Expect.sequenceEqual CWLParameterReference.KnownFieldNames (ResizeArray [| "class"; "path"; "location"; "type"; "value" |]) ""
+            Expect.isEmpty ((reference :> DynamicObj) |> DynamicObjHelpers.dynamicPropertiesSnapshot) "Known fields should not be stored as dynamic properties."
+            DynObj.setProperty "arc:note" "keep me" reference
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:note" reference) (Some "keep me") "Unknown fields should stay in dynamic overflow."
+        testCase "file object parameter fields decode without field order assumptions and keep overflow" <| fun _ ->
+            let yaml = """exampleFile:
+  path: ../examplePath
+  arc:file note: keep file note
+  class: File"""
+            let decoded = DecodeParameters.decodeYAMLParameterFile yaml
+            let reference = decoded.[0]
+            Expect.equal reference.Key "exampleFile" ""
+            Expect.sequenceEqual reference.Values (ResizeArray [| "../examplePath" |]) "Path should decode even when it appears before class."
+            Expect.equal reference.Type (Some (CWLType.file())) "Class should decode to File type regardless of field order."
+            Expect.equal (DynObj.tryGetTypedPropertyValue<string> "arc:file note" reference) (Some "keep file note") "Unknown parameter object fields should be preserved on the parameter reference."
+            Expect.isNone (DynObj.tryGetTypedPropertyValue<string> "class" reference) "Known class field should not be overflow."
+            Expect.isNone (DynObj.tryGetTypedPropertyValue<string> "path" reference) "Known path field should not be overflow."
     ]
 
 let main = 

--- a/tests/TestingUtils/TestObjects.CWL/CommandLineTool.fs
+++ b/tests/TestingUtils/TestObjects.CWL/CommandLineTool.fs
@@ -139,3 +139,17 @@ inputs:
   sample:
     type: string
 outputs: []"""
+
+    let commandFieldsOverflowFile = """cwlVersion: v1.1
+class: CommandLineTool
+outputs: {}
+inputs: {}
+arguments:
+  - --flag
+stdin: stdin.txt
+stdout: stdout.txt
+stderr: stderr.txt
+successCodes: [0]
+temporaryFailCodes: [75]
+permanentFailCodes: [1, 2]
+arc:note: keep overflow"""

--- a/tests/TestingUtils/TestObjects.CWL/Inputs.fs
+++ b/tests/TestingUtils/TestObjects.CWL/Inputs.fs
@@ -45,4 +45,22 @@ module String =
 
     let inputSecondArg = CWLInput(inputStringName, inputStringType, inputBinding = inputStringBinding)
 
+
+let specInputFieldsDecodeFileContent = """inputs:
+  sample:
+    label: Sample
+    inputBinding:
+      valueFrom: $(self.path)
+      shellQuote: false
+      prefix: --sample
+      loadContents: true
+      position: 1
+    default: sample.txt
+    type: File
+    doc: Sample input docs
+    loadListing: shallow_listing
+    loadContents: true
+    streamable: false
+    format: edam:format_2330
+    secondaryFiles: .bai"""
     

--- a/tests/TestingUtils/TestObjects.CWL/Outputs.fs
+++ b/tests/TestingUtils/TestObjects.CWL/Outputs.fs
@@ -32,6 +32,22 @@ module CSV =
 
     let outputCSVGlobStr = "*.csv"
 
-    let outputCSVGlob = {Glob = Some outputCSVGlobStr}
+    let outputCSVGlob = OutputBinding.create(glob = outputCSVGlobStr)
 
     let outputCSV = CWLOutput(outputCSVName, outputCSVType, outputBinding = outputCSVGlob)
+
+
+let specOutputFieldsDecodeFileContent = """outputs:
+  result:
+    label: Result
+    outputBinding:
+      outputEval: $(self[0])
+      glob: "*.txt"
+      loadListing: deep_listing
+      loadContents: true
+    secondaryFiles: .idx
+    type: File
+    outputSource: step/out
+    doc: Result docs
+    streamable: true
+    format: edam:format_2330"""

--- a/tests/TestingUtils/TestObjects.CWL/Requirements.fs
+++ b/tests/TestingUtils/TestObjects.CWL/Requirements.fs
@@ -101,3 +101,19 @@ module Docker =
     let dockerRequirement = DockerRequirement.create (dockerImageId = "devcontainer", dockerFileReference = Include "FSharpArcCapsule/Dockerfile")
 
     let requirement = Requirement.DockerRequirement dockerRequirement
+
+
+let initialWorkDirListingTypedFileContent = """requirements:
+  - class: InitialWorkDirRequirement
+    listing:
+      - checksum: sha1$abc
+        class: File
+        path: /tmp/in.txt
+        basename: in.txt
+        size: 42
+        arc:file note: keep file overflow
+      - class: Directory
+        listing: [out.txt]
+        path: /tmp/out
+        basename: out
+        arc:dir note: keep dir overflow"""

--- a/tests/TestingUtils/TestObjects.CWL/Workflow.fs
+++ b/tests/TestingUtils/TestObjects.CWL/Workflow.fs
@@ -813,6 +813,26 @@ steps:
     source: sensorthingsapi_url
   out: [result]"""
 
+let workflowWithLowerIndentedCommentMapInputsFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+  first:
+    type: string
+# group comment between map entries
+  second:
+    type: string
+outputs: []
+steps: {}"""
+
+let workflowWithLowerIndentedCommentBeforeSequenceInputFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+# group comment before sequence item
+  - id: first
+    type: string
+outputs: []
+steps: {}"""
+
 let workflowWithUnnamedMalformedEntriesFile = """cwlVersion: v1.2
 class: Workflow
 inputs:

--- a/tests/TestingUtils/TestObjects.CWL/Workflow.fs
+++ b/tests/TestingUtils/TestObjects.CWL/Workflow.fs
@@ -833,6 +833,34 @@ inputs:
 outputs: []
 steps: {}"""
 
+let workflowWithMultilineValueFromFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+  source_reads:
+    type: File?
+outputs: []
+steps:
+  expr_step:
+    run:
+      class: ExpressionTool
+      inputs:
+        reads:
+          type: File?
+      outputs:
+        out:
+          type: File[]?
+      expression: ${ return {"out": inputs.reads ? [inputs.reads] : null}; }
+    in:
+      reads:
+        source: source_reads
+        valueFrom:
+          ${
+            var reads = null;
+            if (self !== null) { reads = [self]; }
+            return reads;
+          }
+    out: [out]"""
+
 let workflowWithUnnamedMalformedEntriesFile = """cwlVersion: v1.2
 class: Workflow
 inputs:

--- a/tests/TestingUtils/TestObjects.CWL/Workflow.fs
+++ b/tests/TestingUtils/TestObjects.CWL/Workflow.fs
@@ -785,6 +785,34 @@ steps:
     valueFrom: "merge_properties"
   out: [merged_output]"""
 
+let workflowWithBlankSeparatedSequenceFieldsFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+
+
+- id: trial_id
+  type: string
+
+- id: sensorthingsapi_url
+  type: string
+outputs:
+
+- id: result
+  type: File
+  outputSource: collect/result
+steps:
+
+- id: collect
+  run: ./collect.cwl
+  in:
+
+  - id: trial_id
+    source: trial_id
+
+  - id: sensorthingsapi_url
+    source: sensorthingsapi_url
+  out: [result]"""
+
 let workflowWithUnnamedMalformedEntriesFile = """cwlVersion: v1.2
 class: Workflow
 inputs:

--- a/tests/TestingUtils/TestObjects.CWL/Workflow.fs
+++ b/tests/TestingUtils/TestObjects.CWL/Workflow.fs
@@ -861,6 +861,37 @@ steps:
           }
     out: [out]"""
 
+let workflowWithOptionalArrayInputTypesFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+  optional_files:
+    type: File[]?
+  optional_dirs:
+    type: Directory[]?
+outputs: []
+steps: {}"""
+
+let workflowWithInlineSchemaUnionTypesFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+  mode:
+    type:
+      - "null"
+      - type: enum
+        name: Mode
+        symbols: [fast, stringent]
+  record_payload:
+    type:
+      - "null"
+      - type: record
+        name: Payload
+        fields:
+          sample_id: string
+          files:
+            type: File[]
+outputs: []
+steps: {}"""
+
 let workflowWithUnnamedMalformedEntriesFile = """cwlVersion: v1.2
 class: Workflow
 inputs:

--- a/tests/TestingUtils/TestObjects.CWL/Workflow.fs
+++ b/tests/TestingUtils/TestObjects.CWL/Workflow.fs
@@ -745,3 +745,110 @@ steps:
       in1: input1
     out: [out]"""
 
+let workflowWithSequencePortsAndCommentsFile = """#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.2
+class: Workflow
+doc: |
+  Workflow doc line.
+  # This line is doc text, not a YAML comment.
+inputs:
+# Primary input
+- id: input_data
+  type: File
+  doc: A file input for processing
+- id: param_value
+  type: double
+  default: 0.5
+outputs:
+# Primary output
+- id: result_data
+  type: File
+  outputSource: process_step/result_data
+- id: merged_output
+  type: File
+  outputSource: combine_step/merged_output
+steps:
+# First step
+- id: process_step
+  run: ./tools/process_step.cwl
+  in: []
+  out: [result_data]
+# Second step
+- id: combine_step
+  run: ./tools/combine_step.cwl
+  in:
+  - id: component_files
+    source:
+    - process_step/result_data
+  - id: action
+    valueFrom: "merge_properties"
+  out: [merged_output]"""
+
+let workflowWithUnnamedMalformedEntriesFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+- id: valid_input
+  type: string
+- not_a_cwl_port: true
+outputs:
+- id: valid_output
+  type: File
+  outputSource: step1/out
+- [not, a, cwl, output]
+steps:
+- "not a workflow step"
+- id: step1
+  run: ./tool.cwl
+  in:
+  - id: in1
+    source: valid_input
+  - not_a_step_input: true
+  out: [out]"""
+
+let workflowWithMalformedNamedInputFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+- id: broken_input
+  doc: Missing required type.
+outputs:
+- id: result
+  type: File
+  outputSource: step1/out
+steps:
+- id: step1
+  run: ./tool.cwl
+  in: []
+  out: [out]"""
+
+let workflowWithUnknownPortFieldsFile = """cwlVersion: v1.2
+class: Workflow
+inputs:
+- id: sample
+  type:
+    type: File
+    arc:type note: keep input type note
+  inputBinding:
+    prefix: --sample
+    arc:binding note: keep input binding note
+  arc:note: keep input note
+outputs:
+- id: result
+  type:
+    type: File
+    arc:type note: keep output type note
+  outputSource: step1/out
+  outputBinding:
+    glob: result.txt
+    arc:binding note: keep output binding note
+  arc:note: keep output note
+steps:
+- id: step1
+  run: ./tool.cwl
+  arc:step note: keep step note
+  in:
+    sample:
+      source: sample
+      arc:step input note: keep step input note
+  out: [out]"""
+


### PR DESCRIPTION
- Refactors CWL model types to retain unknown fields as `DynamicObj` overflow while decoding known fields into typed members.
- Adds missing typed support for inputs, outputs, workflow steps, tool fields, requirement payloads, inline schemas, and YAML parameter files.
- Improves YAML decoding for supported CWL forms including comments, blank separators, sequence-based fields, multiline expressions, optional array shorthand, and inline schema unions.
- Adds warning-aware decoding for malformed unnamed sequence entries, while rejecting malformed named entries and malformed present typed fields such as invalid `id` or `label`.
- Preserves unknown extension values through encode/decode, including nested payload extensions and singleton YAML sequences.
- Preserves scalar overflow types, including booleans, integers, decimals, and quoted strings, with cross-compiler fixes for numeric encoding.
- Updates YAMLicious.